### PR TITLE
Update image input example.

### DIFF
--- a/documentation/examples/describe_image.py
+++ b/documentation/examples/describe_image.py
@@ -139,18 +139,20 @@ describe_local_image.run(kbench.llm)
 # ---
 # This example demonstrates sending multiple images to the model for comparison.
 
+
 # %%
 @kbench.task("Compare Logos")
 def compare_logos(llm):
     """Sends two images and asks for differences."""
 
-    # Real mouse
-    img_url1 = "https://www.kaggle.com/static/images/logos/kaggle-logo-transparent-300.png"
-    # Computer mouse
-    img_url2 = "https://www.kaggle.com/static/images/logos/kaggle-logo-gray-300.png"
-
-    img1 = images.from_url(img_url1, caption="Logo 1")
-    img2 = images.from_url(img_url2, caption="Logo 2")
+    img1 = images.from_url(
+        "https://www.kaggle.com/static/images/logos/kaggle-logo-transparent-300.png",
+        caption="Logo 1",
+    )
+    img2 = images.from_url(
+        "https://www.kaggle.com/static/images/logos/kaggle-logo-gray-300.png",
+        caption="Logo 2",
+    )
 
     # Use `send` to enable multi-image conversation.
     # Since `send` doesn't auto-convert URLs, we explicitly encode images to base64
@@ -163,7 +165,6 @@ def compare_logos(llm):
     # kbench.user.send(img1)
     # kbench.user.send(img2)
 
-
     response = llm.prompt("What are the main differences of these two images.")
 
     assessment = kbench.assertions.assess_response_with_judge(
@@ -172,13 +173,13 @@ def compare_logos(llm):
         criteria=[
             "The answer should highlight the main difference is the background.",
             "The answer should mention the font are the same",
-        ]
+        ],
     )
 
     for result in assessment.results:
         kbench.assertions.assert_true(
             result.passed,
-            expectation=f"Judge Criterion '{result.criterion}' should pass: {result.reason}"
+            expectation=f"Judge Criterion '{result.criterion}' should pass: {result.reason}",
         )
 
 

--- a/documentation/examples/describe_image.py
+++ b/documentation/examples/describe_image.py
@@ -21,19 +21,18 @@
 # - When using Base64, you need specify the image format if it's different from default jpeg.
 # - Use `from_path`` to load from local images.
 # %%
-import kaggle_benchmarks as kbench
-from kaggle_benchmarks.content_types import images
 import httpx
 
-
-# %%
 import kaggle_benchmarks as kbench
 from kaggle_benchmarks.content_types import images
+
+# %%
 
 # %% [markdown]
 # ---
 # ### Example 1. Sending LLM image from URL
 # ---
+
 
 # %%
 @kbench.task("Describe Image (URL)")
@@ -54,6 +53,7 @@ def describe_image_url(llm):
         expectation="LLM should identify the Kaggle logo.",
     )
 
+
 describe_image_url.run(kbench.llm)
 
 # %% [markdown]
@@ -61,15 +61,14 @@ describe_image_url.run(kbench.llm)
 # ### Example 2. Sending LLM image from Base64 (specifying format parameter)
 # ---
 
+
 # %%
 @kbench.task("Describe Image (Base64)")
 def describe_image_base64(llm):
     """Sends a base64 encoded image with explicit format specification."""
     # Example: A small red dot (PNG)
     # This is a 1x1 red pixel in PNG format
-    red_dot_b64 = (
-        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
-    )
+    red_dot_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
 
     # Create Image object from Base64, specifying the format as 'png'
     # The 'format' parameter is important when the image is not a JPEG (default)
@@ -83,6 +82,7 @@ def describe_image_base64(llm):
         expectation="LLM should identify the color red.",
     )
 
+
 describe_image_base64.run(kbench.llm)
 
 # %% [markdown]
@@ -94,13 +94,14 @@ describe_image_base64.run(kbench.llm)
 
 # Download the file to local file first
 
+
 def download_image(url, filename):
     try:
         with httpx.Client() as client:
             response = client.get(url)
