### PR TITLE
Add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kaggle Benchmarks
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Kaggle/kaggle-benchmarks)
+
 `kaggle-benchmarks` is a Python library designed to help you rigorously evaluate AI models on tasks that matter to you. It provides a structured framework for defining tasks, interacting with models, and asserting the correctness of their outputs.
 
 This is especially useful for:
@@ -80,5 +82,3 @@ Contributions are welcome! Please refer to our [Contribution Guidelines](CONTRIB
 ## License
 
 This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE) file for details.
-
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Kaggle/kaggle-benchmarks)

--- a/README.md
+++ b/README.md
@@ -80,3 +80,5 @@ Contributions are welcome! Please refer to our [Contribution Guidelines](CONTRIB
 ## License
 
 This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE) file for details.
+
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Kaggle/kaggle-benchmarks)


### PR DESCRIPTION
## Summary
- Adds a DeepWiki badge to the bottom of the README, linking to the auto-generated documentation at https://deepwiki.com/Kaggle/kaggle-benchmarks

## Context
DeepWiki provides AI-generated wiki-style documentation for the kaggle-benchmarks SDK. Adding the badge gives users easy access to always-up-to-date documentation.