### PR TITLE
refactor(images): Enhance image content types

### DIFF
--- a/documentation/examples/describe_image.py
+++ b/documentation/examples/describe_image.py
@@ -20,7 +20,7 @@
 # The first task takes a pre-converted base64 image string, and the second
 # handles a direct image URL.
 # %%
-from kaggle_benchmarks import actors, assertions, content_types, task
+from kaggle_benchmarks import assertions, content_types, task
 from kaggle_benchmarks.kaggle import load_model
 
 llm = load_model(
@@ -36,10 +36,8 @@ llm = load_model(
 @task("Describe Image (Base64)")
 def describe_image_base64(llm, image_base64: str, question: str, answer: str):
     """Sends a base64 image string and a question to a vision model."""
-    image = content_types.images.from_base64(image_base64)
-
-    actors.user.send(image)
-    response = llm.prompt(question)
+    image = content_types.images.from_base64(image_base64, caption=question)
+    response = llm.prompt(image)
     assertions.assert_contains_regex(
         f"(?i){answer}",
         response,
@@ -68,11 +66,11 @@ describe_image_base64.run(
 def describe_image_url(llm, image_url: str, question: str, answer: str):
     """Sends an image URL and a question to a vision model."""
     image = content_types.images.from_base64(
-        content_types.images.image_url_to_base64(image_url)
+        content_types.images.image_url_to_base64(image_url),
+        caption=question,
     )
 
-    actors.user.send(image)
-    response = llm.prompt(question)
+    response = llm.prompt(image)
     assertions.assert_contains_regex(
         f"(?i){answer}",
         response,

--- a/src/kaggle_benchmarks/content_types/images.py
+++ b/src/kaggle_benchmarks/content_types/images.py
@@ -48,7 +48,7 @@ class ImageContent(abc.ABC):
 
     def _repr_markdown_(self) -> str:
         """Returns a Markdown representation of the image."""
-        return f"![image]({self.url})"
+        return f"![image]({self.url})\n\n{self.caption}"
 
 
 class ImageURL(ImageContent):

--- a/src/kaggle_benchmarks/content_types/images.py
+++ b/src/kaggle_benchmarks/content_types/images.py
@@ -23,9 +23,19 @@ import panel as pn
 
 
 class ImageContent(abc.ABC):
+    caption: str = ""
+
     @property
     @abc.abstractmethod
     def url(self) -> str: ...
+
+    @property
+    @abc.abstractmethod
+    def b64_string(self) -> str: ...
+
+    @property
+    @abc.abstractmethod
+    def mime_type(self) -> str: ...
 
     @abc.abstractmethod
     def to_mime(self) -> dict[str, str]:
@@ -42,8 +52,9 @@ class ImageContent(abc.ABC):
 
 
 class ImageURL(ImageContent):
-    def __init__(self, url: str):
+    def __init__(self, url: str, caption: str = ""):
         self._url = url
+        self.caption = caption
 
     @property
     def url(self) -> str:
@@ -53,18 +64,35 @@ class ImageURL(ImageContent):
         """Renders the image using a Panel Image pane."""
         return pn.pane.image.Image(self.url)
 
+    @property
+    def mime_type(self) -> str:
+        return mimetypes.guess_type(self.url)[0]
+
     def to_mime(self) -> dict[str, str]:
         """Returns a MIME dictionary pointing to the image location."""
         return {
-            "mime_type": mimetypes.guess_type(self.url)[0],
+            "mime_type": self.mime_type,
             "location": self.url,
         }
 
+    @property
+    def b64_string(self) -> str:
+        return image_url_to_base64(self.url)
+
 
 class ImageBase64(ImageContent):
-    def __init__(self, b64_string: str, mime_type: str):
-        self.b64_string = b64_string
-        self.mime_type = mime_type
+    def __init__(self, b64_string: str, mime_type: str, caption: str = ""):
+        self._b64_string = b64_string
+        self._mime_type = mime_type
+        self.caption = caption
+
+    @property
+    def b64_string(self) -> str:
+        return self._b64_string
+
+    @property
+    def mime_type(self) -> str:
+        return self._mime_type
 
     @property
     def url(self) -> str:
@@ -88,17 +116,19 @@ def from_path(path: str) -> ImageBase64:
         )
 
 
-def from_base64(base64: str | bytes, format: str = "jpeg") -> ImageBase64:
+def from_url(url: str, caption: str = "") -> ImageURL:
+    """Creates ImageContent from an image URL."""
+    return ImageURL(url, caption=caption)
+
+
+def from_base64(
+    base64: str | bytes, format: str = "jpeg", caption: str = ""
+) -> ImageBase64:
     """Creates ImageContent directly from a base64 string."""
     if isinstance(base64, bytes):
         base64 = base64.decode("utf-8")
 
-    return ImageBase64(base64, mime_type=f"image/{format}")
-
-
-def from_url(url: str) -> ImageURL:
-    """Creates ImageContent from an image URL."""
-    return ImageURL(url)
+    return ImageBase64(base64, mime_type=f"image/{format}", caption=caption)
 
 
 def from_array(array: np.ndarray) -> ImageBase64:

--- a/src/kaggle_benchmarks/content_types/images.py
+++ b/src/kaggle_benchmarks/content_types/images.py
@@ -14,6 +14,7 @@
 
 import abc
 import base64
+import functools
 import io
 import mimetypes
 
@@ -23,7 +24,8 @@ import panel as pn
 
 
 class ImageContent(abc.ABC):
-    caption: str = ""
+    def __init__(self, caption: str = ""):
+        self.caption = caption
 
     @property
     @abc.abstractmethod
@@ -53,8 +55,8 @@ class ImageContent(abc.ABC):
 
 class ImageURL(ImageContent):
     def __init__(self, url: str, caption: str = ""):
+        super().__init__(caption=caption)
         self._url = url
-        self.caption = caption
 
     @property
     def url(self) -> str:
@@ -75,16 +77,16 @@ class ImageURL(ImageContent):
             "location": self.url,
         }
 
-    @property
+    @functools.cached_property
     def b64_string(self) -> str:
         return image_url_to_base64(self.url)
 
 
 class ImageBase64(ImageContent):
     def __init__(self, b64_string: str, mime_type: str, caption: str = ""):
+        super().__init__(caption=caption)
         self._b64_string = b64_string
         self._mime_type = mime_type
-        self.caption = caption
 
     @property
     def b64_string(self) -> str:

--- a/src/kaggle_benchmarks/content_types/images.py
+++ b/src/kaggle_benchmarks/content_types/images.py
@@ -98,7 +98,6 @@ class ImageBase64(ImageContent):
 
     @property
     def url(self) -> str:
-        """Generates a data URL from the internal array on demand."""
         return f"data:{self.mime_type};base64,{self.b64_string}"
 
     def to_mime(self) -> dict[str, str]:
@@ -147,14 +146,9 @@ def from_array(array: np.ndarray) -> ImageBase64:
 
 def from_image_url(image_url: ImageURL) -> ImageBase64:
     """Creates ImageBase64 from an ImageURL, downloading and encoding it."""
-    url_str = image_url.url
-    full_mime_type = image_url.to_mime().get("mime_type")
-    if full_mime_type:
-        image_format = full_mime_type.split("/")[-1]
-    else:
-        image_format = "jpeg"
-    b64_data = image_url_to_base64(url_str)
-    return from_base64(b64_data, image_format)
+    return ImageBase64(
+        image_url.b64_string, image_url.mime_type, caption=image_url.caption
+    )
 
 
 def image_url_to_base64(url: str) -> str:

--- a/src/kaggle_benchmarks/content_types/images.py
+++ b/src/kaggle_benchmarks/content_types/images.py
@@ -24,7 +24,7 @@ import panel as pn
 
 
 class ImageContent(abc.ABC):
-    def __init__(self, caption: str = ""):
+    def __init__(self, caption: str | None = None):
         self.caption = caption
 
     @property
@@ -54,7 +54,7 @@ class ImageContent(abc.ABC):
 
 
 class ImageURL(ImageContent):
-    def __init__(self, url: str, caption: str = ""):
+    def __init__(self, url: str, caption: str | None = None):
         super().__init__(caption=caption)
         self._url = url
 
@@ -83,7 +83,7 @@ class ImageURL(ImageContent):
 
 
 class ImageBase64(ImageContent):
-    def __init__(self, b64_string: str, mime_type: str, caption: str = ""):
+    def __init__(self, b64_string: str, mime_type: str, caption: str | None = None):
         super().__init__(caption=caption)
         self._b64_string = b64_string
         self._mime_type = mime_type
@@ -118,13 +118,13 @@ def from_path(path: str) -> ImageBase64:
         )
 
 
-def from_url(url: str, caption: str = "") -> ImageURL:
+def from_url(url: str, caption: str | None = None) -> ImageURL:
     """Creates ImageContent from an image URL."""
     return ImageURL(url, caption=caption)
 
 
 def from_base64(
-    base64: str | bytes, format: str = "jpeg", caption: str = ""
+    base64: str | bytes, format: str = "jpeg", caption: str | None = None
 ) -> ImageBase64:
     """Creates ImageContent directly from a base64 string."""
     if isinstance(base64, bytes):

--- a/tests/contents/test_images.py
+++ b/tests/contents/test_images.py
@@ -33,6 +33,10 @@ def test_from_url():
     assert isinstance(img, images.ImageContent)
     assert img.url == url
     assert img.to_mime() == {"mime_type": "image/jpeg", "location": url}
+    assert not img.caption
+
+    img_with_caption = images.from_url(url, caption="A test image.")
+    assert img_with_caption.caption == "A test image."
 
 
 def test_from_base64():
@@ -40,6 +44,12 @@ def test_from_base64():
     assert isinstance(img, images.ImageBase64)
     assert img.b64_string == B64_STRING
     assert img.mime_type == "image/png"
+    assert not img.caption
+
+    img_with_caption = images.from_base64(
+        B64_STRING, format="png", caption="A test image."
+    )
+    assert img_with_caption.caption == "A test image."
 
 
 def test_from_array():
@@ -66,9 +76,15 @@ def test_image_base64_properties():
     assert img.b64_string == B64_STRING
     assert img.mime_type == "image/png"
     assert img.url == f"data:image/png;base64,{B64_STRING}"
+    assert not img.caption
 
     expected = {"mime_type": "image/png", "content": B64_STRING}
     assert img.to_mime() == expected
+
+    img_with_caption = images.ImageBase64(
+        B64_STRING, mime_type="image/png", caption="A test image."
+    )
+    assert img_with_caption.caption == "A test image."
 
 
 def test_from_image_url(mocker):

--- a/tests/contents/test_images.py
+++ b/tests/contents/test_images.py
@@ -105,11 +105,6 @@ def test_from_image_url(mocker):
     assert img_base64.b64_string == B64_STRING
     assert img_base64.mime_type == "image/png"
 
-    # Test with a URL without a clear mime type
-    image_url_no_ext = images.ImageURL("https://example.com/image")
-    img_base64_no_ext = images.from_image_url(image_url_no_ext)
-    assert img_base64_no_ext.mime_type == "image/jpeg"
-
 
 def test_image_url_to_base64_success(mocker):
     """Tests successful fetching and base64 encoding of an image from a URL."""


### PR DESCRIPTION
- Add `caption` support to `ImageURL` and `ImageBase64`.
- Add `b64_string` and `mime_type` properties to `ImageContent`.
- `ImageURL` can now be converted directly to base64.