### PR TITLE
refactor(prompting): Standardize error handling with ResponseParsingError

### DIFF
--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -110,10 +110,6 @@ class LLMResponse:
     meta: dict[str, Any] = dataclasses.field(default_factory=dict)
 
 
-class SchemaProcessingError(TypeError):
-    pass
-
-
 class LLMChat(actors.Actor):
     """A chat agent that interacts with a Large Language Model (LLM)."""
 
@@ -227,10 +223,10 @@ class LLMChat(actors.Actor):
 
         try:
             h.send(answer)  # must raise StopIteration by returning the parsed value
-            raise SchemaProcessingError(
+            raise prompting.SchemaProcessingError(
                 f"Generator for {schema!r} yielded multiple values, expected only one."
             )
-        except ValueError as e:
+        except prompting.ResponseParsingError as e:
             chat.append(
                 messages.Message(
                     f"Error processing response {answer}:\n{e}",

--- a/src/kaggle_benchmarks/prompting.py
+++ b/src/kaggle_benchmarks/prompting.py
@@ -41,7 +41,7 @@ handlers = []
 T = TypeVar("T")
 
 
-class BaseModel(pydantic.BaseModel):
+class RenderablePydanticModel(pydantic.BaseModel):
     """Base pydantic model that renderable in markdown."""
 
     def _repr_markdown_(self):
@@ -51,7 +51,7 @@ class BaseModel(pydantic.BaseModel):
         )
 
 
-class TypedResponse(BaseModel, Generic[T]):
+class TypedResponse(RenderablePydanticModel, Generic[T]):
     """
         A generic container for wrapping a typed value.
 
@@ -78,6 +78,10 @@ class ResponseParsingError(ValueError):
 
     def __str__(self) -> str:
         return f"ResponseParsingError(value={self.value}, message={self.message}, schema={self.schema})"
+
+
+class SchemaProcessingError(TypeError):
+    pass
 
 
 def parse_response(handler: Generator[str | tuple[str, T], str, T], value: str) -> T:
@@ -114,7 +118,7 @@ def typed_dict(attrs: dict[str, type]):
         pydantic.create_model(
             "Response",
             **{key: (value, ...) for key, value in attrs.items()},
-            __base__=BaseModel,
+            __base__=RenderablePydanticModel,
         )
     )
 

--- a/src/kaggle_benchmarks/prompting.py
+++ b/src/kaggle_benchmarks/prompting.py
@@ -28,7 +28,6 @@ Handlers are processed in reverse registration order, so later registered handle
 Supported types currently include several build-in types, Pydantic models, and dataclasses.
 """
 
-import dataclasses
 import datetime
 import inspect
 import json
@@ -53,6 +52,20 @@ class BaseModel(pydantic.BaseModel):
 
 
 class TypedResponse(BaseModel, Generic[T]):
+    """
+        A generic container for wrapping a typed value.
+
+        This is particularly useful for APIs that require a JSON object as the
+        root of a response schema. It allows for defining a response format
+    for
+        primitive or generic types on the fly.
+
+        For example:
+        - `TypedResponse[int]` will expect a JSON object like `{"value": 123}`.
+        - `TypedResponse[list[int]]` will expect `{"value": [1, 2, 3]}`.
+        - `TypedResponse[tuple[int, str]]` will expect `{"value": [1, "hello"]}`.
+    """
+
     value: T
 
 
@@ -95,64 +108,6 @@ def handler(criterion=None, types=None):
     return decorator
 
 
-@handler(types=str)
-def string(_):
-    value = yield None
-    return value
-
-
-@handler(types=float)
-def float_handler(_):
-    value = yield "Provide a float."
-    try:
-        return float(utils.extract_code_block(value))
-    except ValueError:
-        raise ResponseParsingError(value, "Invalid float provided.", float)
-
-
-@handler(types=int)
-def integer(_):
-    value = yield "Provide an integer."
-    try:
-        return int(utils.extract_code_block(value))
-    except ValueError:
-        raise ResponseParsingError(value, "Invalid integer provided.", int)
-
-
-@handler(types=datetime.datetime)
-def datetime_handler(_):
-    value = yield "Provide a datetime in ISO 8601 format (e.g., 2024-10-27T10:00:00Z)."
-    try:
-        return datetime.datetime.fromisoformat(
-            utils.extract_code_block(value).replace("Z", "+00:00")
-        )
-    except ValueError:
-        raise ResponseParsingError(value, "Invalid datetime format.", datetime.datetime)
-
-
-@handler(types=bool)
-def boolean(_):
-    value = yield "Start your answer with `True.` or `False.`."
-    value_lower = value.lower()
-    if ("true" in value_lower) + ("false" in value_lower) != 1:
-        raise ResponseParsingError(value, f"Boolean value of {value} is unclear.", bool)
-    return "true" in value.lower()
-
-
-@handler(criterion=dataclasses.is_dataclass)
-def dataclass(cls):
-    fields = "\n".join(
-        f"{field.name}: {field.type.__name__}" for field in dataclasses.fields(cls)
-    )
-
-    value = yield f"Write a JSON with the following keys: {fields}"
-    value = utils.extract_code_block(value, name="json", greedy=False)
-    try:
-        return cls(**json.loads(value))
-    except json.JSONDecodeError:
-        raise ResponseParsingError(value, f"Invalid JSON `{value}`", cls)
-
-
 @handler(criterion=lambda x: isinstance(x, dict))
 def typed_dict(attrs: dict[str, type]):
     return pyndantic_like(
@@ -176,7 +131,54 @@ def pyndantic_like(model: pydantic.BaseModel):
             utils.extract_code_block(response, name="json")
         )
     except pydantic.ValidationError as e:
-        raise ResponseParsingError(response, str(e), model.model_json_schema()) from e
+        raise ResponseParsingError(response, str(e), model) from e
+
+
+def can_be_root_model(cls):
+    try:
+        _ = pydantic.RootModel[cls]
+        _.model_json_schema()
+        return True
+    except Exception:
+        return False
+
+
+@handler(criterion=can_be_root_model)
+def root_model_handler(cls):
+    model_cls = pydantic.RootModel[cls]
+    response = yield (
+        f"Output JSON using this schema: {json.dumps(model_cls.model_json_schema())}",
+        model_cls,
+    )
+
+    try:
+        validated_model = model_cls.model_validate_json(
+            utils.extract_code_block(response, name="json")
+        )
+        return validated_model.root
+    except pydantic.ValidationError as e:
+        raise ResponseParsingError(response, str(e), model_cls) from e
+
+
+@handler(types=(float, int, datetime.datetime, bool))
+def primitive_type_handler(cls):
+    model = TypedResponse[cls]
+    response = yield (
+        f"Output JSON using this schema: {json.dumps(model.model_json_schema())}",
+        model,
+    )
+    try:
+        return model.model_validate_json(
+            utils.extract_code_block(response, name="json")
+        ).value
+    except pydantic.ValidationError as e:
+        raise ResponseParsingError(response, str(e), model) from e
+
+
+@handler(types=str)
+def string(_):
+    value = yield None
+    return value
 
 
 @overload

--- a/src/kaggle_benchmarks/prompting.py
+++ b/src/kaggle_benchmarks/prompting.py
@@ -28,6 +28,7 @@ Handlers are processed in reverse registration order, so later registered handle
 Supported types currently include several build-in types, Pydantic models, and dataclasses.
 """
 
+import dataclasses
 import datetime
 import inspect
 import json
@@ -138,16 +139,7 @@ def pyndantic_like(model: pydantic.BaseModel):
         raise ResponseParsingError(response, str(e), model) from e
 
 
-def can_be_root_model(cls):
-    try:
-        _ = pydantic.RootModel[cls]
-        _.model_json_schema()
-        return True
-    except Exception:
-        return False
-
-
-@handler(criterion=can_be_root_model)
+@handler(criterion=dataclasses.is_dataclass)
 def root_model_handler(cls):
     model_cls = pydantic.RootModel[cls]
     response = yield (

--- a/src/kaggle_benchmarks/prompting.py
+++ b/src/kaggle_benchmarks/prompting.py
@@ -32,7 +32,7 @@ import dataclasses
 import datetime
 import inspect
 import json
-from typing import Generator, TypeVar, overload
+from typing import Generator, Generic, TypeVar, overload
 
 import pydantic
 
@@ -40,6 +40,31 @@ from kaggle_benchmarks import utils
 
 handlers = []
 T = TypeVar("T")
+
+
+class BaseModel(pydantic.BaseModel):
+    """Base pydantic model that renderable in markdown."""
+
+    def _repr_markdown_(self):
+        return "\n".join(
+            f"## {key.title().replace('_', '')}\n{value}"
+            for key, value in self.model_dump().items()
+        )
+
+
+class TypedResponse(BaseModel, Generic[T]):
+    value: T
+
+
+class ResponseParsingError(ValueError):
+    def __init__(self, value=None, message=None, schema=None, *args: object) -> None:
+        self.value = value
+        self.message = message
+        self.schema = schema
+        super().__init__(*args)
+
+    def __str__(self) -> str:
+        return f"ResponseParsingError(value={self.value}, message={self.message}, schema={self.schema})"
 
 
 def parse_response(handler: Generator[str | tuple[str, T], str, T], value: str) -> T:
@@ -82,7 +107,7 @@ def float_handler(_):
     try:
         return float(utils.extract_code_block(value))
     except ValueError:
-        raise ValueError("Invalid float provided.")
+        raise ResponseParsingError(value, "Invalid float provided.", float)
 
 
 @handler(types=int)
@@ -91,7 +116,7 @@ def integer(_):
     try:
         return int(utils.extract_code_block(value))
     except ValueError:
-        raise ValueError("Invalid integer provided.")
+        raise ResponseParsingError(value, "Invalid integer provided.", int)
 
 
 @handler(types=datetime.datetime)
@@ -102,16 +127,15 @@ def datetime_handler(_):
             utils.extract_code_block(value).replace("Z", "+00:00")
         )
     except ValueError:
-        raise ValueError("Invalid datetime format.")
+        raise ResponseParsingError(value, "Invalid datetime format.", datetime.datetime)
 
 
 @handler(types=bool)
 def boolean(_):
     value = yield "Start your answer with `True.` or `False.`."
-    value = value.lower()
-    assert ("true" in value) + ("false" in value) == 1, (
-        f"Boolean value of {value} is unclear."
-    )
+    value_lower = value.lower()
+    if ("true" in value_lower) + ("false" in value_lower) != 1:
+        raise ResponseParsingError(value, f"Boolean value of {value} is unclear.", bool)
     return "true" in value.lower()
 
 
@@ -126,18 +150,11 @@ def dataclass(cls):
     try:
         return cls(**json.loads(value))
     except json.JSONDecodeError:
-        raise AssertionError(f"Invalid JSON `{value}`")
+        raise ResponseParsingError(value, f"Invalid JSON `{value}`", cls)
 
 
 @handler(criterion=lambda x: isinstance(x, dict))
 def typed_dict(attrs: dict[str, type]):
-    class BaseModel(pydantic.BaseModel):
-        def _repr_markdown_(self):
-            return "\n".join(
-                f"## {key.title().replace('_', '')}\n{value}"
-                for key, value in self.model_dump().items()
-            )
-
     return pyndantic_like(
         pydantic.create_model(
             "Response",
@@ -154,7 +171,12 @@ def pyndantic_like(model: pydantic.BaseModel):
         model,
     )
 
-    return model.model_validate_json(utils.extract_code_block(response, name="json"))
+    try:
+        return model.model_validate_json(
+            utils.extract_code_block(response, name="json")
+        )
+    except pydantic.ValidationError as e:
+        raise ResponseParsingError(response, str(e), model.model_json_schema()) from e
 
 
 @overload

--- a/tests/test_llm_chats.py
+++ b/tests/test_llm_chats.py
@@ -16,8 +16,8 @@ import json
 
 import pytest
 
-from kaggle_benchmarks import actors, chats, utils
-from kaggle_benchmarks.actors.llms import LLMResponse, SchemaProcessingError
+from kaggle_benchmarks import actors, chats, prompting, utils
+from kaggle_benchmarks.actors.llms import LLMResponse
 from kaggle_benchmarks.prompting import handler
 
 
@@ -113,10 +113,10 @@ def test_structured():
     @handler(types=F)
     def _(cls):
         yield ""
-        raise ValueError("Bad response")
+        raise prompting.ResponseParsingError("Bad response")
 
     with chats.new() as t:
-        with pytest.raises(ValueError):
+        with pytest.raises(prompting.ResponseParsingError):
             llm.prompt("Test", schema=F)
         assert "Bad response" in t.messages[-1].text
 
@@ -126,7 +126,7 @@ def test_structured():
         yield "nonesense"
         return F()
 
-    with pytest.raises(SchemaProcessingError):
+    with pytest.raises(prompting.SchemaProcessingError):
         llm.prompt("Test", schema=F)
 
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -35,11 +35,12 @@ class Parrot(actors.LLMChat):
 def test_raw_payload():
     p = Parrot()
     with chats.new() as chat:
-        m = p.prompt("1e-2", schema=float)
+        raw_response = '{"value": 0.01}'
+        m = p.prompt(raw_response, schema=float)
         assert m == 0.01
-        assert chat.messages[-1].payload == "1e-2"
+        assert chat.messages[-1].payload == raw_response
 
-    r = p.prompt("TRUE", schema=bool)
+    r = p.prompt('{"value": true}', schema=bool)
     assert r
 
 

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import json
 from dataclasses import dataclass
 
 import pydantic
@@ -28,18 +29,26 @@ def test_str():
         assert x == prompting.parse_response(prompting.process_schema(str), x)
 
 
-def test_bool():
-    assert prompting.parse_response(prompting.process_schema(bool), "true")
-    assert not prompting.parse_response(prompting.process_schema(bool), "False")
-
-
-def test_datetime():
-    assert isinstance(
-        prompting.parse_response(
-            prompting.process_schema(datetime.datetime), "2025-01-01T10:00:00Z"
+@pytest.mark.parametrize(
+    "schema_type, input_value, expected_value",
+    [
+        (int, 123, 123),
+        (float, 123.45, 123.45),
+        (bool, True, True),
+        (bool, False, False),
+        (
+            datetime.datetime,
+            "2025-01-01T10:00:00Z",
+            datetime.datetime(2025, 1, 1, 10, 0, tzinfo=datetime.timezone.utc),
         ),
-        datetime.datetime,
+    ],
+)
+def test_primitive_types(schema_type, input_value, expected_value):
+    json_input = json.dumps({"value": input_value})
+    output_value = prompting.parse_response(
+        prompting.process_schema(schema_type), json_input
     )
+    assert output_value == expected_value
 
 
 def test_dataclass():

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -15,8 +15,12 @@
 import datetime
 from dataclasses import dataclass
 
+import pydantic
+import pytest
+
 from kaggle_benchmarks import actors, chats, messages, prompting
 from kaggle_benchmarks.actors.llms import LLMResponse
+from kaggle_benchmarks.prompting import ResponseParsingError
 
 
 def test_str():
@@ -80,3 +84,11 @@ def test_llm():
         response = LLM().prompt(message="?", schema=A)
         assert isinstance(response, A)
         assert response == A("a", 2)
+
+
+def test_pydantic_error():
+    class Model(pydantic.BaseModel):
+        a: int
+
+    with pytest.raises(ResponseParsingError):
+        prompting.parse_response(prompting.process_schema(Model), '{"a": "not an int"}')


### PR DESCRIPTION
- All parsing handlers now raise `ResponseParsingError` on failure.
- Pydantic's `ValidationError` is re-raised as `ResponseParsingError`.
- Added and using `TypedResponse[T]` for build-in types.
- Added tests to verify error raising.