### PR TITLE
refactor: Adapt to hishel >1.0 caching interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "panel>=1.6.3",
   "playwright>=1.50.0",
   "nest-asyncio>=1.6.0",
-  "hishel==0.1.5",
+  "hishel[httpx]>1.0",
   "pydantic>=2.11.5",
   "joblib",
   "google-genai>=1.38.0",
@@ -30,7 +30,12 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [dependency-groups]
-test = ["pytest", "pytest-asyncio>=0.25.3", "pytest-mock>=3.14.1"]
+test = [
+    "pytest",
+    "pytest-asyncio>=0.25.3",
+    "pytest-mock>=3.14.1",
+    "respx>=0.22.0",
+]
 kaggle = [
   "kagglehub>=0.3.10",
   "pip>=25.0.1",

--- a/src/kaggle_benchmarks/_config.py
+++ b/src/kaggle_benchmarks/_config.py
@@ -59,6 +59,12 @@ class Config:
         )
     )
 
+    cache_timeout_seconds: int = dataclasses.field(
+        default_factory=lambda: int(
+            os.environ.get("CACHE_TIMEOUT_SECONDS", str(7 * 24 * 60 * 60))
+        )
+    )
+
     interactive_mode: bool = dataclasses.field(
         default_factory=lambda: string_to_bool(
             os.environ.get("INTERACTIVE_UI", "False")

--- a/src/kaggle_benchmarks/utils.py
+++ b/src/kaggle_benchmarks/utils.py
@@ -42,12 +42,18 @@ class JSONEncoder(json.encoder.JSONEncoder):
 
 
 class UnconditionalCacheTransport(httpx.HTTPTransport):
+    def __init__(self, cache_timeout_seconds: int = 7 * 24 * 60 * 60) -> None:
+        super().__init__()
+        self.cache_timeout_seconds = cache_timeout_seconds
+
     def handle_request(self, request):
         response = super().handle_request(request)
 
         # Force the header to be cacheable for 1 week
         # This overrides whatever the server said (e.g. no-store)
-        response.headers["Cache-Control"] = "public, max-age=604800"
+        response.headers["Cache-Control"] = (
+            f"public, max-age={self.cache_timeout_seconds}"
+        )
 
         # Remove 'Expires' or 'Pragma' if they exist to avoid conflicts
         response.headers.pop("Pragma", None)
@@ -64,7 +70,9 @@ def build_httpx_client(filename: str = "cache") -> httpx.Client:
 
     return hishel.httpx.SyncCacheClient(
         transport=hishel.httpx.SyncCacheTransport(
-            next_transport=UnconditionalCacheTransport(),
+            next_transport=UnconditionalCacheTransport(
+                cache_timeout_seconds=config.cache_timeout_seconds
+            ),
         ),
         storage=hishel.SyncSqliteStorage(
             database_path=config.cache_directory / f"{filename}.sqlite",

--- a/src/kaggle_benchmarks/utils.py
+++ b/src/kaggle_benchmarks/utils.py
@@ -20,6 +20,7 @@ import re
 from pathlib import Path
 
 import hishel
+import hishel.httpx
 import httpx
 from openai import OpenAI, OpenAIError
 
@@ -40,18 +41,33 @@ class JSONEncoder(json.encoder.JSONEncoder):
         return repr(obj)
 
 
-def build_httpx_client(cache_subdirectory: str = ".") -> httpx.Client:
+class UnconditionalCacheTransport(httpx.HTTPTransport):
+    def handle_request(self, request):
+        response = super().handle_request(request)
+
+        # Force the header to be cacheable for 1 week
+        # This overrides whatever the server said (e.g. no-store)
+        response.headers["Cache-Control"] = "public, max-age=604800"
+
+        # Remove 'Expires' or 'Pragma' if they exist to avoid conflicts
+        response.headers.pop("Pragma", None)
+        response.headers.pop("Expires", None)
+
+        return response
+
+
+def build_httpx_client(filename: str = "cache") -> httpx.Client:
     from kaggle_benchmarks._config import config
 
     if config.disable_caching:
         return httpx.Client()
 
-    return hishel.CacheClient(
-        controller=hishel.Controller(
-            cacheable_methods=["GET", "POST"], force_cache=True
+    return hishel.httpx.SyncCacheClient(
+        transport=hishel.httpx.SyncCacheTransport(
+            next_transport=UnconditionalCacheTransport(),
         ),
-        storage=hishel.FileStorage(
-            base_path=config.cache_directory / cache_subdirectory
+        storage=hishel.SyncSqliteStorage(
+            database_path=config.cache_directory / f"{filename}.sqlite",
         ),
     )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 
 import json
+from unittest.mock import patch
 
+import httpx
 import pytest
+import respx
 
 from kaggle_benchmarks import utils
 
@@ -83,3 +86,32 @@ def test_json_encoder():
 )
 def test_normalize_name(name, expected):
     assert utils.normalize_name(name) == expected
+
+
+@respx.mock
+def test_client_caches_despite_server_headers(tmp_path):
+    with (
+        patch("kaggle_benchmarks.config.cache_directory", tmp_path),
+        patch("kaggle_benchmarks.config.disable_caching", False),
+    ):
+        url = "https://test.com/api"
+        route = respx.get(url)
+        client = utils.build_httpx_client(filename="test")
+
+        resp1 = client.get(url)
+        assert resp1.status_code == 200
+        assert route.called
+        assert not resp1.extensions.get("hishel_from_cache")
+
+        resp2 = client.get(url)
+        assert resp2.status_code == 200
+        assert route.call_count == 1
+        assert resp2.extensions.get("hishel_from_cache") is True
+
+
+def test_client_respects_disable_config():
+    with patch("kaggle_benchmarks.config.disable_caching", True):
+        client = utils.build_httpx_client()
+
+        assert isinstance(client, httpx.Client)
+        assert not hasattr(client, "_controller")

--- a/uv.lock
+++ b/uv.lock
@@ -1101,18 +1101,22 @@ wheels = [
 
 [[package]]
 name = "hishel"
-version = "0.1.5"
+version = "1.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "anysqlite" },
-    { name = "httpx" },
     { name = "msgpack" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/64/a104ccac48f123f853254483617b16e0efc1649bd7e35bcdc5a5a5ef0ae2/hishel-0.1.5.tar.gz", hash = "sha256:9d40c682cd94fd6e1394fb05713ae20a75ed8aeba6f5272380444039ce6257f2", size = 75468, upload-time = "2025-10-18T13:32:41.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/cf/4e1d09cc81c48ff7498398fd82c87fb21800c85e631d03831703d8594506/hishel-1.1.7.tar.gz", hash = "sha256:32c625be581e94dc50b773a8cfb9a65cba487660561950fe976ae49945455179", size = 61473, upload-time = "2025-12-03T09:32:28.524Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/83/4f8b77839e62114bb034375ee8e08cfb6af1164754b925b271d3f1ec06ee/hishel-0.1.5-py3-none-any.whl", hash = "sha256:0bfbe9a2b9342090eba82ba6de88258092e1c4c7b730cd4cb4b570e4b40e44a7", size = 92486, upload-time = "2025-10-18T13:32:40.333Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/2a/8134de761e4fd9d0a3b301b897b8c5ce9ccb17af7f846d66c676d8c03fd8/hishel-1.1.7-py3-none-any.whl", hash = "sha256:436c2a5a62d705528e581cbeba85b10d130c47c861906b21262a07ac02463a9f", size = 70569, upload-time = "2025-12-03T09:32:27.144Z" },
+]
+
+[package.optional-dependencies]
+httpx = [
+    { name = "anyio" },
+    { name = "anysqlite" },
+    { name = "httpx" },
 ]
 
 [[package]]
@@ -1722,7 +1726,7 @@ source = { editable = "." }
 dependencies = [
     { name = "docker" },
     { name = "google-genai" },
-    { name = "hishel" },
+    { name = "hishel", extra = ["httpx"] },
     { name = "joblib" },
     { name = "jupyter" },
     { name = "nest-asyncio" },
@@ -1760,6 +1764,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
+    { name = "respx" },
     { name = "roman" },
     { name = "ruff" },
     { name = "sentence-transformers" },
@@ -1796,13 +1801,14 @@ test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
+    { name = "respx" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "docker", specifier = ">=7.1.0" },
     { name = "google-genai", specifier = ">=1.38.0" },
-    { name = "hishel", specifier = "==0.1.5" },
+    { name = "hishel", extras = ["httpx"], specifier = ">1.0" },
     { name = "joblib" },
     { name = "jupyter" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
@@ -1840,6 +1846,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=0.25.3" },
     { name = "pytest-mock", specifier = ">=3.14.1" },
+    { name = "respx", specifier = ">=0.22.0" },
     { name = "roman", specifier = ">=5.0" },
     { name = "ruff" },
     { name = "sentence-transformers", specifier = ">=4.1.0" },
@@ -1876,6 +1883,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=0.25.3" },
     { name = "pytest-mock", specifier = ">=3.14.1" },
+    { name = "respx", specifier = ">=0.22.0" },
 ]
 
 [[package]]
@@ -3764,6 +3772,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/7c/96bd0bc759cf009675ad1ee1f96535edcb11e9666b985717eb8c87192a95/respx-0.22.0.tar.gz", hash = "sha256:3c8924caa2a50bd71aefc07aa812f2466ff489f1848c96e954a5362d17095d91", size = 28439, upload-time = "2024-12-19T22:33:59.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/67/afbb0978d5399bc9ea200f1d4489a23c9a1dad4eee6376242b8182389c79/respx-0.22.0-py2.py3-none-any.whl", hash = "sha256:631128d4c9aba15e56903fb5f66fb1eff412ce28dd387ca3a81339e52dbd3ad0", size = 25127, upload-time = "2024-12-19T22:33:57.837Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updates the `hishel` library to a version greater than 1.0 and refactors the caching logic to align with the new API.

The `force_cache` option has been removed in the newer versions of `hishel`. To maintain the behavior of unconditionally caching responses, a custom `httpx.HTTPTransport` has been implemented. This transport layer explicitly sets the `Cache-Control` header on responses to ensure they are cached.