### PR TITLE
refactor(prompting): Improve error handling and pydantic support

### DIFF
--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -224,13 +224,13 @@ class LLMChat(actors.Actor):
 
         try:
             h.send(answer)  # must raise StopIteration by returning the parsed value
-            raise prompting.SchemaProcessingError(
+            raise prompting.SchemaError(
                 f"Generator for {schema!r} yielded multiple values, expected only one."
             )
         except prompting.ResponseParsingError as e:
             chat.append(
                 messages.Message(
-                    f"Error processing response {answer}:\n{e}",
+                    str(e),
                     sender=actors.system,
                 )
             )

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -111,10 +111,6 @@ class LLMResponse:
     meta: dict[str, Any] = dataclasses.field(default_factory=dict)
 
 
-class SchemaProcessingError(TypeError):
-    pass
-
-
 class LLMChat(actors.Actor):
     """A chat agent that interacts with a Large Language Model (LLM)."""
 
@@ -228,10 +224,10 @@ class LLMChat(actors.Actor):
 
         try:
             h.send(answer)  # must raise StopIteration by returning the parsed value
-            raise SchemaProcessingError(
+            raise prompting.SchemaProcessingError(
                 f"Generator for {schema!r} yielded multiple values, expected only one."
             )
-        except ValueError as e:
+        except prompting.ResponseParsingError as e:
             chat.append(
                 messages.Message(
                     f"Error processing response {answer}:\n{e}",

--- a/src/kaggle_benchmarks/assertions.py
+++ b/src/kaggle_benchmarks/assertions.py
@@ -17,7 +17,6 @@
 import dataclasses
 import functools
 import inspect
-import json
 import re
 import textwrap
 import uuid
@@ -25,7 +24,6 @@ from typing import Any, Callable, Iterable, Type
 
 import panel as pn
 import pydantic
-from pydantic import TypeAdapter
 
 from kaggle_benchmarks import chats
 
@@ -433,41 +431,18 @@ class AssessResult(pydantic.BaseModel):
 
 
 class AssessReport(pydantic.BaseModel):
-    """Represents the complete assessment report from a judge LLM.
+    """Represents the complete assessment report from a judge LLM."""
 
-    This dataclass is the default `output_schema` for the
-    `assess_response_with_judge` function. It holds a list of `AssessResult`
-    objects, each corresponding to one of the evaluation criteria.
+    # This class is the default `output_schema` for the
+    # `assess_response_with_judge` function. It holds a list of `AssessResult`
+    # objects, each corresponding to one of the evaluation criteria.
 
-    This class serves as an example for users who may want to
-    define their own report structure. When providing a custom `output_schema`
-    to `assess_response_with_judge`, it must contain a `results` field that
-    holds a list of the individual assessment outcomes.
-    """
+    # This class serves as an example for users who may want to
+    # define their own report structure. When providing a custom `output_schema`
+    # to `assess_response_with_judge`, it must contain a `results` field that
+    # holds a list of the individual assessment outcomes.
 
     results: list[AssessResult]
-
-    def __post_init__(self):
-        """
-        Automatically converts dictionary items to
-        AssessResult objects if the LLM library returns raw dicts.
-        """
-        cleaned_results = []
-        for item in self.results:
-            if isinstance(item, dict):
-                cleaned_results.append(AssessResult(**item))
-            elif isinstance(item, AssessResult):
-                cleaned_results.append(item)
-            else:
-                continue
-        self.results = cleaned_results
-
-
-def generate_schema_description(schema_cls: Type[Any]) -> str:
-    """Generates a pretty-printed JSON schema string from a class."""
-    adapter = TypeAdapter(schema_cls)
-    schema = adapter.json_schema()
-    return json.dumps(schema, indent=2)
 
 
 def assess_response_with_judge(
@@ -496,7 +471,6 @@ def assess_response_with_judge(
 
     if prompt_fn is None:
         formatted_criteria = "\n".join(f"{i + 1}. {c}" for i, c in enumerate(criteria))
-        # schema_desc = generate_schema_description(output_schema)
 
         prompt_text = textwrap.dedent(f"""
         You are an impartial and strict technical evaluator.
@@ -515,7 +489,6 @@ def assess_response_with_judge(
         1. Analyze the response against the criteria.
         2. Be strict. If the text is ambiguous, the check fails.
         3. Output your assessment using the specific structure requested below.
-
         """)
     else:
         prompt_text = prompt_fn(criteria, response_text)

--- a/src/kaggle_benchmarks/assertions.py
+++ b/src/kaggle_benchmarks/assertions.py
@@ -24,6 +24,7 @@ import uuid
 from typing import Any, Callable, Iterable, Type
 
 import panel as pn
+import pydantic
 from pydantic import TypeAdapter
 
 from kaggle_benchmarks import chats
@@ -422,8 +423,7 @@ def assert_raises_no_exceptions(
 # --- Assessment with a Judge LLM ---
 
 
-@dataclasses.dataclass
-class AssessResult:
+class AssessResult(pydantic.BaseModel):
     """Represents the outcome of a single criterion's evaluation by a judge LLM."""
 
     criterion: str
@@ -432,8 +432,7 @@ class AssessResult:
     confidence: int
 
 
-@dataclasses.dataclass
-class AssessReport:
+class AssessReport(pydantic.BaseModel):
     """Represents the complete assessment report from a judge LLM.
 
     This dataclass is the default `output_schema` for the
@@ -497,7 +496,7 @@ def assess_response_with_judge(
 
     if prompt_fn is None:
         formatted_criteria = "\n".join(f"{i + 1}. {c}" for i, c in enumerate(criteria))
-        schema_desc = generate_schema_description(output_schema)
+        # schema_desc = generate_schema_description(output_schema)
 
         prompt_text = textwrap.dedent(f"""
         You are an impartial and strict technical evaluator.
@@ -517,11 +516,6 @@ def assess_response_with_judge(
         2. Be strict. If the text is ambiguous, the check fails.
         3. Output your assessment using the specific structure requested below.
 
-        ### Output Schema Requirements
-        You must return a JSON object containing the following fields:
-        {schema_desc}
-
-        *Ensure your JSON output strictly adheres to these types.*
         """)
     else:
         prompt_text = prompt_fn(criteria, response_text)

--- a/src/kaggle_benchmarks/kaggle/model_proxy.py
+++ b/src/kaggle_benchmarks/kaggle/model_proxy.py
@@ -35,6 +35,7 @@ class ModelProxy:
         resolved_api_key = api_key or os.getenv("MODEL_PROXY_API_KEY")
         resolved_base_url = base_url or os.getenv("MODEL_PROXY_URL")
         llm_instance = None
+        kwargs.setdefault("support_structured_outputs", "gemini" in model)
 
         if api == "genai":
             if not resolved_base_url:
@@ -57,8 +58,6 @@ class ModelProxy:
                 base_url=resolved_base_url,
                 http_client=utils.build_httpx_client("model_proxy"),
             )
-
-            kwargs.setdefault("support_structured_outputs", "meta" not in model)
             # TODO (b/439876083): Disable temperature parameter till this is resolved.
             kwargs.setdefault("support_temperature", False)
             llm_instance = OpenAI(client, model, **kwargs)

--- a/src/kaggle_benchmarks/kaggle/model_proxy.py
+++ b/src/kaggle_benchmarks/kaggle/model_proxy.py
@@ -35,7 +35,11 @@ class ModelProxy:
         resolved_api_key = api_key or os.getenv("MODEL_PROXY_API_KEY")
         resolved_base_url = base_url or os.getenv("MODEL_PROXY_URL")
         llm_instance = None
-        kwargs.setdefault("support_structured_outputs", "gemini" in model)
+        # Qwen and DeepSeek models support response_format, but the schema must be under 64 characters.
+        kwargs.setdefault(
+            "support_structured_outputs",
+            "meta" not in model and "qwen" not in model and "deepseek" not in model,
+        )
 
         if api == "genai":
             if not resolved_base_url:
@@ -58,6 +62,7 @@ class ModelProxy:
                 base_url=resolved_base_url,
                 http_client=utils.build_httpx_client("model_proxy"),
             )
+
             # TODO (b/439876083): Disable temperature parameter till this is resolved.
             kwargs.setdefault("support_temperature", False)
             llm_instance = OpenAI(client, model, **kwargs)

--- a/src/kaggle_benchmarks/prompting.py
+++ b/src/kaggle_benchmarks/prompting.py
@@ -32,7 +32,7 @@ import dataclasses
 import datetime
 import inspect
 import json
-from typing import Generator, TypeVar, overload
+from typing import Generator, Generic, TypeVar, overload
 
 import pydantic
 
@@ -40,6 +40,49 @@ from kaggle_benchmarks import utils
 
 handlers = []
 T = TypeVar("T")
+
+
+class RenderablePydanticModel(pydantic.BaseModel):
+    """Base pydantic model that renderable in markdown."""
+
+    def _repr_markdown_(self):
+        return "\n".join(
+            f"## {key.title().replace('_', '')}\n{value}"
+            for key, value in self.model_dump().items()
+        )
+
+
+class TypedResponse(RenderablePydanticModel, Generic[T]):
+    """
+        A generic container for wrapping a typed value.
+
+        This is particularly useful for APIs that require a JSON object as the
+        root of a response schema. It allows for defining a response format
+    for
+        primitive or generic types on the fly.
+
+        For example:
+        - `TypedResponse[int]` will expect a JSON object like `{"value": 123}`.
+        - `TypedResponse[list[int]]` will expect `{"value": [1, 2, 3]}`.
+        - `TypedResponse[tuple[int, str]]` will expect `{"value": [1, "hello"]}`.
+    """
+
+    value: T
+
+
+class ResponseParsingError(ValueError):
+    def __init__(self, value=None, message=None, schema=None, *args: object) -> None:
+        self.value = value
+        self.message = message
+        self.schema = schema
+        super().__init__(*args)
+
+    def __str__(self) -> str:
+        return f"ResponseParsingError(value={self.value}, message={self.message}, schema={self.schema})"
+
+
+class SchemaProcessingError(TypeError):
+    pass
 
 
 def parse_response(handler: Generator[str | tuple[str, T], str, T], value: str) -> T:
@@ -70,79 +113,13 @@ def handler(criterion=None, types=None):
     return decorator
 
 
-@handler(types=str)
-def string(_):
-    value = yield None
-    return value
-
-
-@handler(types=float)
-def float_handler(_):
-    value = yield "Provide a float."
-    try:
-        return float(utils.extract_code_block(value))
-    except ValueError:
-        raise ValueError("Invalid float provided.")
-
-
-@handler(types=int)
-def integer(_):
-    value = yield "Provide an integer."
-    try:
-        return int(utils.extract_code_block(value))
-    except ValueError:
-        raise ValueError("Invalid integer provided.")
-
-
-@handler(types=datetime.datetime)
-def datetime_handler(_):
-    value = yield "Provide a datetime in ISO 8601 format (e.g., 2024-10-27T10:00:00Z)."
-    try:
-        return datetime.datetime.fromisoformat(
-            utils.extract_code_block(value).replace("Z", "+00:00")
-        )
-    except ValueError:
-        raise ValueError("Invalid datetime format.")
-
-
-@handler(types=bool)
-def boolean(_):
-    value = yield "Start your answer with `True.` or `False.`."
-    value = value.lower()
-    assert ("true" in value) + ("false" in value) == 1, (
-        f"Boolean value of {value} is unclear."
-    )
-    return "true" in value.lower()
-
-
-@handler(criterion=dataclasses.is_dataclass)
-def dataclass(cls):
-    fields = "\n".join(
-        f"{field.name}: {field.type.__name__}" for field in dataclasses.fields(cls)
-    )
-
-    value = yield f"Write a JSON with the following keys: {fields}"
-    value = utils.extract_code_block(value, name="json", greedy=False)
-    try:
-        return cls(**json.loads(value))
-    except json.JSONDecodeError:
-        raise AssertionError(f"Invalid JSON `{value}`")
-
-
 @handler(criterion=lambda x: isinstance(x, dict))
 def typed_dict(attrs: dict[str, type]):
-    class BaseModel(pydantic.BaseModel):
-        def _repr_markdown_(self):
-            return "\n".join(
-                f"## {key.title().replace('_', '')}\n{value}"
-                for key, value in self.model_dump().items()
-            )
-
     return pyndantic_like(
         pydantic.create_model(
             "Response",
             **{key: (value, ...) for key, value in attrs.items()},
-            __base__=BaseModel,
+            __base__=RenderablePydanticModel,
         )
     )
 
@@ -154,7 +131,54 @@ def pyndantic_like(model: pydantic.BaseModel):
         model,
     )
 
-    return model.model_validate_json(utils.extract_code_block(response, name="json"))
+    try:
+        return model.model_validate_json(
+            utils.extract_code_block(response, name="json")
+        )
+    except pydantic.ValidationError as e:
+        raise ResponseParsingError(response, str(e), model) from e
+
+
+@handler(criterion=dataclasses.is_dataclass)
+def root_model_handler(cls):
+    schema = pydantic.TypeAdapter(cls).json_schema()
+    model_cls = pydantic.create_model(
+        cls.__name__,
+        __base__=(RenderablePydanticModel, cls),
+        **{field.name: (field.type, ...) for field in dataclasses.fields(cls)},
+    )
+
+    response = yield (
+        f"Output JSON using this schema: {json.dumps(schema)}",
+        model_cls,
+    )
+
+    try:
+        value = json.loads(utils.extract_code_block(response, name="json"))
+        return cls(**value)
+    except (json.JSONDecodeError, pydantic.ValidationError) as e:
+        raise ResponseParsingError(response, str(e), model_cls) from e
+
+
+@handler(types=(float, int, datetime.datetime, bool))
+def primitive_type_handler(cls):
+    model = TypedResponse[cls]
+    response = yield (
+        f"Output JSON using this schema: {json.dumps(model.model_json_schema())}",
+        model,
+    )
+    try:
+        return model.model_validate_json(
+            utils.extract_code_block(response, name="json")
+        ).value
+    except pydantic.ValidationError as e:
+        raise ResponseParsingError(response, str(e), model) from e
+
+
+@handler(types=str)
+def string(_):
+    value = yield None
+    return value
 
 
 @overload

--- a/src/kaggle_benchmarks/prompting.py
+++ b/src/kaggle_benchmarks/prompting.py
@@ -51,38 +51,46 @@ class RenderablePydanticModel(pydantic.BaseModel):
             for key, value in self.model_dump().items()
         )
 
+    def get_payload(self):
+        return self.model_dump_json()
+
 
 class TypedResponse(RenderablePydanticModel, Generic[T]):
-    """
-        A generic container for wrapping a typed value.
-
-        This is particularly useful for APIs that require a JSON object as the
-        root of a response schema. It allows for defining a response format
-    for
-        primitive or generic types on the fly.
-
-        For example:
-        - `TypedResponse[int]` will expect a JSON object like `{"value": 123}`.
-        - `TypedResponse[list[int]]` will expect `{"value": [1, 2, 3]}`.
-        - `TypedResponse[tuple[int, str]]` will expect `{"value": [1, "hello"]}`.
+    """A generic shortcut for wrapping a typed response.
+    For example:
+    - `TypedResponse[int]` will expect a JSON object like `{"value": 123}`.
+    - `TypedResponse[list[int]]` will expect `{"value": [1, 2, 3]}`.
+    - `TypedResponse[tuple[int, str]]` will expect `{"value": [1, "hello"]}`.
     """
 
     value: T
 
 
 class ResponseParsingError(ValueError):
-    def __init__(self, value=None, message=None, schema=None, *args: object) -> None:
+    """Error raised when a model response cannot be parsed into the desired schema."""
+
+    def __init__(self, *args: object, value, error, schema) -> None:
         self.value = value
-        self.message = message
+        self.error = error
         self.schema = schema
-        super().__init__(*args)
+        super().__init__("Failed to parse model response.", *args)
 
     def __str__(self) -> str:
-        return f"ResponseParsingError(value={self.value}, message={self.message}, schema={self.schema})"
+        if issubclass(self.schema, pydantic.BaseModel):
+            schema_str = json.dumps(self.schema.model_json_schema(), indent=2)
+        else:
+            schema_str = str(self.schema)
+
+        return (
+            f"Response parsing failed.\n"
+            f"Input Value:\n---\n{self.value}\n---\n"
+            f"Target Schema:\n---\n{schema_str}\n---\n"
+            f"Parsing Error:\n---\n{self.error}\n---"
+        )
 
 
-class SchemaProcessingError(TypeError):
-    pass
+class SchemaError(TypeError):
+    """Covers errors related to wrong schema or handler."""
 
 
 def parse_response(handler: Generator[str | tuple[str, T], str, T], value: str) -> T:
@@ -136,7 +144,9 @@ def pyndantic_like(model: pydantic.BaseModel):
             utils.extract_code_block(response, name="json")
         )
     except pydantic.ValidationError as e:
-        raise ResponseParsingError(response, str(e), model) from e
+        raise ResponseParsingError(
+            value=response, error=e.errors(), schema=model
+        ) from e
 
 
 @handler(criterion=dataclasses.is_dataclass)
@@ -156,8 +166,15 @@ def root_model_handler(cls):
     try:
         value = json.loads(utils.extract_code_block(response, name="json"))
         return cls(**value)
-    except (json.JSONDecodeError, pydantic.ValidationError) as e:
-        raise ResponseParsingError(response, str(e), model_cls) from e
+    except json.JSONDecodeError as e:
+        raise ResponseParsingError(
+            value=response, error=f"Invalid JSON {e}", schema=model_cls
+        ) from e
+
+    except pydantic.ValidationError as e:
+        raise ResponseParsingError(
+            value=response, error=e.errors(), schema=model_cls
+        ) from e
 
 
 @handler(types=(float, int, datetime.datetime, bool))
@@ -172,7 +189,9 @@ def primitive_type_handler(cls):
             utils.extract_code_block(response, name="json")
         ).value
     except pydantic.ValidationError as e:
-        raise ResponseParsingError(response, str(e), model) from e
+        raise ResponseParsingError(
+            value=response, error=e.errors(), schema=model
+        ) from e
 
 
 @handler(types=str)

--- a/src/kaggle_benchmarks/prompting.py
+++ b/src/kaggle_benchmarks/prompting.py
@@ -55,14 +55,12 @@ class RenderablePydanticModel(pydantic.BaseModel):
         return self.model_dump_json()
 
 
+# A generic shortcut for wrapping a typed response.
+# For example:
+# - `TypedResponse[int]` will expect a JSON object like `{"value": 123}`.
+# - `TypedResponse[list[int]]` will expect `{"value": [1, 2, 3]}`.
+# - `TypedResponse[tuple[int, str]]` will expect `{"value": [1, "hello"]}`.
 class TypedResponse(RenderablePydanticModel, Generic[T]):
-    """A generic shortcut for wrapping a typed response.
-    For example:
-    - `TypedResponse[int]` will expect a JSON object like `{"value": 123}`.
-    - `TypedResponse[list[int]]` will expect `{"value": [1, 2, 3]}`.
-    - `TypedResponse[tuple[int, str]]` will expect `{"value": [1, "hello"]}`.
-    """
-
     value: T
 
 

--- a/tests/test_llm_chats.py
+++ b/tests/test_llm_chats.py
@@ -112,13 +112,17 @@ def test_structured():
 
     @handler(types=F)
     def _(cls):
-        yield ""
-        raise prompting.ResponseParsingError("Bad response")
+        value = yield ""
+        raise prompting.ResponseParsingError(
+            error="Bad response", schema=cls, value=value
+        )
 
     with chats.new() as t:
         with pytest.raises(prompting.ResponseParsingError):
-            llm.prompt("Test", schema=F)
+            llm.prompt("test_value", schema=F)
         assert "Bad response" in t.messages[-1].text
+        assert "test_value" in t.messages[-1].text
+        assert "F" in t.messages[-1].text
 
     @handler(types=F)
     def _(cls):
@@ -126,7 +130,7 @@ def test_structured():
         yield "nonesense"
         return F()
 
-    with pytest.raises(prompting.SchemaProcessingError):
+    with pytest.raises(prompting.SchemaError):
         llm.prompt("Test", schema=F)
 
 

--- a/tests/test_llm_chats.py
+++ b/tests/test_llm_chats.py
@@ -16,8 +16,8 @@ import json
 
 import pytest
 
-from kaggle_benchmarks import actors, chats, utils
-from kaggle_benchmarks.actors.llms import LLMResponse, SchemaProcessingError
+from kaggle_benchmarks import actors, chats, prompting, utils
+from kaggle_benchmarks.actors.llms import LLMResponse
 from kaggle_benchmarks.prompting import handler
 
 
@@ -113,10 +113,10 @@ def test_structured():
     @handler(types=F)
     def _(cls):
         yield ""
-        raise ValueError("Bad response")
+        raise prompting.ResponseParsingError("Bad response")
 
     with chats.new() as t:
-        with pytest.raises(ValueError):
+        with pytest.raises(prompting.ResponseParsingError):
             llm.prompt("Test", schema=F)
         assert "Bad response" in t.messages[-1].text
 
@@ -126,7 +126,7 @@ def test_structured():
         yield "nonesense"
         return F()
 
-    with pytest.raises(SchemaProcessingError):
+    with pytest.raises(prompting.SchemaProcessingError):
         llm.prompt("Test", schema=F)
 
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -35,11 +35,12 @@ class Parrot(actors.LLMChat):
 def test_raw_payload():
     p = Parrot()
     with chats.new() as chat:
-        m = p.prompt("1e-2", schema=float)
+        raw_response = '{"value": 0.01}'
+        m = p.prompt(raw_response, schema=float)
         assert m == 0.01
-        assert chat.messages[-1].payload == "1e-2"
+        assert chat.messages[-1].payload == raw_response
 
-    r = p.prompt("TRUE", schema=bool)
+    r = p.prompt('{"value": true}', schema=bool)
     assert r
 
 

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -116,3 +116,51 @@ def test_nested_pydantic():
     expected_output = Outer(a="hello", b=Inner(c=123))
     output = prompting.parse_response(prompting.process_schema(Outer), json_input)
     assert output == expected_output
+
+
+def test_pydantic_validation_error_str():
+    """Tests that the string representation of ResponseParsingError has key info."""
+
+    class Model(pydantic.BaseModel):
+        a: int
+
+    input_val = '{"a": "not an int"}'
+    with pytest.raises(ResponseParsingError) as excinfo:
+        prompting.parse_response(prompting.process_schema(Model), input_val)
+
+    error_str = str(excinfo.value)
+    pydantic_error_detail = str(excinfo.value.error)
+
+    assert "Response parsing failed" in error_str
+    assert input_val in error_str
+    assert "Target Schema" in error_str
+    assert '"title": "Model"' in error_str
+    assert "Parsing Error" in error_str
+    # Check for key info in the pydantic error, not the exact message
+    assert "a" in pydantic_error_detail
+    assert "not an int" in pydantic_error_detail
+
+
+def test_dataclass_json_decode_error_str():
+    """Tests ResponseParsingError for a dataclass with invalid JSON has key info."""
+
+    @dataclass
+    class MyData:
+        name: str
+        value: int
+
+    input_val = '{"name": "test", "value": 123,}'  # Malformed JSON with trailing comma
+    with pytest.raises(ResponseParsingError) as excinfo:
+        prompting.parse_response(prompting.process_schema(MyData), input_val)
+
+    error_str = str(excinfo.value)
+    json_error_detail = str(excinfo.value.error)
+
+    assert "Response parsing failed" in error_str
+    assert input_val in error_str
+    assert "Target Schema" in error_str
+    assert '"title": "MyData"' in error_str
+    assert "Parsing Error" in error_str
+    # Check that the error is a JSON decoding error with position info
+    assert "line 1" in json_error_detail
+    assert "column" in json_error_detail

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -13,10 +13,15 @@
 # limitations under the License.
 
 import datetime
+import json
 from dataclasses import dataclass
+
+import pydantic
+import pytest
 
 from kaggle_benchmarks import actors, chats, messages, prompting
 from kaggle_benchmarks.actors.llms import LLMResponse
+from kaggle_benchmarks.prompting import ResponseParsingError
 
 
 def test_str():
@@ -24,18 +29,27 @@ def test_str():
         assert x == prompting.parse_response(prompting.process_schema(str), x)
 
 
-def test_bool():
-    assert prompting.parse_response(prompting.process_schema(bool), "true")
-    assert not prompting.parse_response(prompting.process_schema(bool), "False")
-
-
-def test_datetime():
-    assert isinstance(
-        prompting.parse_response(
-            prompting.process_schema(datetime.datetime), "2025-01-01T10:00:00Z"
+@pytest.mark.parametrize(
+    "schema_type, input_value, expected_value",
+    [
+        pytest.param(int, 123, 123, id="int"),
+        pytest.param(float, 123.45, 123.45, id="float"),
+        pytest.param(bool, True, True, id="bool_true"),
+        pytest.param(bool, False, False, id="bool_false"),
+        pytest.param(
+            datetime.datetime,
+            "2025-01-01T10:00:00Z",
+            datetime.datetime(2025, 1, 1, 10, 0, tzinfo=datetime.timezone.utc),
+            id="datetime",
         ),
-        datetime.datetime,
+    ],
+)
+def test_primitive_types(schema_type, input_value, expected_value):
+    json_input = json.dumps({"value": input_value})
+    output_value = prompting.parse_response(
+        prompting.process_schema(schema_type), json_input
     )
+    assert output_value == expected_value
 
 
 def test_dataclass():
@@ -80,3 +94,25 @@ def test_llm():
         response = LLM().prompt(message="?", schema=A)
         assert isinstance(response, A)
         assert response == A("a", 2)
+
+
+def test_pydantic_error():
+    class Model(pydantic.BaseModel):
+        a: int
+
+    with pytest.raises(ResponseParsingError):
+        prompting.parse_response(prompting.process_schema(Model), '{"a": "not an int"}')
+
+
+def test_nested_pydantic():
+    class Inner(pydantic.BaseModel):
+        c: int
+
+    class Outer(pydantic.BaseModel):
+        a: str
+        b: Inner
+
+    json_input = '{"a": "hello", "b": {"c": 123}}'
+    expected_output = Outer(a="hello", b=Inner(c=123))
+    output = prompting.parse_response(prompting.process_schema(Outer), json_input)
+    assert output == expected_output


### PR DESCRIPTION
- All parsing handlers now raise `ResponseParsingError` on failure.
- Pydantic's `ValidationError` is re-raised as `ResponseParsingError`.
- Added tests to verify error raising.
- Updates judge assertions to use schema argument.