### PR TITLE
refactor(tests): add config fixture to simplify test setup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,7 +26,7 @@
   "python.defaultInterpreterPath": ".venv/bin/python",
   "python.terminal.activateEnvironment": true,
   "python.testing.pytestArgs": [
-    "tests"
+    "."
   ],
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": false,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,14 +14,25 @@
 
 import pytest
 
-from kaggle_benchmarks import clients, config, contexts, events
+from kaggle_benchmarks import ExecutionMode, clients, config, contexts, events
 
 
 @pytest.fixture(autouse=True)
 def context(monkeypatch):
     with contexts.enter():
+        config.execution_mode = ExecutionMode.TESTING
+        config.enable_caching = True
         config.interactive_mode = False
         events.manager.listeners = []
         config.ui_handler = None
+        config.apply()
         monkeypatch.setattr("kaggle_benchmarks.client", clients.InMemoryClient())
         yield
+
+
+@pytest.fixture()
+def cfg():
+    before = config.__dict__.copy()
+    yield config
+    config.__dict__.update(before)
+    config.apply()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,6 @@ from kaggle_benchmarks import ExecutionMode, clients, config, contexts, events
 def context(monkeypatch):
     with contexts.enter():
         config.execution_mode = ExecutionMode.TESTING
-        config.enable_caching = True
         config.interactive_mode = False
         events.manager.listeners = []
         config.ui_handler = None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,6 @@
 
 import json
 import uuid
-from unittest.mock import patch
 
 import httpx
 import pydantic
@@ -92,56 +91,53 @@ def test_normalize_name(name, expected):
 
 @respx.mock
 @pytest.mark.parametrize("method", ["get", "post"])
-def test_client_caches_despite_server_headers(tmp_path, method):
-    with (
-        patch("kaggle_benchmarks.config.cache_directory", tmp_path),
-        patch("kaggle_benchmarks.config.enable_caching", True),
-    ):
-        url = f"https://test.com/{uuid.uuid4()}"
-        client = utils.build_httpx_client(filename="test")
-        route = respx.request(method, url).mock(
-            return_value=httpx.Response(200, content="")
-        )
+def test_client_caches_despite_server_headers(tmp_path, method, cfg):
+    cfg.cache_directory = tmp_path
+    cfg.enable_caching = True
+    url = f"https://test.com/{uuid.uuid4()}"
+    client = utils.build_httpx_client(filename="test")
+    route = respx.request(method, url).mock(
+        return_value=httpx.Response(200, content="")
+    )
 
-        resp1 = client.request(method, url, headers={"Cache-Control": "no-cache"})
-        assert resp1.status_code == 200
-        assert route.called
-        assert not resp1.extensions.get("hishel_from_cache")
+    resp1 = client.request(method, url, headers={"Cache-Control": "no-cache"})
+    assert resp1.status_code == 200
+    assert route.called
+    assert not resp1.extensions.get("hishel_from_cache")
 
-        resp2 = client.request(method, url)
-        assert resp2.status_code == 200
-        assert route.call_count == 1
-        assert resp2.extensions.get("hishel_from_cache") is True
+    resp2 = client.request(method, url)
+    assert resp2.status_code == 200
+    assert route.call_count == 1
+    assert resp2.extensions.get("hishel_from_cache") is True
 
 
-def test_client_respects_disable_config():
-    with patch("kaggle_benchmarks.config.enable_caching", False):
-        client = utils.build_httpx_client()
+def test_client_respects_disable_config(cfg):
+    cfg.enable_caching = False
+    client = utils.build_httpx_client()
 
-        assert isinstance(client, httpx.Client)
-        assert not hasattr(client, "_controller")
+    assert isinstance(client, httpx.Client)
+    assert not hasattr(client, "_controller")
 
 
 @respx.mock
 @pytest.mark.parametrize("method", ["get", "post"])
-def test_client_does_not_cache_error_responses(tmp_path, method):
-    with (
-        patch("kaggle_benchmarks.config.cache_directory", tmp_path),
-        patch("kaggle_benchmarks.config.enable_caching", True),
-    ):
-        url = f"https://test.com/{uuid.uuid4()}"
-        client = utils.build_httpx_client(filename="test")
-        route = respx.request(method, url).mock(return_value=httpx.Response(400))
+def test_client_does_not_cache_error_responses(tmp_path, method, cfg):
+    cfg.cache_directory = tmp_path
+    cfg.enable_caching = True
 
-        resp1 = client.request(method, url)
-        assert resp1.status_code == 400
-        assert route.called
-        assert not resp1.extensions.get("hishel_from_cache")
+    url = f"https://test.com/{uuid.uuid4()}"
+    client = utils.build_httpx_client(filename="test")
+    route = respx.request(method, url).mock(return_value=httpx.Response(400))
 
-        resp2 = client.request(method, url)
-        assert resp2.status_code == 400
-        assert route.call_count == 2
-        assert not resp2.extensions.get("hishel_from_cache")
+    resp1 = client.request(method, url)
+    assert resp1.status_code == 400
+    assert route.called
+    assert not resp1.extensions.get("hishel_from_cache")
+
+    resp2 = client.request(method, url)
+    assert resp2.status_code == 400
+    assert route.call_count == 2
+    assert not resp2.extensions.get("hishel_from_cache")
 
 
 class NestedModel(pydantic.BaseModel):


### PR DESCRIPTION
Introduces a `cfg` fixture to provide a cleaner way to modify configuration settings within individual tests, replacing the more verbose ``unittest.mock.patch``.

The global `context` fixture is also updated to set more default configuration values, ensuring a more consistent and predictable state across the test suite.