### PR TITLE
Revert "refactor(prompting): Standardize error handling with ResponseParsingError"

### DIFF
--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -110,6 +110,10 @@ class LLMResponse:
     meta: dict[str, Any] = dataclasses.field(default_factory=dict)
 
 
+class SchemaProcessingError(TypeError):
+    pass
+
+
 class LLMChat(actors.Actor):
     """A chat agent that interacts with a Large Language Model (LLM)."""
 
@@ -223,10 +227,10 @@ class LLMChat(actors.Actor):
 
         try:
             h.send(answer)  # must raise StopIteration by returning the parsed value
-            raise prompting.SchemaProcessingError(
+            raise SchemaProcessingError(
                 f"Generator for {schema!r} yielded multiple values, expected only one."
             )
-        except prompting.ResponseParsingError as e:
+        except ValueError as e:
             chat.append(
                 messages.Message(
                     f"Error processing response {answer}:\n{e}",

--- a/src/kaggle_benchmarks/prompting.py
+++ b/src/kaggle_benchmarks/prompting.py
@@ -32,7 +32,7 @@ import dataclasses
 import datetime
 import inspect
 import json
-from typing import Generator, Generic, TypeVar, overload
+from typing import Generator, TypeVar, overload
 
 import pydantic
 
@@ -40,49 +40,6 @@ from kaggle_benchmarks import utils
 
 handlers = []
 T = TypeVar("T")
-
-
-class RenderablePydanticModel(pydantic.BaseModel):
-    """Base pydantic model that renderable in markdown."""
-
-    def _repr_markdown_(self):
-        return "\n".join(
-            f"## {key.title().replace('_', '')}\n{value}"
-            for key, value in self.model_dump().items()
-        )
-
-
-class TypedResponse(RenderablePydanticModel, Generic[T]):
-    """
-        A generic container for wrapping a typed value.
-
-        This is particularly useful for APIs that require a JSON object as the
-        root of a response schema. It allows for defining a response format
-    for
-        primitive or generic types on the fly.
-
-        For example:
-        - `TypedResponse[int]` will expect a JSON object like `{"value": 123}`.
-        - `TypedResponse[list[int]]` will expect `{"value": [1, 2, 3]}`.
-        - `TypedResponse[tuple[int, str]]` will expect `{"value": [1, "hello"]}`.
-    """
-
-    value: T
-
-
-class ResponseParsingError(ValueError):
-    def __init__(self, value=None, message=None, schema=None, *args: object) -> None:
-        self.value = value
-        self.message = message
-        self.schema = schema
-        super().__init__(*args)
-
-    def __str__(self) -> str:
-        return f"ResponseParsingError(value={self.value}, message={self.message}, schema={self.schema})"
-
-
-class SchemaProcessingError(TypeError):
-    pass
 
 
 def parse_response(handler: Generator[str | tuple[str, T], str, T], value: str) -> T:
@@ -113,13 +70,79 @@ def handler(criterion=None, types=None):
     return decorator
 
 
+@handler(types=str)
+def string(_):
+    value = yield None
+    return value
+
+
+@handler(types=float)
+def float_handler(_):
+    value = yield "Provide a float."
+    try:
+        return float(utils.extract_code_block(value))
+    except ValueError:
+        raise ValueError("Invalid float provided.")
+
+
+@handler(types=int)
+def integer(_):
+    value = yield "Provide an integer."
+    try:
+        return int(utils.extract_code_block(value))
+    except ValueError:
+        raise ValueError("Invalid integer provided.")
+
+
+@handler(types=datetime.datetime)
+def datetime_handler(_):
+    value = yield "Provide a datetime in ISO 8601 format (e.g., 2024-10-27T10:00:00Z)."
+    try:
+        return datetime.datetime.fromisoformat(
+            utils.extract_code_block(value).replace("Z", "+00:00")
+        )
+    except ValueError:
+        raise ValueError("Invalid datetime format.")
+
+
+@handler(types=bool)
+def boolean(_):
+    value = yield "Start your answer with `True.` or `False.`."
+    value = value.lower()
+    assert ("true" in value) + ("false" in value) == 1, (
+        f"Boolean value of {value} is unclear."
+    )
+    return "true" in value.lower()
+
+
+@handler(criterion=dataclasses.is_dataclass)
+def dataclass(cls):
+    fields = "\n".join(
+        f"{field.name}: {field.type.__name__}" for field in dataclasses.fields(cls)
+    )
+
+    value = yield f"Write a JSON with the following keys: {fields}"
+    value = utils.extract_code_block(value, name="json", greedy=False)
+    try:
+        return cls(**json.loads(value))
+    except json.JSONDecodeError:
+        raise AssertionError(f"Invalid JSON `{value}`")
+
+
 @handler(criterion=lambda x: isinstance(x, dict))
 def typed_dict(attrs: dict[str, type]):
+    class BaseModel(pydantic.BaseModel):
+        def _repr_markdown_(self):
+            return "\n".join(
+                f"## {key.title().replace('_', '')}\n{value}"
+                for key, value in self.model_dump().items()
+            )
+
     return pyndantic_like(
         pydantic.create_model(
             "Response",
             **{key: (value, ...) for key, value in attrs.items()},
-            __base__=RenderablePydanticModel,
+            __base__=BaseModel,
         )
     )
 
@@ -131,50 +154,7 @@ def pyndantic_like(model: pydantic.BaseModel):
         model,
     )
 
-    try:
-        return model.model_validate_json(
-            utils.extract_code_block(response, name="json")
-        )
-    except pydantic.ValidationError as e:
-        raise ResponseParsingError(response, str(e), model) from e
-
-
-@handler(criterion=dataclasses.is_dataclass)
-def root_model_handler(cls):
-    model_cls = pydantic.RootModel[cls]
-    response = yield (
-        f"Output JSON using this schema: {json.dumps(model_cls.model_json_schema())}",
-        model_cls,
-    )
-
-    try:
-        validated_model = model_cls.model_validate_json(
-            utils.extract_code_block(response, name="json")
-        )
-        return validated_model.root
-    except pydantic.ValidationError as e:
-        raise ResponseParsingError(response, str(e), model_cls) from e
-
-
-@handler(types=(float, int, datetime.datetime, bool))
-def primitive_type_handler(cls):
-    model = TypedResponse[cls]
-    response = yield (
-        f"Output JSON using this schema: {json.dumps(model.model_json_schema())}",
-        model,
-    )
-    try:
-        return model.model_validate_json(
-            utils.extract_code_block(response, name="json")
-        ).value
-    except pydantic.ValidationError as e:
-        raise ResponseParsingError(response, str(e), model) from e
-
-
-@handler(types=str)
-def string(_):
-    value = yield None
-    return value
+    return model.model_validate_json(utils.extract_code_block(response, name="json"))
 
 
 @overload

--- a/tests/test_llm_chats.py
+++ b/tests/test_llm_chats.py
@@ -16,8 +16,8 @@ import json
 
 import pytest
 
-from kaggle_benchmarks import actors, chats, prompting, utils
-from kaggle_benchmarks.actors.llms import LLMResponse
+from kaggle_benchmarks import actors, chats, utils
+from kaggle_benchmarks.actors.llms import LLMResponse, SchemaProcessingError
 from kaggle_benchmarks.prompting import handler
 
 
@@ -113,10 +113,10 @@ def test_structured():
     @handler(types=F)
     def _(cls):
         yield ""
-        raise prompting.ResponseParsingError("Bad response")
+        raise ValueError("Bad response")
 
     with chats.new() as t:
-        with pytest.raises(prompting.ResponseParsingError):
+        with pytest.raises(ValueError):
             llm.prompt("Test", schema=F)
         assert "Bad response" in t.messages[-1].text
 
@@ -126,7 +126,7 @@ def test_structured():
         yield "nonesense"
         return F()
 
-    with pytest.raises(prompting.SchemaProcessingError):
+    with pytest.raises(SchemaProcessingError):
         llm.prompt("Test", schema=F)
 
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -35,12 +35,11 @@ class Parrot(actors.LLMChat):
 def test_raw_payload():
     p = Parrot()
     with chats.new() as chat:
-        raw_response = '{"value": 0.01}'
-        m = p.prompt(raw_response, schema=float)
+        m = p.prompt("1e-2", schema=float)
         assert m == 0.01
-        assert chat.messages[-1].payload == raw_response
+        assert chat.messages[-1].payload == "1e-2"
 
-    r = p.prompt('{"value": true}', schema=bool)
+    r = p.prompt("TRUE", schema=bool)
     assert r
 
 

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -13,15 +13,10 @@
 # limitations under the License.
 
 import datetime
-import json
 from dataclasses import dataclass
-
-import pydantic
-import pytest
 
 from kaggle_benchmarks import actors, chats, messages, prompting
 from kaggle_benchmarks.actors.llms import LLMResponse
-from kaggle_benchmarks.prompting import ResponseParsingError
 
 
 def test_str():
@@ -29,26 +24,18 @@ def test_str():
         assert x == prompting.parse_response(prompting.process_schema(str), x)
 
 
-@pytest.mark.parametrize(
-    "schema_type, input_value, expected_value",
-    [
-        (int, 123, 123),
-        (float, 123.45, 123.45),
-        (bool, True, True),
-        (bool, False, False),
-        (
-            datetime.datetime,
-            "2025-01-01T10:00:00Z",
-            datetime.datetime(2025, 1, 1, 10, 0, tzinfo=datetime.timezone.utc),
+def test_bool():
+    assert prompting.parse_response(prompting.process_schema(bool), "true")
+    assert not prompting.parse_response(prompting.process_schema(bool), "False")
+
+
+def test_datetime():
+    assert isinstance(
+        prompting.parse_response(
+            prompting.process_schema(datetime.datetime), "2025-01-01T10:00:00Z"
         ),
-    ],
-)
-def test_primitive_types(schema_type, input_value, expected_value):
-    json_input = json.dumps({"value": input_value})
-    output_value = prompting.parse_response(
-        prompting.process_schema(schema_type), json_input
+        datetime.datetime,
     )
-    assert output_value == expected_value
 
 
 def test_dataclass():
@@ -93,11 +80,3 @@ def test_llm():
         response = LLM().prompt(message="?", schema=A)
         assert isinstance(response, A)
         assert response == A("a", 2)
-
-
-def test_pydantic_error():
-    class Model(pydantic.BaseModel):
-        a: int
-
-    with pytest.raises(ResponseParsingError):
-        prompting.parse_response(prompting.process_schema(Model), '{"a": "not an int"}')


### PR DESCRIPTION
Reverts Kaggle/kaggle-benchmarks#30

This will break our existing starter example like

```
kbench.assertions.assess_response_with_judge(...)
```

Revert it first for further investigation.