### PR TITLE
fix(caching): Enable caching for POST requests

### DIFF
--- a/local_development.md
+++ b/local_development.md
@@ -43,3 +43,11 @@ Local Development is for internal team (kaggle) only. For local development, you
     - `LLMS_AVAILABLE`: A comma-separated list of models authorized for use by your proxy token.
 
     **Note**: The `LLM_DEFAULT`, `LLM_DEFAULT_EVAL`, and `LLMS_AVAILABLE` variables depend on the models authorized by your proxy token.
+
+**Caching**:
+
+To speed up development and reduce costs, the framework uses [hishel](https://hishel.com/) to cache HTTP responses. Caching is disabled by default. To enable it, set the `ENABLE_LOCAL_CACHING` environment variable to `true`:
+
+```bash
+export ENABLE_LOCAL_CACHING=true
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,17 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [project]
 name = "kaggle_benchmarks"
 dynamic=["version"]
@@ -16,7 +30,7 @@ dependencies = [
   "panel>=1.6.3",
   "playwright>=1.50.0",
   "nest-asyncio>=1.6.0",
-  "hishel[httpx]>1.0",
+  "hishel[httpx]>1.1.8",
   "pydantic>=2.11.5",
   "joblib",
   "google-genai>=1.38.0",

--- a/src/kaggle_benchmarks/_config.py
+++ b/src/kaggle_benchmarks/_config.py
@@ -47,9 +47,9 @@ class Config:
         default_factory=lambda: ExecutionMode[os.getenv("BENCHMARK_MODE", "NOTEBOOK")]
     )
 
-    disable_caching: bool = dataclasses.field(
+    enable_caching: bool = dataclasses.field(
         default_factory=lambda: string_to_bool(
-            os.environ.get("DISABLE_LOCAL_CACHE", "True")
+            os.environ.get("ENABLE_LOCAL_CACHING", "False")
         )
     )
 

--- a/src/kaggle_benchmarks/utils.py
+++ b/src/kaggle_benchmarks/utils.py
@@ -79,7 +79,7 @@ class _StatusFilter(hishel.BaseFilter[hishel.Response]):
 def build_httpx_client(filename: str = "cache") -> httpx.Client:
     from kaggle_benchmarks._config import config
 
-    if config.disable_caching:
+    if not config.enable_caching:
         return httpx.Client()
     policy = hishel.FilterPolicy(response_filters=[_StatusFilter([200])])
     policy.use_body_key = True

--- a/src/kaggle_benchmarks/utils.py
+++ b/src/kaggle_benchmarks/utils.py
@@ -69,12 +69,15 @@ def build_httpx_client(filename: str = "cache") -> httpx.Client:
 
     if config.disable_caching:
         return httpx.Client()
-
+    policy = hishel.FilterPolicy()
+    policy.use_body_key = True
     return hishel.httpx.SyncCacheClient(
+        policy=policy,
         transport=hishel.httpx.SyncCacheTransport(
             next_transport=UnconditionalCacheTransport(
                 cache_timeout_seconds=config.cache_timeout_seconds
             ),
+            policy=policy,
         ),
         storage=hishel.SyncSqliteStorage(
             database_path=config.cache_directory / f"{filename}.sqlite",

--- a/src/kaggle_benchmarks/utils.py
+++ b/src/kaggle_benchmarks/utils.py
@@ -64,12 +64,24 @@ class UnconditionalCacheTransport(httpx.HTTPTransport):
         return response
 
 
+class _StatusFilter(hishel.BaseFilter[hishel.Response]):
+    def __init__(self, allowed_codes: list[int]):
+        self.allowed_codes = allowed_codes
+
+    def needs_body(self) -> bool:
+        return False
+
+    def apply(self, item: hishel.Response, body: bytes | None) -> bool:
+        # Only cache successful responses
+        return item.status_code in self.allowed_codes
+
+
 def build_httpx_client(filename: str = "cache") -> httpx.Client:
     from kaggle_benchmarks._config import config
 
     if config.disable_caching:
         return httpx.Client()
-    policy = hishel.FilterPolicy()
+    policy = hishel.FilterPolicy(response_filters=[_StatusFilter([200])])
     policy.use_body_key = True
     return hishel.httpx.SyncCacheClient(
         policy=policy,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import uuid
 from unittest.mock import patch
 
 import httpx
@@ -90,21 +91,24 @@ def test_normalize_name(name, expected):
 
 
 @respx.mock
-def test_client_caches_despite_server_headers(tmp_path):
+@pytest.mark.parametrize("method", ["get", "post"])
+def test_client_caches_despite_server_headers(tmp_path, method):
     with (
         patch("kaggle_benchmarks.config.cache_directory", tmp_path),
         patch("kaggle_benchmarks.config.disable_caching", False),
     ):
-        url = "https://test.com/api"
+        url = f"https://test.com/{uuid.uuid4()}"
         client = utils.build_httpx_client(filename="test")
-        route = respx.get(url).mock(return_value=httpx.Response(200))
+        route = respx.request(method, url).mock(
+            return_value=httpx.Response(200, content="")
+        )
 
-        resp1 = client.get(url, headers={"Cache-Control": "no-cache"})
+        resp1 = client.request(method, url, headers={"Cache-Control": "no-cache"})
         assert resp1.status_code == 200
         assert route.called
         assert not resp1.extensions.get("hishel_from_cache")
 
-        resp2 = client.get(url)
+        resp2 = client.request(method, url)
         assert resp2.status_code == 200
         assert route.call_count == 1
         assert resp2.extensions.get("hishel_from_cache") is True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -95,7 +95,7 @@ def test_normalize_name(name, expected):
 def test_client_caches_despite_server_headers(tmp_path, method):
     with (
         patch("kaggle_benchmarks.config.cache_directory", tmp_path),
-        patch("kaggle_benchmarks.config.disable_caching", False),
+        patch("kaggle_benchmarks.config.enable_caching", True),
     ):
         url = f"https://test.com/{uuid.uuid4()}"
         client = utils.build_httpx_client(filename="test")
@@ -115,18 +115,19 @@ def test_client_caches_despite_server_headers(tmp_path, method):
 
 
 def test_client_respects_disable_config():
-    with patch("kaggle_benchmarks.config.disable_caching", True):
+    with patch("kaggle_benchmarks.config.enable_caching", False):
         client = utils.build_httpx_client()
 
         assert isinstance(client, httpx.Client)
         assert not hasattr(client, "_controller")
+
 
 @respx.mock
 @pytest.mark.parametrize("method", ["get", "post"])
 def test_client_does_not_cache_error_responses(tmp_path, method):
     with (
         patch("kaggle_benchmarks.config.cache_directory", tmp_path),
-        patch("kaggle_benchmarks.config.disable_caching", False),
+        patch("kaggle_benchmarks.config.enable_caching", True),
     ):
         url = f"https://test.com/{uuid.uuid4()}"
         client = utils.build_httpx_client(filename="test")
@@ -141,6 +142,7 @@ def test_client_does_not_cache_error_responses(tmp_path, method):
         assert resp2.status_code == 400
         assert route.call_count == 2
         assert not resp2.extensions.get("hishel_from_cache")
+
 
 class NestedModel(pydantic.BaseModel):
     a: int

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -121,6 +121,26 @@ def test_client_respects_disable_config():
         assert isinstance(client, httpx.Client)
         assert not hasattr(client, "_controller")
 
+@respx.mock
+@pytest.mark.parametrize("method", ["get", "post"])
+def test_client_does_not_cache_error_responses(tmp_path, method):
+    with (
+        patch("kaggle_benchmarks.config.cache_directory", tmp_path),
+        patch("kaggle_benchmarks.config.disable_caching", False),
+    ):
+        url = f"https://test.com/{uuid.uuid4()}"
+        client = utils.build_httpx_client(filename="test")
+        route = respx.request(method, url).mock(return_value=httpx.Response(400))
+
+        resp1 = client.request(method, url)
+        assert resp1.status_code == 400
+        assert route.called
+        assert not resp1.extensions.get("hishel_from_cache")
+
+        resp2 = client.request(method, url)
+        assert resp2.status_code == 400
+        assert route.call_count == 2
+        assert not resp2.extensions.get("hishel_from_cache")
 
 class NestedModel(pydantic.BaseModel):
     a: int

--- a/uv.lock
+++ b/uv.lock
@@ -21,13 +21,13 @@ name = "aiohttp"
 version = "3.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohappyeyeballs", marker = "python_full_version >= '3.12'" },
-    { name = "aiosignal", marker = "python_full_version >= '3.12'" },
-    { name = "attrs", marker = "python_full_version >= '3.12'" },
-    { name = "frozenlist", marker = "python_full_version >= '3.12'" },
-    { name = "multidict", marker = "python_full_version >= '3.12'" },
-    { name = "propcache", marker = "python_full_version >= '3.12'" },
-    { name = "yarl", marker = "python_full_version >= '3.12'" },
+    { name = "aiohappyeyeballs", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "aiosignal", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "attrs", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "frozenlist", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "multidict", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "propcache", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "yarl", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/ce/3b83ebba6b3207a7135e5fcaba49706f8a4b6008153b4e30540c982fae26/aiohttp-3.13.2.tar.gz", hash = "sha256:40176a52c186aefef6eb3cad2cdd30cd06e3afbe88fe8ab2af9c0b90f228daca", size = 7837994, upload-time = "2025-10-28T20:59:39.937Z" }
 wheels = [
@@ -123,7 +123,7 @@ name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "frozenlist", marker = "python_full_version >= '3.12'" },
+    { name = "frozenlist", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
     { name = "typing-extensions", marker = "python_full_version == '3.12.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
@@ -1104,15 +1104,15 @@ wheels = [
 
 [[package]]
 name = "hishel"
-version = "1.1.7"
+version = "1.1.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "msgpack" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/cf/4e1d09cc81c48ff7498398fd82c87fb21800c85e631d03831703d8594506/hishel-1.1.7.tar.gz", hash = "sha256:32c625be581e94dc50b773a8cfb9a65cba487660561950fe976ae49945455179", size = 61473, upload-time = "2025-12-03T09:32:28.524Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/2b/11bd033664620a9b193dd41b427247f7447432f3b146b17a1358386fbdfc/hishel-1.1.9.tar.gz", hash = "sha256:47248a50e4cff4fbaa141832782d8c07b2169914916f4bd792f37449176dfa23", size = 61898, upload-time = "2026-02-05T15:13:52.884Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/2a/8134de761e4fd9d0a3b301b897b8c5ce9ccb17af7f846d66c676d8c03fd8/hishel-1.1.7-py3-none-any.whl", hash = "sha256:436c2a5a62d705528e581cbeba85b10d130c47c861906b21262a07ac02463a9f", size = 70569, upload-time = "2025-12-03T09:32:27.144Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/11/bd36aa79932c4b24373cc5243a7630659f608af825418f4e195c021f5d5e/hishel-1.1.9-py3-none-any.whl", hash = "sha256:6b6f294cb7593f170a9bf874849cc85330ff81f5e35d2ca189548498fed10806", size = 70956, upload-time = "2026-02-05T15:13:51.314Z" },
 ]
 
 [package.optional-dependencies]
@@ -1811,7 +1811,7 @@ test = [
 requires-dist = [
     { name = "docker", specifier = ">=7.1.0" },
     { name = "google-genai", specifier = ">=1.38.0" },
-    { name = "hishel", extras = ["httpx"], specifier = ">1.0" },
+    { name = "hishel", extras = ["httpx"], specifier = ">1.1.8" },
     { name = "joblib" },
     { name = "jupyter" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
@@ -4809,9 +4809,9 @@ name = "yarl"
 version = "1.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna", marker = "python_full_version >= '3.12'" },
-    { name = "multidict", marker = "python_full_version >= '3.12'" },
-    { name = "propcache", marker = "python_full_version >= '3.12'" },
+    { name = "idna", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "multidict", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "propcache", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/63/0c6ebca57330cd313f6102b16dd57ffaf3ec4c83403dcb45dbd15c6f3ea1/yarl-1.22.0.tar.gz", hash = "sha256:bebf8557577d4401ba8bd9ff33906f1376c877aa78d1fe216ad01b4d6745af71", size = 187169, upload-time = "2025-10-06T14:12:55.963Z" }
 wheels = [


### PR DESCRIPTION
The default caching policy was skipping POST requests, preventing them from being cached at all.

This change uses a policy that enables caching for POST requests and correctly uses the request body to generate unique cache keys. The test suite is updated to verify this new behavior.