### PR TITLE
🔒 Fix shell injection in LocalEnvironment.run

### DIFF
--- a/src/kaggle_benchmarks/envs/local.py
+++ b/src/kaggle_benchmarks/envs/local.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import shlex
 import subprocess
 
 from kaggle_benchmarks.envs import environment, mixins
@@ -27,9 +28,12 @@ class LocalEnvironment(mixins.TemporalDirectoryMixin):
         self, command: str | list[str], input: str | None = None
     ) -> environment.RunResult:
         """Runs a shell command in the temporary directory."""
+        if isinstance(command, str):
+            command = shlex.split(command)
+
         result = subprocess.run(
             command,
-            shell=isinstance(command, str),
+            shell=False,
             input=input,
             cwd=self.temp_dir.name,
             capture_output=True,

--- a/tests/test_security_local.py
+++ b/tests/test_security_local.py
@@ -1,0 +1,58 @@
+import os
+import pytest
+from kaggle_benchmarks.envs.local import LocalEnvironment
+
+def test_shell_injection_prevention():
+    """Test that shell injection is prevented."""
+    env = LocalEnvironment()
+    try:
+        # Attempt to create a file using shell injection
+        # If shell=True, this would create 'injected.txt'
+        cmd = "echo vulnerable; touch injected.txt"
+
+        result = env.run(cmd)
+
+        # Verify the command executed (echo vulnerable) but the injection failed
+        # shlex.split("echo vulnerable; touch injected.txt") -> ['echo', 'vulnerable;', 'touch', 'injected.txt']
+        # So echo will print "vulnerable; touch injected.txt"
+
+        assert "vulnerable" in result.stdout
+        assert "injected.txt" in result.stdout
+
+        # Verify injected file does not exist
+        injected_file = os.path.join(env.temp_dir.name, "injected.txt")
+        assert not os.path.exists(injected_file), "Shell injection successful! File created."
+
+    finally:
+        env.close()
+
+def test_valid_commands_string():
+    """Test that valid commands still work when passed as string."""
+    env = LocalEnvironment()
+    try:
+        result = env.run("echo hello world")
+        assert result.exit_code == 0
+        assert result.stdout.strip() == "hello world"
+    finally:
+        env.close()
+
+def test_valid_commands_list():
+    """Test that valid commands still work when passed as list."""
+    env = LocalEnvironment()
+    try:
+        result = env.run(["echo", "hello", "world"])
+        assert result.exit_code == 0
+        assert result.stdout.strip() == "hello world"
+    finally:
+        env.close()
+
+def test_quoted_arguments():
+    """Test that quoted arguments are handled correctly by shlex."""
+    env = LocalEnvironment()
+    try:
+        # "echo 'hello world'" -> ['echo', 'hello world']
+        result = env.run("echo 'hello world'")
+        assert result.exit_code == 0
+        assert result.stdout.strip() == "hello world"
+    finally:
+        env.close()


### PR DESCRIPTION
🎯 **What:** Fixed a shell injection vulnerability in `src/kaggle_benchmarks/envs/local.py`.
⚠️ **Risk:** Previously, passing a string command with `shell=True` allowed arbitrary shell command execution if the input was user-controlled.
🛡️ **Solution:** Modified `LocalEnvironment.run` to always use `shell=False`. If the input is a string, it is now split using `shlex.split` before being passed to `subprocess.run`. This ensures arguments are treated as data, not code.
✅ **Verification:** Added `tests/test_security_local.py` which confirms that injection attempts fail and valid commands still work. Existing `local` environment tests pass.

---
*PR created automatically by Jules for task [10632411542524370869](https://jules.google.com/task/10632411542524370869) started by @yyl*