### PR TITLE
feat: Add error rendering in Run.

### DIFF
--- a/documentation/examples/assess_with_a_judge.py
+++ b/documentation/examples/assess_with_a_judge.py
@@ -68,7 +68,7 @@ def explain_zero_knowledge_proofs(llm):
             )
 
 
-explain_zero_knowledge_proofs.run(kbench.judge_llm)
+explain_zero_knowledge_proofs.run(kbench.llm)
 
 
 # %% [markdown]
@@ -144,6 +144,6 @@ def critique_short_story(llm):
         )
 
 
-critique_short_story.run(kbench.judge_llm)
+critique_short_story.run(kbench.llm)
 
 # %%

--- a/src/kaggle_benchmarks/assertions.py
+++ b/src/kaggle_benchmarks/assertions.py
@@ -533,8 +533,8 @@ def assess_response_with_judge(
         if isinstance(assess_report, dict):
             assess_report = output_schema(**assess_report)
 
-    except KeyboardInterrupt: 
-         raise 
+    except KeyboardInterrupt:
+        raise
     except Exception:
         assess_report = None
 

--- a/src/kaggle_benchmarks/runs.py
+++ b/src/kaggle_benchmarks/runs.py
@@ -15,6 +15,7 @@
 import dataclasses
 import datetime
 import threading
+import traceback
 from collections import abc
 from typing import Any, Generic, Literal, Self, TypeVar
 
@@ -78,7 +79,8 @@ class Run(Generic[T]):
         It will mark the run's status as FAILED.
         """
 
-        self.fail_with_message(repr(e))
+        summary = "".join(traceback.format_exception_only(type(e), e)).strip()
+        self.fail_with_message(summary)
 
         raise e
 

--- a/src/kaggle_benchmarks/runs.py
+++ b/src/kaggle_benchmarks/runs.py
@@ -79,7 +79,7 @@ class Run(Generic[T]):
         It will mark the run's status as FAILED.
         """
 
-        summary = "".join(traceback.format_exception_only(type(e), e)).strip()
+        summary = traceback.format_exc()
         self.fail_with_message(summary)
 
         raise e

--- a/src/kaggle_benchmarks/ui/panel.py
+++ b/src/kaggle_benchmarks/ui/panel.py
@@ -128,6 +128,15 @@ def render_result(run: runs.Run) -> pn.viewable.Viewable:
     return pn.pane.Markdown(f"Result: `{run.format_result()}`")
 
 
+def render_error(run: runs.Run) -> pn.viewable.Viewable:
+    return pn.pane.Alert(
+        f"❌ **Thrown Error:**\n```\n{run.error_message or 'Unknown Error'}\n```",
+        alert_type="danger",
+        sizing_mode="stretch_width",
+        styles={"overflow-x": "auto"},
+    )
+
+
 def render_run(run: runs.Run, with_title: bool = True) -> pn.viewable.Viewable:
     objects: list[pn.viewable.Viewable | str] = (
         [
@@ -148,8 +157,11 @@ def render_run(run: runs.Run, with_title: bool = True) -> pn.viewable.Viewable:
     if run.chat and run.chat.history:
         objects.append(render_chat(run.chat, with_header=False))
 
-    if run.status == utils.Status.SUCCESS:
-        objects.append(render_result(run))
+    match run.status:
+        case utils.Status.SUCCESS:
+            objects.append(render_result(run))
+        case utils.Status.FAILED:
+            objects.append(render_error(run))
 
     return pn.Feed(objects=objects)
 

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -161,7 +161,10 @@ def test_standalone_run_on_exception(monkeypatch, continue_with_exceptions):
         run = task_that_errors.run()
         assert not run.passed
         assert run.status == utils.Status.FAILED
-        assert "ValueError: This is an intentional error" == run.error_message
+        assert (
+            run.error_message
+            and 'ValueError("This is an intentional error")' in run.error_message
+        )
     else:
         with pytest.raises(ValueError, match="This is an intentional error"):
             task_that_errors.run()
@@ -179,7 +182,10 @@ def test_run_with_subrun_on_exception(monkeypatch, continue_with_exceptions):
         run = wrapper_task.run()
         assert not run.passed
         assert run.status == utils.Status.FAILED
-        assert "ValueError: This is an intentional error" == run.error_message
+        assert (
+            run.error_message
+            and 'ValueError("This is an intentional error")' in run.error_message
+        )
     else:
         with pytest.raises(ValueError, match="This is an intentional error"):
             wrapper_task.run()
@@ -210,7 +216,10 @@ def test_run_evaluating_subrun_on_exception(monkeypatch, continue_with_exception
         run = wrapper_task.run(llm=Duck())
         assert not run.passed
         assert run.status == utils.Status.FAILED
-        assert "ValueError: This is an intentional error" == run.error_message
+        assert (
+            run.error_message
+            and 'ValueError("This is an intentional error")' in run.error_message
+        )
     else:
         with pytest.raises(ValueError, match="This is an intentional error"):
             wrapper_task.run(llm=Duck())

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -161,7 +161,7 @@ def test_standalone_run_on_exception(monkeypatch, continue_with_exceptions):
         run = task_that_errors.run()
         assert not run.passed
         assert run.status == utils.Status.FAILED
-        assert "ValueError('This is an intentional error')" == run.error_message
+        assert "ValueError: This is an intentional error" == run.error_message
     else:
         with pytest.raises(ValueError, match="This is an intentional error"):
             task_that_errors.run()
@@ -179,7 +179,7 @@ def test_run_with_subrun_on_exception(monkeypatch, continue_with_exceptions):
         run = wrapper_task.run()
         assert not run.passed
         assert run.status == utils.Status.FAILED
-        assert "ValueError('This is an intentional error')" == run.error_message
+        assert "ValueError: This is an intentional error" == run.error_message
     else:
         with pytest.raises(ValueError, match="This is an intentional error"):
             wrapper_task.run()
@@ -210,7 +210,7 @@ def test_run_evaluating_subrun_on_exception(monkeypatch, continue_with_exception
         run = wrapper_task.run(llm=Duck())
         assert not run.passed
         assert run.status == utils.Status.FAILED
-        assert "ValueError('This is an intentional error')" == run.error_message
+        assert "ValueError: This is an intentional error" == run.error_message
     else:
         with pytest.raises(ValueError, match="This is an intentional error"):
             wrapper_task.run(llm=Duck())

--- a/tests/test_protobuf.py
+++ b/tests/test_protobuf.py
@@ -394,7 +394,10 @@ def test_exception_run_serialization(monkeypatch):
         == serialization.types.BENCHMARK_TASK_RUN_ASSERTION_STATUS_PASSED
     )
     assert message.state == serialization.types.BENCHMARK_TASK_RUN_STATE_ERRORED
-    assert message.error_message == "ValueError: Something went wrong"
+    assert (
+        message.error_message
+        and 'ValueError("Something went wrong")' in message.error_message
+    )
 
     # Check JSON dict
     result = json_format.MessageToDict(message)
@@ -406,4 +409,4 @@ def test_exception_run_serialization(monkeypatch):
         == "BENCHMARK_TASK_RUN_ASSERTION_STATUS_PASSED"
     )
     assert result["state"] == "BENCHMARK_TASK_RUN_STATE_ERRORED"
-    assert result["errorMessage"] == "ValueError: Something went wrong"
+    assert 'ValueError("Something went wrong")' in result["errorMessage"]

--- a/tests/test_protobuf.py
+++ b/tests/test_protobuf.py
@@ -394,7 +394,7 @@ def test_exception_run_serialization(monkeypatch):
         == serialization.types.BENCHMARK_TASK_RUN_ASSERTION_STATUS_PASSED
     )
     assert message.state == serialization.types.BENCHMARK_TASK_RUN_STATE_ERRORED
-    assert message.error_message == "ValueError('Something went wrong')"
+    assert message.error_message == "ValueError: Something went wrong"
 
     # Check JSON dict
     result = json_format.MessageToDict(message)
@@ -406,4 +406,4 @@ def test_exception_run_serialization(monkeypatch):
         == "BENCHMARK_TASK_RUN_ASSERTION_STATUS_PASSED"
     )
     assert result["state"] == "BENCHMARK_TASK_RUN_STATE_ERRORED"
-    assert result["errorMessage"] == "ValueError('Something went wrong')"
+    assert result["errorMessage"] == "ValueError: Something went wrong"


### PR DESCRIPTION
**Summary** Improves error visibility in "batch" mode (continue_with_exceptions=True). Previously, failures were only recorded in run.json; this PR surfaces them directly in the notebook UI.

**Changes**
- Detailed Logging: Includes stack traces in the run.json error output, using `traceback.format_exc`.
- UI Rendering: Automatically displays error messages in the notebook if a run's state is failure.
