### PR TITLE
fix: Prevent import errors when ModelProxy is not configured

### DIFF
--- a/cicd/build/cloudbuild_branch.yaml
+++ b/cicd/build/cloudbuild_branch.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 steps:
   - id: "build-image"
     name: "gcr.io/cloud-builders/docker"
@@ -25,9 +39,6 @@ steps:
     args: ["run", "--group", "test",  "pytest", "tests"]
     waitFor: ["push-image"]
     env:
-      - "LLM_DEFAULT=x"
-      - "MODEL_PROXY_URL=y"
-      - "MODEL_PROXY_API_KEY=z"
       - "PLAYWRIGHT_BROWSERS_PATH=/root/.cache/ms-playwright"
 
   - id: ruff

--- a/src/kaggle_benchmarks/__init__.py
+++ b/src/kaggle_benchmarks/__init__.py
@@ -32,9 +32,10 @@ from kaggle_benchmarks.actors import Actor, LLMChat, system, user
 from kaggle_benchmarks.runs import Run, Runs
 from kaggle_benchmarks.tasks import benchmark, task
 
-llm = kaggle.load_default_model()
-judge_llm = kaggle.load_judge_model()
-llms = kaggle.load_available_models()
+if kaggle.is_configured():
+    llm = kaggle.load_default_model()
+    judge_llm = kaggle.load_judge_model()
+    llms = kaggle.load_available_models()
 
 
 client: clients.Client = clients.resolve_client()

--- a/src/kaggle_benchmarks/kaggle/__init__.py
+++ b/src/kaggle_benchmarks/kaggle/__init__.py
@@ -20,6 +20,7 @@ from kaggle_benchmarks.kaggle.benchmark_types_pb2 import (  # type: ignore[attr-
 from kaggle_benchmarks.kaggle.client import KaggleClient
 from kaggle_benchmarks.kaggle.model_proxy import ModelProxy
 from kaggle_benchmarks.kaggle.models import (
+    is_configured,
     load_available_models,
     load_default_model,
     load_judge_model,

--- a/src/kaggle_benchmarks/kaggle/models.py
+++ b/src/kaggle_benchmarks/kaggle/models.py
@@ -18,6 +18,10 @@ from kaggle_benchmarks.actors import LLMChat
 from kaggle_benchmarks.kaggle.model_proxy import ModelProxy
 
 
+def is_configured():
+    return "MODEL_PROXY_URL" in os.environ and "MODEL_PROXY_API_KEY" in os.environ
+
+
 def load_default_model() -> LLMChat:
     if "MODEL_PROXY_URL" in os.environ:
         return load_model(os.environ["LLM_DEFAULT"])


### PR DESCRIPTION
Previously, importing the `kaggle_benchmarks` library would fail if the `MODEL_PROXY_URL` and `MODEL_PROXY_API_KEY` environment variables were not set. This was caused by the library attempting to load the `llm`, `llms`, and `judge_llm` objects at import time.

This change introduces a `kaggle.is_configured()` check and only loads these model-related objects if the environment is properly configured. This allows for the use of other library features without requiring model proxy credentials, making the package more modular and easier to use in a wider range of scenarios.

The CI build configuration has been updated to reflect this change, allowing tests to run in an environment without model proxy credentials.