### PR TITLE
Add asset sharing instructions to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -151,6 +151,32 @@ body:
     validations:
       required: false
 
+  # ── Share Your Assets ─────────────────────────────────────────
+
+  - type: markdown
+    attributes:
+      value: |
+        **Important:** To help us troubleshoot your issue, please share any associated Kaggle assets (notebooks, tasks, benchmarks, models, datasets) with **kaggle-ai-resources-support@google.com** as a **Viewer**.
+
+        To do this:
+        1. Go to your asset on Kaggle (notebook, dataset, model, etc.)
+        2. Click the **Share** button
+        3. Search for `kaggle-ai-resources-support@google.com`
+        4. Grant **Viewer** access
+        5. Paste the link(s) to the shared asset(s) in the field below
+
+  - type: textarea
+    id: shared-assets
+    attributes:
+      label: Shared Asset Links
+      description: |
+        Paste links to any Kaggle assets you've shared with kaggle-ai-resources-support@google.com.
+      placeholder: |
+        - https://www.kaggle.com/code/yourusername/your-notebook
+        - https://www.kaggle.com/datasets/yourusername/your-dataset
+    validations:
+      required: false
+
   # ── Additional Context ────────────────────────────────────────
 
   - type: textarea


### PR DESCRIPTION
## Summary
- Adds a new "Share Your Assets" section to the bug report template instructing users to share their notebooks, tasks, benchmarks, models, and datasets with `kaggle-ai-resources-support@google.com` as a Viewer
- Includes a text field for users to paste links to shared assets

## Context
The team has been getting bug reports (especially via GitHub issues) that require asking users to share their notebooks for troubleshooting. This adds the sharing step directly into the bug report flow so assets are shared upfront.

## Test plan
- [ ] Verify the template renders correctly on GitHub (preview at `New Issue > Bug Report`)