### PR TITLE
test(pyversion): Test multiple pyversion

### DIFF
--- a/cicd/build/cloudbuild_branch.yaml
+++ b/cicd/build/cloudbuild_branch.yaml
@@ -32,11 +32,20 @@ steps:
     args: ["push", "${_IMAGE_REPO_NAME}/${_IMAGE_NAME}", "--all-tags"]
     waitFor: ["build-image"]
 
-  - id: test
+  - id: test-3.11
     name: "${_IMAGE_REPO_NAME}/${_IMAGE_NAME}:${COMMIT_SHA}"
     dir: /benchmarks
     entrypoint: uv
-    args: ["run", "--group", "test", "pytest", "tests"]
+    args: ["run", "--python", "3.11", "--group", "test", "pytest", "tests"]
+    waitFor: ["push-image"]
+    env:
+      - "PLAYWRIGHT_BROWSERS_PATH=/root/.cache/ms-playwright"
+
+  - id: test-3.12
+    name: "${_IMAGE_REPO_NAME}/${_IMAGE_NAME}:${COMMIT_SHA}"
+    dir: /benchmarks
+    entrypoint: uv
+    args: ["run", "--python", "3.12", "--group", "test", "pytest", "tests"]
     waitFor: ["push-image"]
     env:
       - "PLAYWRIGHT_BROWSERS_PATH=/root/.cache/ms-playwright"


### PR DESCRIPTION
- Adds parallel pytest steps for Python 3.11 and 3.12 in branch CI to de-risk the planned migration from 3.11 to 3.12
- Uses `uv run --python <version>` to test against managed Python installations without Dockerfile changes

TESTED=[Tests of both version appear.](https://pantheon.corp.google.com/cloud-build/builds/02db74e1-d143-4b18-897e-af964fd765c6;step=2?e=13803378&project=kaggle-cicd)