-            response.raise_for_status() # Raise error for 4xx/5xx responses
+            response.raise_for_status()  # Raise error for 4xx/5xx responses
 
-            with open(filename, 'wb') as file:
+            with open(filename, "wb") as file:
                 file.write(response.content)
 
         print(f"Successfully downloaded: {filename}")
@@ -108,7 +109,9 @@ def download_image(url, filename):
     except httpx.HTTPError as e:
         print(f"Error downloading image: {e}")
 
+
 download_image("https://www.kaggle.com/static/images/site-logo.png", "kaggle_logo.png")
+
 
 # Benchmark task using local file
 @kbench.task("Describe Image (Local File)")
@@ -126,6 +129,7 @@ def describe_local_image(llm):
         response,
         expectation="LLM should recognize the logo.",
     )
+
 
 describe_local_image.run(kbench.llm)
 

--- a/documentation/examples/describe_image.py
+++ b/documentation/examples/describe_image.py
@@ -14,75 +14,119 @@
 
 # %% [markdown]
 # ---
-# ## Vision-Capable Tasks for Gemini
+# ## How to Send Images to LLM
 #
-# Here we add two tasks to test the vision capabilities of the Gemini model using the genai api.
-# The first task takes a pre-converted base64 image string, and the second
-# handles a direct image URL.
+# You can send images using a direct URL or a Base64 string. We also provide helper function to load a local image to base64.
+# - When using URL, the image image format is automatically guessed.
+# - When using Base64, you need specify the image format if it's different from default jpeg.
+# - Use `from_path`` to load from local images.
 # %%
-from kaggle_benchmarks import assertions, content_types, task
-from kaggle_benchmarks.kaggle import load_model
-
-llm = load_model(
-    model_name="google/gemini-2.5-pro",
-    api="genai",
-)
-
-# ---
-# ### 1. Task for Image with Base64 Input
-# ---
+import kaggle_benchmarks as kbench
+from kaggle_benchmarks.content_types import images
+import httpx
 
 
-@task("Describe Image (Base64)")
-def describe_image_base64(llm, image_base64: str, question: str, answer: str):
-    """Sends a base64 image string and a question to a vision model."""
-    image = content_types.images.from_base64(image_base64, caption=question)
-    response = llm.prompt(image)
-    assertions.assert_contains_regex(
-        f"(?i){answer}",
-        response,
-        expectation="LLM should identify the object correctly.",
-    )
-
-
-dog_image_url = (
-    "https://upload.wikimedia.org/wikipedia/commons/4/47/American_Eskimo_Dog.jpg"
-)
-dog_image_base64 = content_types.images.image_url_to_base64(dog_image_url)
-
-describe_image_base64.run(
-    llm=llm,
-    image_base64=dog_image_base64,
-    question="What is in the picture?",
-    answer="dog",
-)
 # %%
+import kaggle_benchmarks as kbench
+from kaggle_benchmarks.content_types import images
+
+# %% [markdown]
 # ---
-# ### 2. Task for Image with URL Input
+# ### Example 1. Sending LLM image from URL
 # ---
 
+# %%
+@kbench.task("Describe Image (URL)")
+def describe_image_url(llm):
+    """Sends an image URL directly to the model."""
+    # Kaggle logo
+    image_url = "https://www.kaggle.com/static/images/site-logo.png"
 
-@task("Describe Image (URL)")
-def describe_image_url(llm, image_url: str, question: str, answer: str):
-    """Sends an image URL and a question to a vision model."""
-    image = content_types.images.from_base64(
-        content_types.images.image_url_to_base64(image_url),
-        caption=question,
-    )
+    # Create Image object from URL.
+    # It will guess image type from URL.
+    image = images.from_url(image_url, caption="a logo")
 
