### PR TITLE
fix(model_proxy): Support nested models in response_format

### DIFF
--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -88,6 +88,7 @@ print(outer_t)
 import base64
 import dataclasses
 import enum
+import json
 import mimetypes
 import typing
 from typing import Any, Iterator, TypeVar
@@ -320,7 +321,22 @@ class OpenAI(LLMChat):
         self, messages: list[dict[str, str]], **kwargs
     ) -> LLMResponse | Iterator[LLMResponse]:
         if self.support_structured_outputs and "response_format" in kwargs:
-            method = self.client.beta.chat.completions.parse
+            # quickfix for nested models in ModelProxy API
+            if utils.has_nested_models(kwargs["response_format"]):
+                method = self.client.chat.completions.create
+                response_format = kwargs.pop("response_format")
+                json_schema = json.dumps(response_format.model_json_schema())
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": (
+                            "The output must be a valid JSON object that strictly adheres to the following JSON schema:\n"
+                            f"{json_schema}"
+                        ),
+                    }
+                )
+            else:
+                method = self.client.beta.chat.completions.parse
         else:
             if self.stream_responses:
                 kwargs["stream"] = True

--- a/src/kaggle_benchmarks/utils.py
+++ b/src/kaggle_benchmarks/utils.py
@@ -14,6 +14,7 @@
 
 import difflib
 import enum
+import inspect
 import json
 import os
 import re
@@ -22,6 +23,7 @@ from pathlib import Path
 import hishel
 import hishel.httpx
 import httpx
+import pydantic
 from openai import OpenAI, OpenAIError
 
 
@@ -104,6 +106,14 @@ def extract_code_block(
             return "\n\n".join(m.strip() for m in matches)
         return matches[0]
     return text
+
+
+def has_nested_models(model: type[pydantic.BaseModel]) -> bool:
+    """Checks if a Pydantic model's schema contains nested definitions."""
+    if not inspect.isclass(model) or not issubclass(model, pydantic.BaseModel):
+        return False
+    schema = model.model_json_schema()
+    return bool(schema.get("$defs"))
 
 
 def string_diff_as_markdown(str1: str, str2: str, sep: str = "\n") -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,6 +16,7 @@ import json
 from unittest.mock import patch
 
 import httpx
+import pydantic
 import pytest
 import respx
 
@@ -115,3 +116,31 @@ def test_client_respects_disable_config():
 
         assert isinstance(client, httpx.Client)
         assert not hasattr(client, "_controller")
+
+
+class NestedModel(pydantic.BaseModel):
+    a: int
+
+
+class MyModel(pydantic.BaseModel):
+    nested: NestedModel
+    b: str
+
+
+class SimpleModel(pydantic.BaseModel):
+    a: int
+    b: str
+
+
+@pytest.mark.parametrize(
+    "model, expected",
+    [
+        (MyModel, True),
+        (SimpleModel, False),
+        (None, False),
+        (int, False),
+        (str, False),
+    ],
+)
+def test_has_nested_models(model, expected):
+    assert utils.has_nested_models(model) is expected


### PR DESCRIPTION
Works around `parse` method limitations by detecting nested models and injecting their JSON schema into the prompt.