### PR TITLE
Write cost metadata when available to run files

### DIFF
--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -263,9 +263,20 @@ class OpenAI(LLMChat):
         """Extracts token usage metadata from an OpenAI response object."""
         if usage is None:
             return {}
+
+        # Model Proxy augments responses to include extra cost information
+        cost = getattr(usage, "cost", None) or {}
+
         return {
             "input_tokens": usage.prompt_tokens,
             "output_tokens": usage.completion_tokens,
+            # Fields outside of the standard ChatCompletions API
+            "input_tokens_cost_nanodollars": cost.get(
+                "input_tokens_cost_nanodollars", None
+            ),
+            "output_tokens_cost_nanodollars": cost.get(
+                "output_tokens_cost_nanodollars", None
+            ),
         }
 
     def invoke(
@@ -367,9 +378,20 @@ class GoogleGenAI(LLMChat):
     def _get_usage_meta(self, usage: types.UsageMetadata | None) -> dict[str, Any]:
         if usage is None:
             return {}
+
+        # Model Proxy augments responses to include extra cost information
+        cost = getattr(usage, "cost", None) or {}
+
         return {
             "input_tokens": usage.prompt_token_count,
             "output_tokens": usage.candidates_token_count,
+            # Fields outside of the standard ChatCompletions API
+            "input_tokens_cost_nanodollars": cost.get(
+                "input_tokens_cost_nanodollars", None
+            ),
+            "output_tokens_cost_nanodollars": cost.get(
+                "output_tokens_cost_nanodollars", None
+            ),
         }
 
     def _get_raw_messages(self, messages: list[messages.Message]):

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -104,6 +104,16 @@ from kaggle_benchmarks.content_types import images
 T = TypeVar("T")
 
 
+# TODO: Figure out a more robust way to handle extra fields.
+def _extract_cost(usage: Any) -> dict[str, Any]:
+    """Extracts cost metadata from a usage object augmented by Model Proxy."""
+    cost = getattr(usage, "cost", None) or {}
+    return {
+        "input_tokens_cost_nanodollars": cost.get("input_tokens_cost_nanodollars"),
+        "output_tokens_cost_nanodollars": cost.get("output_tokens_cost_nanodollars"),
+    }
+
+
 @dataclasses.dataclass(frozen=True)
 class LLMResponse:
     content: str
@@ -263,20 +273,10 @@ class OpenAI(LLMChat):
         """Extracts token usage metadata from an OpenAI response object."""
         if usage is None:
             return {}
-
-        # Model Proxy augments responses to include extra cost information
-        cost = getattr(usage, "cost", None) or {}
-
         return {
             "input_tokens": usage.prompt_tokens,
             "output_tokens": usage.completion_tokens,
-            # Fields outside of the standard ChatCompletions API
-            "input_tokens_cost_nanodollars": cost.get(
-                "input_tokens_cost_nanodollars", None
-            ),
-            "output_tokens_cost_nanodollars": cost.get(
-                "output_tokens_cost_nanodollars", None
-            ),
+            **_extract_cost(usage),
         }
 
     def invoke(
@@ -378,20 +378,10 @@ class GoogleGenAI(LLMChat):
     def _get_usage_meta(self, usage: types.UsageMetadata | None) -> dict[str, Any]:
         if usage is None:
             return {}
-
-        # Model Proxy augments responses to include extra cost information
-        cost = getattr(usage, "cost", None) or {}
-
         return {
             "input_tokens": usage.prompt_token_count,
             "output_tokens": usage.candidates_token_count,
-            # Fields outside of the standard ChatCompletions API
-            "input_tokens_cost_nanodollars": cost.get(
-                "input_tokens_cost_nanodollars", None
-            ),
-            "output_tokens_cost_nanodollars": cost.get(
-                "output_tokens_cost_nanodollars", None
-            ),
+            **_extract_cost(usage),
         }
 
     def _get_raw_messages(self, messages: list[messages.Message]):

--- a/src/kaggle_benchmarks/kaggle/serialization.py
+++ b/src/kaggle_benchmarks/kaggle/serialization.py
@@ -358,19 +358,21 @@ def _prepare_conversations_data(
     conversation_metrics = {
         "input_tokens": 0,
         "output_tokens": 0,
-        "input_tokens_cost_nanodollars": 0,
-        "output_tokens_cost_nanodollars": 0,
+        "input_tokens_cost_nanodollars": None,
+        "output_tokens_cost_nanodollars": None,
     }
     for request in current_conversation_requests:
         if metrics := request.get("metrics"):
             conversation_metrics["input_tokens"] += metrics.get("input_tokens") or 0
             conversation_metrics["output_tokens"] += metrics.get("output_tokens") or 0
-            conversation_metrics["input_tokens_cost_nanodollars"] += (
-                metrics.get("input_tokens_cost_nanodollars") or 0
-            )
-            conversation_metrics["output_tokens_cost_nanodollars"] += (
-                metrics.get("output_tokens_cost_nanodollars") or 0
-            )
+            if (cost := metrics.get("input_tokens_cost_nanodollars")) is not None:
+                conversation_metrics["input_tokens_cost_nanodollars"] = (
+                    conversation_metrics["input_tokens_cost_nanodollars"] or 0
+                ) + cost
+            if (cost := metrics.get("output_tokens_cost_nanodollars")) is not None:
+                conversation_metrics["output_tokens_cost_nanodollars"] = (
+                    conversation_metrics["output_tokens_cost_nanodollars"] or 0
+                ) + cost
 
     current_conversation_entry = {
         "id": chat.id,

--- a/src/kaggle_benchmarks/kaggle/serialization.py
+++ b/src/kaggle_benchmarks/kaggle/serialization.py
@@ -326,6 +326,12 @@ def _prepare_conversations_data(
                     request_metrics = {
                         "input_tokens": item._meta.get("input_tokens"),
                         "output_tokens": item._meta.get("output_tokens"),
+                        "input_tokens_cost_nanodollars": item._meta.get(
+                            "input_tokens_cost_nanodollars"
+                        ),
+                        "output_tokens_cost_nanodollars": item._meta.get(
+                            "output_tokens_cost_nanodollars"
+                        ),
                     }
                     request_counter += 1
                     current_conversation_requests.append(
@@ -352,11 +358,19 @@ def _prepare_conversations_data(
     conversation_metrics = {
         "input_tokens": 0,
         "output_tokens": 0,
+        "input_tokens_cost_nanodollars": 0,
+        "output_tokens_cost_nanodollars": 0,
     }
     for request in current_conversation_requests:
         if metrics := request.get("metrics"):
             conversation_metrics["input_tokens"] += metrics.get("input_tokens") or 0
             conversation_metrics["output_tokens"] += metrics.get("output_tokens") or 0
+            conversation_metrics["input_tokens_cost_nanodollars"] += (
+                metrics.get("input_tokens_cost_nanodollars") or 0
+            )
+            conversation_metrics["output_tokens_cost_nanodollars"] += (
+                metrics.get("output_tokens_cost_nanodollars") or 0
+            )
 
     current_conversation_entry = {
         "id": chat.id,

--- a/tests/kaggle/test_serialization.py
+++ b/tests/kaggle/test_serialization.py
@@ -337,3 +337,145 @@ def test_request_metrics_include_cost_fields():
     conv_metrics = conversations[0]["metrics"]
     assert conv_metrics["input_tokens_cost_nanodollars"] == 1000
     assert conv_metrics["output_tokens_cost_nanodollars"] == 2000
+
+
+def test_conversation_metrics_cost_none_when_missing():
+    """Tests that conversation metrics keep cost as None when not provided."""
+    from kaggle_benchmarks import actors, chats, messages
+
+    chat = chats.Chat(name="test")
+    chat.append(messages.Message(sender=actors.user, content="hello"))
+
+    response = messages.Message(sender=actors.system, content="response")
+    response.sender = actors.Actor(name="assistant", role="assistant")
+    response._meta["input_tokens"] = 100
+    response._meta["output_tokens"] = 50
+    # No cost fields set
+    chat.append(response)
+
+    conversations, _ = serialization._prepare_conversations_data(chat)
+    conv_metrics = conversations[0]["metrics"]
+
+    assert conv_metrics["input_tokens"] == 100
+    assert conv_metrics["output_tokens"] == 50
+    assert conv_metrics["input_tokens_cost_nanodollars"] is None
+    assert conv_metrics["output_tokens_cost_nanodollars"] is None
+
+
+def test_int64_cost_fields_serialized_as_strings_in_json():
+    """
+    Documents that int64 fields (cost_nanodollars) are serialized as strings in JSON.
+
+    Protocol Buffers serialize int64 values as strings to avoid precision loss in
+    JavaScript (which uses 64-bit floats). This doesn't affect SDK dump/parse but
+    FE consumers reading raw JSON should be aware of this.
+    """
+    from kaggle_benchmarks import actors, chats, messages
+    from kaggle_benchmarks.kaggle import benchmark_types_pb2 as types
+
+    chat = chats.Chat(name="test")
+    chat.append(messages.Message(sender=actors.user, content="hello"))
+
+    response = messages.Message(sender=actors.system, content="response")
+    response.sender = actors.Actor(name="assistant", role="assistant")
+    response._meta["input_tokens"] = 100
+    response._meta["output_tokens"] = 50
+    response._meta["input_tokens_cost_nanodollars"] = 123456789012345
+    response._meta["output_tokens_cost_nanodollars"] = 987654321098765
+    chat.append(response)
+
+    conversations, _ = serialization._prepare_conversations_data(chat)
+
+    # Create a Conversation proto and serialize to JSON
+    conv_proto = json_format.ParseDict(
+        conversations[0], types.Conversation(), ignore_unknown_fields=True
+    )
+    json_str = json_format.MessageToJson(conv_proto)
+    raw_json = json.loads(json_str)
+
+    # Verify int64 fields are serialized as strings in the raw JSON
+    request_metrics = raw_json["requests"][0]["metrics"]
+    assert request_metrics["inputTokensCostNanodollars"] == "123456789012345"
+    assert request_metrics["outputTokensCostNanodollars"] == "987654321098765"
+    assert isinstance(request_metrics["inputTokensCostNanodollars"], str)
+    assert isinstance(request_metrics["outputTokensCostNanodollars"], str)
+
+    # Conversation-level metrics also serialized as strings
+    conv_metrics = raw_json["metrics"]
+    assert conv_metrics["inputTokensCostNanodollars"] == "123456789012345"
+    assert conv_metrics["outputTokensCostNanodollars"] == "987654321098765"
+
+
+def test_int64_cost_fields_file_roundtrip():
+    """
+    Tests that int64 cost fields survive a file write/read cycle correctly.
+
+    Writes a run.json file, reads it back as raw JSON (simulating FE read),
+    and verifies the SDK can parse it back to proto with correct values.
+    """
+    from kaggle_benchmarks.kaggle import benchmark_types_pb2 as types
+
+    # Create a BenchmarkTaskRun proto directly with large int64 cost values
+    # Values > 2^53 would lose precision if stored as JS floats
+    large_input_cost = 9007199254740993  # > 2^53
+    large_output_cost = 9007199254740994  # > 2^53
+
+    run_proto = types.BenchmarkTaskRun(
+        py_run_id="test-cost-run",
+        conversations=[
+            types.Conversation(
+                id="conv-1",
+                requests=[
+                    types.ModelRequest(
+                        id="req-1",
+                        metrics=types.ModelUsageMetrics(
+                            input_tokens=100,
+                            output_tokens=50,
+                            input_tokens_cost_nanodollars=large_input_cost,
+                            output_tokens_cost_nanodollars=large_output_cost,
+                        ),
+                    )
+                ],
+                metrics=types.ModelUsageMetrics(
+                    input_tokens=100,
+                    output_tokens=50,
+                    input_tokens_cost_nanodollars=large_input_cost,
+                    output_tokens_cost_nanodollars=large_output_cost,
+                ),
+            )
+        ],
+    )
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        filepath = Path(tmp_dir) / "test_cost.run.json"
+
+        # Write to file
+        with open(filepath, "w") as f:
+            f.write(json_format.MessageToJson(run_proto))
+
+        # Read back as raw JSON (simulating FE read)
+        with open(filepath, "r") as f:
+            raw_json = json.load(f)
+
+        # Verify int64 fields are strings in raw JSON
+        conv = raw_json["conversations"][0]
+        request_metrics = conv["requests"][0]["metrics"]
+        assert isinstance(request_metrics["inputTokensCostNanodollars"], str)
+        assert isinstance(request_metrics["outputTokensCostNanodollars"], str)
+        assert request_metrics["inputTokensCostNanodollars"] == "9007199254740993"
+        assert request_metrics["outputTokensCostNanodollars"] == "9007199254740994"
+
+        # Conversation-level metrics also strings
+        conv_metrics = conv["metrics"]
+        assert isinstance(conv_metrics["inputTokensCostNanodollars"], str)
+        assert conv_metrics["inputTokensCostNanodollars"] == "9007199254740993"
+
+        # Parse back to proto (simulating SDK read)
+        with open(filepath, "r") as f:
+            json_str = f.read()
+        parsed_proto = json_format.Parse(json_str, types.BenchmarkTaskRun())
+
+        # Verify values are correctly restored as integers in proto
+        parsed_metrics = parsed_proto.conversations[0].requests[0].metrics
+        assert parsed_metrics.input_tokens_cost_nanodollars == 9007199254740993
+        assert parsed_metrics.output_tokens_cost_nanodollars == 9007199254740994

--- a/tests/kaggle/test_serialization.py
+++ b/tests/kaggle/test_serialization.py
@@ -308,3 +308,32 @@ def test_find_subtask_names_with_non_task_run():
     """Tests that _find_subtask_names ignores .run() calls on non-Task objects."""
     names = serialization._find_subtask_names(task_with_non_task_run_call)
     assert names == ["Subtask For Test"]
+
+
+def test_request_metrics_include_cost_fields():
+    """Tests that request metrics include token cost fields from _meta."""
+    from kaggle_benchmarks import actors, chats, messages
+
+    chat = chats.Chat(name="test")
+    chat.append(messages.Message(sender=actors.user, content="hello"))
+
+    response = messages.Message(sender=actors.system, content="response")
+    response.sender = actors.Actor(name="assistant", role="assistant")
+    response._meta["input_tokens"] = 100
+    response._meta["output_tokens"] = 50
+    response._meta["input_tokens_cost_nanodollars"] = 1000
+    response._meta["output_tokens_cost_nanodollars"] = 2000
+    chat.append(response)
+
+    conversations, _ = serialization._prepare_conversations_data(chat)
+    metrics = conversations[0]["requests"][0]["metrics"]
+
+    assert metrics["input_tokens"] == 100
+    assert metrics["output_tokens"] == 50
+    assert metrics["input_tokens_cost_nanodollars"] == 1000
+    assert metrics["output_tokens_cost_nanodollars"] == 2000
+
+    # Verify conversation-level aggregation includes cost fields
+    conv_metrics = conversations[0]["metrics"]
+    assert conv_metrics["input_tokens_cost_nanodollars"] == 1000
+    assert conv_metrics["output_tokens_cost_nanodollars"] == 2000


### PR DESCRIPTION
Kaggle's Model Proxy returns cost data in augmented fields for the Genai and ChatCompletions APIs. Write these values if they exist to the run files.