-    response = llm.prompt(image)
-    assertions.assert_contains_regex(
-        f"(?i){answer}",
+    response = llm.prompt("What does this logo say?", image=image)
+
+    kbench.assertions.assert_contains_regex(
+        r"(?i)kaggle",
         response,
-        expectation="LLM should identify the object correctly.",
+        expectation="LLM should identify the Kaggle logo.",
     )
 
+describe_image_url.run(kbench.llm)
 
-describe_image_url.run(
-    llm=llm,
-    image_url=dog_image_url,
-    question="Describe the main subject in this image.",
-    answer="dog",
-)
+# %% [markdown]
+# ---
+# ### Example 2. Sending LLM image from Base64 (specifying format parameter)
+# ---
+
+# %%
+@kbench.task("Describe Image (Base64)")
+def describe_image_base64(llm):
+    """Sends a base64 encoded image with explicit format specification."""
+    # Example: A small red dot (PNG)
+    # This is a 1x1 red pixel in PNG format
+    red_dot_b64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    )
+
+    # Create Image object from Base64, specifying the format as 'png'
+    # The 'format' parameter is important when the image is not a JPEG (default)
+    image = images.from_base64(red_dot_b64, format="png", caption="a colorful dot")
+
+    response = llm.prompt("What color is this image?", image=image)
+
+    kbench.assertions.assert_contains_regex(
+        r"(?i)red",
+        response,
+        expectation="LLM should identify the color red.",
+    )
+
+describe_image_base64.run(kbench.llm)
+
+# %% [markdown]
+# ---
+# ### Example 3. Sending LLM image from local image file
+# ---
+
+# %%
+
+# Download the file to local file first
+
+def download_image(url, filename):
+    try:
+        with httpx.Client() as client:
+            response = client.get(url)
+            response.raise_for_status() # Raise error for 4xx/5xx responses
+
+            with open(filename, 'wb') as file:
+                file.write(response.content)
+
+        print(f"Successfully downloaded: {filename}")
+
+    except httpx.HTTPError as e:
+        print(f"Error downloading image: {e}")
+
+download_image("https://www.kaggle.com/static/images/site-logo.png", "kaggle_logo.png")
+
+# Benchmark task using local file
+@kbench.task("Describe Image (Local File)")
+def describe_local_image(llm):
+    """Sends a local image with explicit format specification."""
+
+    # Load a local image from an attached Kaggle dataset
+    image = images.from_path("kaggle_logo.png")
+    prompt = "How many letters are there in the image?"
+
+    response = llm.prompt(prompt, image=image, schema=int)
+
+    kbench.assertions.assert_equal(
+        6,
+        response,
+        expectation="LLM should recognize the logo.",
+    )
+
+describe_local_image.run(kbench.llm)
 
 # %%

--- a/documentation/examples/describe_image.py
+++ b/documentation/examples/describe_image.py
@@ -133,4 +133,55 @@ def describe_local_image(llm):
 
 describe_local_image.run(kbench.llm)
 
+# %% [markdown]
+# ---
+# ### Example 4. Comparing two images
+# ---
+# This example demonstrates sending multiple images to the model for comparison.
+
+# %%
+@kbench.task("Compare Logos")
+def compare_logos(llm):
+    """Sends two images and asks for differences."""
+
+    # Real mouse
+    img_url1 = "https://www.kaggle.com/static/images/logos/kaggle-logo-transparent-300.png"
+    # Computer mouse
+    img_url2 = "https://www.kaggle.com/static/images/logos/kaggle-logo-gray-300.png"
+
+    img1 = images.from_url(img_url1, caption="Logo 1")
+    img2 = images.from_url(img_url2, caption="Logo 2")
+
+    # Use `send` to enable multi-image conversation.
+    # Since `send` doesn't auto-convert URLs, we explicitly encode images to base64
+    # so it will work with more models that don't directly accept an image URL.
+    kbench.user.send(images.from_image_url(img1))
+    kbench.user.send(images.from_image_url(img2))
+
+    # For models that directly work with image URL
+    # You can simply call
+    # kbench.user.send(img1)
+    # kbench.user.send(img2)
+
+
+    response = llm.prompt("What are the main differences of these two images.")
+
+    assessment = kbench.assertions.assess_response_with_judge(
+        response_text=response,
+        judge_llm=kbench.judge_llm,
+        criteria=[
+            "The answer should highlight the main difference is the background.",
+            "The answer should mention the font are the same",
+        ]
+    )
+
+    for result in assessment.results:
+        kbench.assertions.assert_true(
+            result.passed,
+            expectation=f"Judge Criterion '{result.criterion}' should pass: {result.reason}"
+        )
+
+
+compare_logos.run(kbench.llm)
+
 # %%

