### PR TITLE
fix(prompting): Structured output class invalid chars

### DIFF
--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -60,6 +60,7 @@ TEST_LLM_NAMES = {
     "anthropic/claude-sonnet-4-5@20250929",
     "deepseek-ai/deepseek-r1-0528",
     "deepseek-ai/deepseek-v3.2",
+    "zai/glm-5",
 }
 
 # Models to be used as judges for evaluation.

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -61,6 +61,7 @@ TEST_LLM_NAMES = {
     "deepseek-ai/deepseek-r1-0528",
     "deepseek-ai/deepseek-v3.2",
     "zai/glm-5",
+    "google/gemini-3.1-flash-lite-preview",
 }
 
 # Models to be used as judges for evaluation.
@@ -407,6 +408,7 @@ def test_dataset_eval(llm, df) -> tuple[float, float]:
         "deepseek-ai/deepseek-v3.2",
         "qwen/qwen3-235b-a22b-instruct-2507",
         "qwen/qwen3-next-80b-a3b-instruct",
+        "zai/glm-5",
     }
 )
 @kbench.task()
@@ -437,6 +439,7 @@ def test_image_url(llm):
         "qwen/qwen3-235b-a22b-instruct-2507",
         "qwen/qwen3-next-80b-a3b-instruct",
         "anthropic/claude-sonnet-4-5@20250929",
+        "zai/glm-5",
     }
 )
 @kbench.task()
@@ -467,6 +470,7 @@ def test_image_base64(llm):
         "deepseek-ai/deepseek-v3.2",
         "qwen/qwen3-235b-a22b-instruct-2507",
         "qwen/qwen3-next-80b-a3b-instruct",
+        "zai/glm-5",
     }
 )
 @kbench.task()
@@ -512,6 +516,7 @@ def run_simple_calculator(a: float, b: float, operator: str) -> float:
         "deepseek-ai/deepseek-r1-0528",
         "deepseek-ai/deepseek-v3.2",
         "google/gemma-3-12b",
+        "google/gemini-3.1-flash-lite-preview",
     }
 )
 @kbench.task()

--- a/src/kaggle_benchmarks/prompting.py
+++ b/src/kaggle_benchmarks/prompting.py
@@ -63,6 +63,14 @@ class RenderablePydanticModel(pydantic.BaseModel):
 class TypedResponse(RenderablePydanticModel, Generic[T]):
     value: T
 
+    model_config = pydantic.ConfigDict(
+        title="Response",
+        extra="forbid",
+        arbitrary_types_allowed=False,
+    )
+
+    __name__ = "Response"
+
 
 class ResponseParsingError(ValueError):
     """Error raised when a model response cannot be parsed into the desired schema."""
@@ -178,6 +186,7 @@ def root_model_handler(cls):
 @handler(types=(float, int, datetime.datetime, bool))
 def primitive_type_handler(cls):
     model = TypedResponse[cls]
+    model.__name__ = "Response"
     response = yield (
         f"Output JSON using this schema: {json.dumps(model.model_json_schema())}",
         model,


### PR DESCRIPTION
Fix the error when parsing primary types in LLM structured output:

```
"Expected the \'name\' field of a(n) \'json_schema\' \'response_format\' to be at most 64 characters containing a-z, A-Z, 0-9, dashes, or underscores; found: \'TypedResponse[int]\'."
```