### PR TITLE
Create base image for library

### DIFF
--- a/cicd/Dockerfile.base
+++ b/cicd/Dockerfile.base
@@ -56,5 +56,3 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-project --no-dev --group kaggle
 
 RUN uv run playwright install chromium --only-shell
-
-CMD ["/bin/bash"]

--- a/cicd/Dockerfile.base
+++ b/cicd/Dockerfile.base
@@ -1,0 +1,60 @@
+# Create an image that will run personal benchmarks on Kaggle
+# BASE LAYER: Contains OS, system deps, and third-party libraries.
+FROM python:3.11-slim
+
+COPY --from=ghcr.io/astral-sh/uv:0.6.14 /uv /uvx /bin/
+
+WORKDIR /benchmarks
+
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+
+# Manually install Playwright's system dependencies for Debian Trixie.
+# This step is necessary because the base image was recently updated to Debian
+# Trixie, which changed the names and availability of several packages required
+# by Playwright's browsers.
+#
+# This list of packages was obtained from the detailed error logs produced
+# by Playwright when it failed to launch a browser.
+RUN apt-get update && apt-get install -y \
+    libnss3 \
+    libnss3-tools \
+    libnspr4 \
+    libdbus-1-3 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdrm2 \
+    libatspi2.0-0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libgbm1 \
+    libpango-1.0-0 \
+    libcairo2 \
+    libasound2 \
+    fonts-unifont \
+    libxkbcommon0 \
+    libglib2.0-0 \
+    libgobject-2.0-0 \
+    libexpat1 \
+    libx11-6 \
+    libxext6 \
+    libxcb1 \
+    libgtk-3-0 \
+    libfontconfig1 \
+    --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
+# Pre-install external dependencies from the lockfile.
+# We use --no-install-project because the source code isn't here yet.
+# This ensures all third-party libs are cached in this base layer.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --frozen --no-install-project --no-dev --group kaggle
+
+RUN uv run playwright install chromium --only-shell
+
+CMD ["/bin/bash"]

--- a/cicd/build/cloudbuild.yaml
+++ b/cicd/build/cloudbuild.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 steps:
   - id: "build-image"
     name: "gcr.io/cloud-builders/docker"

--- a/cicd/build/cloudbuild_base.yaml
+++ b/cicd/build/cloudbuild_base.yaml
@@ -1,0 +1,10 @@
+steps:
+  - id: "build-base"
+    name: "gcr.io/cloud-builders/docker"
+    args: ["build", "-t", "${_REPO}/${_NAME}:latest", "-f", "cicd/Dockerfile.base", "."]
+  - id: "push-base"
+    name: "gcr.io/cloud-builders/docker"
+    args: ["push", "${_REPO}/${_NAME}:latest"]
+substitutions:
+  _REPO: gcr.io/kaggle-private-byod
+  _NAME: personal-benchmarks-base

--- a/cicd/build/cloudbuild_base.yaml
+++ b/cicd/build/cloudbuild_base.yaml
@@ -1,10 +1,36 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 steps:
   - id: "build-base"
     name: "gcr.io/cloud-builders/docker"
     args: ["build", "-t", "${_REPO}/${_NAME}:latest", "-f", "cicd/Dockerfile.base", "."]
+    waitFor: ["-"]
+    env:
+      - "DOCKER_BUILDKIT=1"
+
   - id: "push-base"
     name: "gcr.io/cloud-builders/docker"
     args: ["push", "${_REPO}/${_NAME}:latest"]
+    waitFor: ["build-base"]
+
+
+images:
+  - "${_REPO}/${_NAME}"
+
+timeout: 3600s
+
 substitutions:
   _REPO: gcr.io/kaggle-private-byod
   _NAME: personal-benchmarks-base

--- a/cicd/build/cloudbuild_base_branch.yaml
+++ b/cicd/build/cloudbuild_base_branch.yaml
@@ -22,6 +22,7 @@ steps:
         "-f", "cicd/Dockerfile.base",
         ".",
       ]
+    waitFor: ["-"]
     env:
       - "DOCKER_BUILDKIT=1"
 
@@ -29,6 +30,11 @@ steps:
     name: "gcr.io/cloud-builders/docker"
     args: ["push", "${_BASE_IMAGE_REPO}/${_BASE_IMAGE_NAME}:${COMMIT_SHA}"]
     waitFor: ["build-base-pr"]
+
+images:
+  - "${_BASE_IMAGE_REPO}/${_BASE_IMAGE_NAME}"
+
+timeout: 3600s # 1 hour
 
 substitutions:
   _BASE_IMAGE_REPO: gcr.io/kaggle-private-byod

--- a/cicd/build/cloudbuild_base_branch.yaml
+++ b/cicd/build/cloudbuild_base_branch.yaml
@@ -1,0 +1,36 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - id: "build-base-pr"
+    name: "gcr.io/cloud-builders/docker"
+    args:
+      [
+        "build",
+        "-t", "${_BASE_IMAGE_REPO}/${_BASE_IMAGE_NAME}:${COMMIT_SHA}",
+        "-f", "cicd/Dockerfile.base",
+        ".",
+      ]
+    env:
+      - "DOCKER_BUILDKIT=1"
+
+  - id: "push-base-pr"
+    name: "gcr.io/cloud-builders/docker"
+    args: ["push", "${_BASE_IMAGE_REPO}/${_BASE_IMAGE_NAME}:${COMMIT_SHA}"]
+    waitFor: ["build-base-pr"]
+
+substitutions:
+  _BASE_IMAGE_REPO: gcr.io/kaggle-private-byod
+  # Renamed to keep PR bases separate from the prod base repo
+  _BASE_IMAGE_NAME: personal-benchmarks-base-pr

--- a/cicd/build/cloudbuild_branch.yaml
+++ b/cicd/build/cloudbuild_branch.yaml
@@ -36,7 +36,7 @@ steps:
     name: "${_IMAGE_REPO_NAME}/${_IMAGE_NAME}:${COMMIT_SHA}"
     dir: /benchmarks
     entrypoint: uv
-    args: ["run", "--group", "test",  "pytest", "tests"]
+    args: ["run", "--group", "test", "pytest", "tests"]
     waitFor: ["push-image"]
     env:
       - "PLAYWRIGHT_BROWSERS_PATH=/root/.cache/ms-playwright"


### PR DESCRIPTION
This base image will be cached for faster Kaggle notebook loads.

Tested locally by building the docker image and running all the tests.