--- a/src/kaggle_benchmarks/_config.py
+++ b/src/kaggle_benchmarks/_config.py
@@ -87,9 +87,7 @@ class Config:
         )
     )
     render_subruns: bool = dataclasses.field(
-        default_factory=lambda: (
-            string_to_bool(os.environ.get("RENDER_SUBRUNS", "True"))
-        )
+        default_factory=lambda: string_to_bool(os.environ.get("RENDER_SUBRUNS", "True"))
     )
 
     show_message_details: bool = False

--- a/src/kaggle_benchmarks/content_types/images.py
+++ b/src/kaggle_benchmarks/content_types/images.py
@@ -154,7 +154,9 @@ def from_image_url(image_url: ImageURL) -> ImageBase64:
 def image_url_to_base64(url: str) -> str:
     """Load an image from its url to base64."""
     # Explicit User-Agent: https://meta.wikimedia.org/wiki/User-Agent_policy
-    headers = {"User-Agent": "test"}
+    headers = {
+        "User-Agent": "MyImageDownloader/1.0 (myemail@example.com)"
+    }
     client = httpx.Client()
     response = client.get(url, headers=headers)
     response.raise_for_status()

--- a/src/kaggle_benchmarks/content_types/images.py
+++ b/src/kaggle_benchmarks/content_types/images.py
@@ -154,9 +154,7 @@ def from_image_url(image_url: ImageURL) -> ImageBase64:
 def image_url_to_base64(url: str) -> str:
     """Load an image from its url to base64."""
     # Explicit User-Agent: https://meta.wikimedia.org/wiki/User-Agent_policy
-    headers = {
-        "User-Agent": "MyImageDownloader/1.0 (myemail@example.com)"
-    }
+    headers = {"User-Agent": "MyImageDownloader/1.0 (myemail@example.com)"}
     client = httpx.Client()
     response = client.get(url, headers=headers)
     response.raise_for_status()

--- a/src/kaggle_benchmarks/tools/python.py
+++ b/src/kaggle_benchmarks/tools/python.py
@@ -37,12 +37,11 @@ def extract_code(text: str, all_blocks: bool = False) -> str:
     Returns:
         Extracted Python code, or the original text if no code blocks found.
     """
-    if "```python" in text:  
-        return utils.extract_code_block(  
-                text, name="python", greedy=False, all_blocks=all_blocks  
-            ).strip()  
-    return text  
-
+    if "```python" in text:
+        return utils.extract_code_block(
+            text, name="python", greedy=False, all_blocks=all_blocks
+        ).strip()
+    return text
 
 
 def markdown_code(string: str | None, kind: str = "", header: str = "") -> str:

--- a/tests/contents/test_images.py
+++ b/tests/contents/test_images.py
@@ -124,7 +124,9 @@ def test_image_url_to_base64_success(mocker):
     result = images.image_url_to_base64(url)
 
     # Verify that requests.get was called correctly
-    mock_get.assert_called_once_with(url, headers={"User-Agent": "test"})
+    mock_get.assert_called_once_with(
+        url, headers={"User-Agent": "MyImageDownloader/1.0 (myemail@example.com)"}
+    )
 
     # Verify the result is the expected base64 string
     assert result == B64_STRING
@@ -151,4 +153,6 @@ def test_image_url_to_base64_http_error(mocker):
         images.image_url_to_base64(url)
 
     # Verify that requests.get was still called
-    mock_get.assert_called_once_with(url, headers={"User-Agent": "test"})
+    mock_get.assert_called_once_with(
+        url, headers={"User-Agent": "MyImageDownloader/1.0 (myemail@example.com)"}
+    )


### PR DESCRIPTION
Update the image input examples with 3 cases: from url, from base 64 and from a local file. This is consistent with our cookbook example.