### PR TITLE
feat(kaggle-client): add kaggle-bench CLI entry point

### DIFF
--- a/golden_tests/conftest.py
+++ b/golden_tests/conftest.py
@@ -62,7 +62,6 @@ def module_report_fixture(request):
                 test_result.outcome
             )
 
-
         base_name = Path(request.module.__file__).stem
         report_filename = f"{base_name}_report.yaml"
         report_path = Path(__file__).parent / report_filename

--- a/golden_tests/test_kaggle_client.py
+++ b/golden_tests/test_kaggle_client.py
@@ -17,8 +17,7 @@ Golden tests for kaggle_client.notebook_api.BenchmarkNotebookClient.
 
 These tests exercise the real Kaggle API (authentication, push, status
 polling, fork, output download) and are excluded from CI because they
-require valid Kaggle credentials (~/.kaggle/kaggle.json) and internet
-access.
+require valid Kaggle credentials and internet access.
 
 Tests are organized to mirror the typical user journey:
 
@@ -115,7 +114,7 @@ def fork_source_notebook_id(client):
 
 
 # ===========================================================================
-# Phase 1: AUTHENTICATE
+# AUTHENTICATE
 #
 # The very first thing a user does — verify they can talk to Kaggle.
 # ===========================================================================
@@ -138,7 +137,7 @@ class TestAuth:
 
 
 # ===========================================================================
-# Phase 2: FORK AN EXISTING BENCHMARK
+# FORK AN EXISTING BENCHMARK
 #
 # Users often start by forking a public benchmark, then modifying it.
 # ===========================================================================
@@ -205,7 +204,7 @@ class TestFork:
 
 
 # ===========================================================================
-# Phase 3: PUBLISH & RUN
+# PUBLISH & RUN
 #
 # Prepare a script and push it to Kaggle for execution.
 # ===========================================================================
@@ -317,7 +316,7 @@ class TestPublish:
 
 
 # ===========================================================================
-# Phase 4: POLL & GET RESULTS
+# POLL & GET RESULTS
 #
 # After publishing, poll for completion and download outputs.
 # ===========================================================================
@@ -421,7 +420,7 @@ class TestGetResults:
 
 
 # ===========================================================================
-# Phase 5: ERROR HANDLING
+# ERROR HANDLING
 #
 # What happens when things go wrong on Kaggle.
 # ===========================================================================

--- a/golden_tests/test_kaggle_client.py
+++ b/golden_tests/test_kaggle_client.py
@@ -1,0 +1,444 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Golden tests for kaggle_client.notebook_api.BenchmarkNotebookClient.
+
+These tests exercise the real Kaggle API (authentication, push, status
+polling, fork, output download) and are excluded from CI because they
+require valid Kaggle credentials and internet access.
+
+Tests are organized to mirror the typical user journey:
+
+  1. Authenticate        →  TestAuth
+  2. Fork a benchmark    →  TestFork
+  3. Publish & run       →  TestPublish
+  4. Poll & get results  →  TestGetResults
+  5. Error handling      →  TestErrorHandling
+
+Usage:
+    uv run --group test pytest golden_tests/test_kaggle_client.py
+    uv run --group test pytest golden_tests/test_kaggle_client.py::TestAuth
+    uv run --group test pytest golden_tests/test_kaggle_client.py::TestGetResults::test_full_round_trip
+"""
+
+import json
+import threading
+import time
+import uuid
+
+import pytest
+
+from kaggle_benchmarks.kaggle_client.notebook_api import (
+    BenchmarkNotebookClient,
+    ConcurrentRunError,
+    RunResult,
+)
+
+# ---------------------------------------------------------------------------
+# Constants & Helpers
+# ---------------------------------------------------------------------------
+
+# A minimal benchmark script that runs a subtraction task twice, producing
+# two *.run.json output files for end-to-end verification.
+MINIMAL_BENCHMARK_SCRIPT = """\
+# %%
+import kaggle_benchmarks as kbench
+
+@kbench.task("subtraction")
+def test_subtraction(llm):
+    llm.stream_responses = True
+    response = llm.prompt("9.9 - 9.11 = ?")
+    kbench.assertions.assert_in("0.79", response, expectation="Expect 9.9-9.11=0.79")
+
+# %%
+# Execute the task twice to generate two run.json files
+test_subtraction.run(llm=kbench.llm)
+test_subtraction.run(llm=kbench.llm)
+"""
+
+
+def _make_client(base_dir):
+    """Create a BenchmarkNotebookClient rooted in a given directory."""
+    return BenchmarkNotebookClient(base_dir=base_dir)
+
+
+def _prepare_workspace(client, slug=None, script=MINIMAL_BENCHMARK_SCRIPT):
+    """Create a workspace with a benchmark script.  Returns (workspace, slug)."""
+    slug = slug or f"kbench-golden-{uuid.uuid4().hex[:8]}"
+    workspace = client._workspace(slug)
+    workspace.mkdir(parents=True, exist_ok=True)
+    benchmark_py = workspace / BenchmarkNotebookClient.BENCHMARK_FILENAME
+    benchmark_py.write_text(script, encoding="utf-8")
+    return workspace, slug
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def client(tmp_path_factory):
+    """Module-scoped client — shared across tests that don't need isolation."""
+    base = tmp_path_factory.mktemp("kaggle_client_golden")
+    return _make_client(base)
+
+
+@pytest.fixture
+def fresh_client(tmp_path):
+    """Function-scoped client — for tests that need a clean API state."""
+    return _make_client(tmp_path)
+
+
+@pytest.fixture(scope="module")
+def fork_source_notebook_id(client):
+    """Publish a dummy notebook that fork tests can reliably pull from."""
+    _, slug = _prepare_workspace(
+        client,
+        slug=f"kbench-golden-source-{uuid.uuid4().hex[:8]}",
+        script='print("dummy notebook for fork test")\n',
+    )
+    client.publish_and_run(slug, force=True)
+    return f"{client.username}/{slug}"
+
+
+# ===========================================================================
+# AUTHENTICATE
+#
+# The very first thing a user does — verify they can talk to Kaggle.
+# ===========================================================================
+
+
+class TestAuth:
+    """Credential validation against the real Kaggle API.
+
+    Docs: https://github.com/Kaggle/kaggle-cli/blob/main/docs/README.md#authentication
+    """
+
+    def test_client_authenticates(self, client):
+        """Creating a client should authenticate without error."""
+        assert client.api is not None
+
+    def test_username_is_populated(self, client):
+        """Client should derive a non-empty username from credentials."""
+        assert isinstance(client.username, str)
+        assert len(client.username) > 0
+
+
+# ===========================================================================
+# FORK AN EXISTING BENCHMARK
+#
+# Users often start by forking a public benchmark, then modifying it.
+# ===========================================================================
+
+
+class TestFork:
+    """Forking (pulling) an existing notebook from Kaggle."""
+
+    def test_fork_creates_workspace_with_files(self, client, fork_source_notebook_id):
+        """fork() pulls the notebook, metadata, and converts .ipynb → .py."""
+        workspace = client.fork(
+            fork_source_notebook_id,
+            dest_notebook_slug=f"kbench-golden-fork-{uuid.uuid4().hex[:8]}",
+            overwrite=True,
+        )
+
+        assert workspace.exists() and workspace.is_dir()
+
+        # Metadata should be present
+        meta_path = workspace / BenchmarkNotebookClient.METADATA_FILENAME
+        assert meta_path.exists()
+
+        # Should have a .py or .ipynb file (depending on source notebook type)
+        py_path = workspace / BenchmarkNotebookClient.BENCHMARK_FILENAME
+        ipynb_path = workspace / BenchmarkNotebookClient.NOTEBOOK_FILENAME
+        assert py_path.exists() or ipynb_path.exists(), (
+            f"Expected benchmark.py or benchmark.ipynb in {workspace}"
+        )
+
+    def test_fork_raises_on_existing_workspace(self, client, fork_source_notebook_id):
+        """fork(overwrite=False) raises FileExistsError if workspace exists."""
+        slug = f"kbench-golden-fork-{uuid.uuid4().hex[:8]}"
+        client._workspace(slug).mkdir(parents=True, exist_ok=True)
+
+        with pytest.raises(FileExistsError, match="Workspace already exists"):
+            client.fork(
+                fork_source_notebook_id, dest_notebook_slug=slug, overwrite=False
+            )
+
+    def test_fork_raises_on_missing_notebook(self, client):
+        """fork() raises ValueError for a non-existent notebook."""
+        with pytest.raises(ValueError, match="Failed to pull notebook"):
+            client.fork("kaggle/54321-tsixe-ton-seod-koobeton-siht")
+
+    def test_fork_modify_publish_lifecycle(self, client, fork_source_notebook_id):
+        """Full lifecycle: fork → modify → publish_and_run → get_results."""
+        slug = f"kbench-golden-fork-lifecycle-{uuid.uuid4().hex[:8]}"
+        workspace = client.fork(
+            fork_source_notebook_id,
+            dest_notebook_slug=slug,
+            overwrite=True,
+        )
+
+        # Modify the script
+        benchmark_py = workspace / BenchmarkNotebookClient.BENCHMARK_FILENAME
+        with open(benchmark_py, "a", encoding="utf-8") as f:
+            f.write('\n# %%\nprint("modified after fork")\n')
+
+        # Publish and wait for results
+        client.publish_and_run(slug, force=True)
+        result = client.get_results(slug, poll_interval=30, timeout=600)
+
+        assert result.status == "complete", f"Error: {result.error}"
+
+
+# ===========================================================================
+# PUBLISH & RUN
+#
+# Prepare a script and push it to Kaggle for execution.
+# ===========================================================================
+
+
+class TestPublish:
+    """Publishing benchmark scripts to Kaggle."""
+
+    def test_publish_from_workspace(self, client):
+        """Tests the default workflow where the user authors benchmark.py directly inside the workspace."""
+        workspace, slug = _prepare_workspace(client)
+
+        url = client.publish_and_run(slug, force=True)
+
+        # URL is well-formed
+        assert url.startswith("https://www.kaggle.com/")
+        assert client.username in url
+        assert slug in url
+
+        # Metadata was written with correct id and keyword
+        meta_path = workspace / BenchmarkNotebookClient.METADATA_FILENAME
+        metadata = json.loads(meta_path.read_text(encoding="utf-8"))
+        assert metadata["id"] == f"{client.username}/{slug}"
+        assert "personal-benchmark" in metadata.get("keywords", [])
+
+        # Notebook .ipynb was generated
+        assert (workspace / BenchmarkNotebookClient.NOTEBOOK_FILENAME).exists()
+
+    def test_publish_with_source_file(self, client, tmp_path):
+        """Tests the override workflow where an external script is dynamically copied into the workspace."""
+        slug = f"kbench-golden-source-file-{uuid.uuid4().hex[:8]}"
+
+        # Write a source file outside the workspace
+        source = tmp_path / "my_bench.py"
+        source.write_text('# %%\nprint("source file test")\n', encoding="utf-8")
+
+        url = client.publish_and_run(slug, source_file=source, force=True)
+        assert url is not None and slug in url
+
+        # Verify the file was copied and converted
+        workspace = client._workspace(slug)
+        bench_py = workspace / BenchmarkNotebookClient.BENCHMARK_FILENAME
+        assert bench_py.exists()
+        assert (
+            bench_py.read_text(encoding="utf-8") == '# %%\nprint("source file test")\n'
+        )
+
+        # Verify the .ipynb has the source code in a cell
+        notebook_data = json.loads(
+            (workspace / BenchmarkNotebookClient.NOTEBOOK_FILENAME).read_text(
+                encoding="utf-8"
+            )
+        )
+        source_found = any(
+            'print("source file test")' in "".join(cell.get("source", []))
+            for cell in notebook_data["cells"]
+            if cell.get("cell_type") == "code"
+        )
+        assert source_found, "Source code not found in generated notebook cells"
+
+    def test_publish_with_dataset_sources(self, client):
+        """publish_and_run(dataset_sources=...) includes them in metadata."""
+        workspace, slug = _prepare_workspace(
+            client, script='# %%\nprint("dataset test")\n'
+        )
+
+        datasets = ["kaggle/meta-kaggle", "kaggle/meta-kaggle-code"]
+        client.publish_and_run(slug, dataset_sources=datasets, force=True)
+
+        meta_path = workspace / BenchmarkNotebookClient.METADATA_FILENAME
+        metadata = json.loads(meta_path.read_text(encoding="utf-8"))
+        assert metadata["dataset_sources"] == datasets
+
+    def test_publish_raises_without_benchmark_file(self, client):
+        """publish_and_run() raises FileNotFoundError if no benchmark.py exists."""
+        slug = f"kbench-golden-no-source-{uuid.uuid4().hex[:8]}"
+
+        with pytest.raises(FileNotFoundError, match="Benchmark file not found"):
+            client.publish_and_run(slug, force=True)
+
+    def test_concurrent_guard_blocks_duplicate_push(self, fresh_client):
+        """publish_and_run(force=False) raises ConcurrentRunError if already running."""
+        from requests.exceptions import HTTPError
+
+        _, slug = _prepare_workspace(fresh_client)
+
+        # First push starts the run
+        fresh_client.publish_and_run(slug, force=True)
+
+        # Immediate second push without force should be blocked
+        # (unless Kaggle already finished the run — handle that edge case)
+        try:
+            fresh_client.publish_and_run(slug, force=False)
+        except ConcurrentRunError as e:
+            assert "already running" in str(e)
+        except HTTPError:
+            pass  # 404 race condition — guard still passed
+
+    def test_concurrent_guard_bypassed_with_force(self, fresh_client):
+        """publish_and_run(force=True) always succeeds regardless of run status."""
+        _, slug = _prepare_workspace(fresh_client)
+
+        # First push starts the run
+        fresh_client.publish_and_run(slug, force=True)
+
+        # Immediate second push with force=True should bypass the guard and succeed
+        url = fresh_client.publish_and_run(slug, force=True)
+        assert url is not None
+
+
+# ===========================================================================
+# POLL & GET RESULTS
+#
+# After publishing, poll for completion and download outputs.
+# ===========================================================================
+
+
+class TestGetResults:
+    """Polling for results and downloading output from Kaggle."""
+
+    def test_full_round_trip(self, client):
+        """Publish → poll → download → parse run.json: the complete happy path.
+
+        NOTE: This test takes several minutes while the notebook executes
+        on Kaggle.  Timeout is set to 10 minutes.
+        """
+        _, slug = _prepare_workspace(client)
+
+        client.publish_and_run(slug, force=True)
+
+        statuses_seen = []
+        result = client.get_results(
+            slug,
+            poll_interval=30,
+            timeout=600,
+            on_status=statuses_seen.append,
+        )
+
+        assert isinstance(result, RunResult)
+        assert result.tracking_url is not None
+        assert slug in result.tracking_url
+        assert result.status == "complete", (
+            f"Expected 'complete', got '{result.status}'. Error: {result.error}"
+        )
+        assert result.output_dir is not None
+        assert result.error is None
+
+        # Verify the on_status callback fired correctly
+        assert len(statuses_seen) > 0, "on_status callback was never invoked"
+        assert statuses_seen[-1] == "complete", (
+            f"Final callback was {statuses_seen[-1]}, not complete"
+        )
+
+        # Verify *.run.json files were downloaded and have expected structure
+        runs = dict(result.iter_run_results())
+        assert len(runs) >= 2, (
+            f"Expected at least 2 run files, got {len(runs)}: {list(runs.keys())}"
+        )
+        for filename, run_data in runs.items():
+            assert run_data.get("state") == "BENCHMARK_TASK_RUN_STATE_COMPLETED", (
+                f"Run '{filename}' has unexpected state: {run_data.get('state')}"
+            )
+            assert run_data.get("taskVersion", {}).get("name") == "subtraction", (
+                f"Run '{filename}' has unexpected task name"
+            )
+
+    def test_custom_output_dir(self, client, tmp_path):
+        """get_results(output_dir=...) saves output to the given path."""
+        _, slug = _prepare_workspace(client)
+        client.publish_and_run(slug, force=True)
+
+        custom_output = tmp_path / "custom_output"
+        result = client.get_results(
+            slug, output_dir=str(custom_output), poll_interval=30, timeout=600
+        )
+
+        if result.status == "timeout":
+            pytest.skip("Notebook did not complete in time.")
+
+        assert result.status == "complete", f"Failed with error: {result.error}"
+        assert result.output_dir == str(custom_output)
+        assert custom_output.exists()
+
+    def test_timeout_returns_early(self, fresh_client):
+        """get_results returns status='timeout' when the time limit is hit."""
+        _, slug = _prepare_workspace(fresh_client)
+        fresh_client.publish_and_run(slug, force=True)
+
+        result = fresh_client.get_results(slug, poll_interval=5, timeout=1)
+
+        assert isinstance(result, RunResult)
+        assert result.status == "timeout"
+
+    def test_cancel_event_returns_early(self, fresh_client):
+        """get_results respects cancel_event and returns 'cancelled'."""
+        _, slug = _prepare_workspace(fresh_client)
+
+        cancel = threading.Event()
+
+        def cancel_after_delay():
+            time.sleep(0.5)
+            cancel.set()
+
+        timer = threading.Thread(target=cancel_after_delay, daemon=True)
+        timer.start()
+
+        fresh_client.publish_and_run(slug, force=True)
+        result = fresh_client.get_results(slug, poll_interval=60, cancel_event=cancel)
+        timer.join(timeout=5)
+
+        assert isinstance(result, RunResult)
+        assert result.status == "cancelled"
+
+
+# ===========================================================================
+# ERROR HANDLING
+#
+# What happens when things go wrong on Kaggle.
+# ===========================================================================
+
+
+class TestErrorHandling:
+    """Tests for Kaggle-side execution errors."""
+
+    def test_crashing_script_returns_error(self, client):
+        """A script that raises at runtime should produce status='error'."""
+        _, slug = _prepare_workspace(
+            client, script='# %%\nraise ValueError("Deliberate crash")\n'
+        )
+
+        client.publish_and_run(slug, force=True)
+        result = client.get_results(slug, poll_interval=20, timeout=600)
+
+        assert result.status == "error"
+        assert result.error is not None
+        assert "finished with status: error" in result.error

--- a/golden_tests/test_kaggle_client.py
+++ b/golden_tests/test_kaggle_client.py
@@ -62,6 +62,7 @@ def test_subtraction(llm):
     response = llm.prompt("9.9 - 9.11 = ?")
     kbench.assertions.assert_in("0.79", response, expectation="Expect 9.9-9.11=0.79")
 
+# %%
 # Execute the task twice to generate two run.json files
 test_subtraction.run(llm=kbench.llm)
 test_subtraction.run(llm=kbench.llm)

--- a/golden_tests/test_kaggle_client.py
+++ b/golden_tests/test_kaggle_client.py
@@ -29,7 +29,7 @@ Tests are organized to mirror the typical user journey:
   5. Error handling      →  TestErrorHandling
 
 Usage:
-    uv run --group test pytest golden_tests/test_kaggle_client.py -v
+    uv run --group test pytest golden_tests/test_kaggle_client.py
     uv run --group test pytest golden_tests/test_kaggle_client.py::TestAuth
     uv run --group test pytest golden_tests/test_kaggle_client.py::TestGetResults::test_full_round_trip
 """
@@ -38,14 +38,12 @@ import json
 import threading
 import time
 import uuid
-from unittest.mock import patch
 
 import pytest
 
 from kaggle_benchmarks.kaggle_client.notebook_api import (
     BenchmarkNotebookClient,
     ConcurrentRunError,
-    KaggleAuthError,
     RunResult,
 )
 
@@ -138,19 +136,6 @@ class TestAuth:
         assert isinstance(client.username, str)
         assert len(client.username) > 0
 
-    def test_validate_and_get_username(self, client):
-        """validate_and_get_username() returns the authenticated username."""
-        username = client.validate_and_get_username()
-        assert isinstance(username, str)
-        assert len(username) > 0
-        assert username == client.username
-
-    def test_bad_credentials_raise_auth_error(self, client):
-        """validate_and_get_username() raises KaggleAuthError on bad creds."""
-        with patch.object(client.api, "get_config_value", return_value=""):
-            with pytest.raises(KaggleAuthError, match="invalid or missing"):
-                client.validate_and_get_username()
-
 
 # ===========================================================================
 # Phase 2: FORK AN EXISTING BENCHMARK
@@ -178,9 +163,9 @@ class TestFork:
 
         # Should have a .py or .ipynb file (depending on source notebook type)
         py_path = workspace / BenchmarkNotebookClient.BENCHMARK_FILENAME
-        ipynb_files = list(workspace.glob("*.ipynb"))
-        assert py_path.exists() or len(ipynb_files) > 0, (
-            f"Expected benchmark.py or .ipynb in {workspace}"
+        ipynb_path = workspace / BenchmarkNotebookClient.NOTEBOOK_FILENAME
+        assert py_path.exists() or ipynb_path.exists(), (
+            f"Expected benchmark.py or benchmark.ipynb in {workspace}"
         )
 
     def test_fork_raises_on_existing_workspace(self, client, fork_source_notebook_id):
@@ -196,7 +181,7 @@ class TestFork:
     def test_fork_raises_on_missing_notebook(self, client):
         """fork() raises ValueError for a non-existent notebook."""
         with pytest.raises(ValueError, match="Failed to pull notebook"):
-            client.fork("kaggle/this-notebook-does-not-exist-12345")
+            client.fork("kaggle/54321-tsixe-ton-seod-koobeton-siht")
 
     def test_fork_modify_publish_lifecycle(self, client, fork_source_notebook_id):
         """Full lifecycle: fork → modify → publish_and_run → get_results."""
@@ -230,7 +215,7 @@ class TestPublish:
     """Publishing benchmark scripts to Kaggle."""
 
     def test_publish_from_workspace(self, client):
-        """publish_and_run() converts .py → .ipynb, writes metadata, and pushes."""
+        """Tests the default workflow where the user authors benchmark.py directly inside the workspace."""
         workspace, slug = _prepare_workspace(client)
 
         url = client.publish_and_run(slug, force=True)
@@ -250,7 +235,7 @@ class TestPublish:
         assert (workspace / BenchmarkNotebookClient.NOTEBOOK_FILENAME).exists()
 
     def test_publish_with_source_file(self, client, tmp_path):
-        """publish_and_run(source_file=...) copies the file into the workspace."""
+        """Tests the override workflow where an external script is dynamically copied into the workspace."""
         slug = f"kbench-golden-source-file-{uuid.uuid4().hex[:8]}"
 
         # Write a source file outside the workspace
@@ -305,7 +290,6 @@ class TestPublish:
         """publish_and_run(force=False) raises ConcurrentRunError if already running."""
         from requests.exceptions import HTTPError
 
-        _prepare_workspace(fresh_client)
         _, slug = _prepare_workspace(fresh_client)
 
         # First push starts the run
@@ -324,6 +308,10 @@ class TestPublish:
         """publish_and_run(force=True) always succeeds regardless of run status."""
         _, slug = _prepare_workspace(fresh_client)
 
+        # First push starts the run
+        fresh_client.publish_and_run(slug, force=True)
+
+        # Immediate second push with force=True should bypass the guard and succeed
         url = fresh_client.publish_and_run(slug, force=True)
         assert url is not None
 
@@ -365,8 +353,14 @@ class TestGetResults:
         assert result.output_dir is not None
         assert result.error is None
 
+        # Verify the on_status callback fired correctly
+        assert len(statuses_seen) > 0, "on_status callback was never invoked"
+        assert statuses_seen[-1] == "complete", (
+            f"Final callback was {statuses_seen[-1]}, not complete"
+        )
+
         # Verify *.run.json files were downloaded and have expected structure
-        runs = dict(result.iter_runs())
+        runs = dict(result.iter_run_results())
         assert len(runs) >= 2, (
             f"Expected at least 2 run files, got {len(runs)}: {list(runs.keys())}"
         )
@@ -391,9 +385,9 @@ class TestGetResults:
         if result.status == "timeout":
             pytest.skip("Notebook did not complete in time.")
 
-        if result.status == "complete":
-            assert result.output_dir == str(custom_output)
-            assert custom_output.exists()
+        assert result.status == "complete", f"Failed with error: {result.error}"
+        assert result.output_dir == str(custom_output)
+        assert custom_output.exists()
 
     def test_timeout_returns_early(self, fresh_client):
         """get_results returns status='timeout' when the time limit is hit."""

--- a/golden_tests/test_kaggle_client.py
+++ b/golden_tests/test_kaggle_client.py
@@ -1,0 +1,450 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Golden tests for kaggle_client.notebook_api.BenchmarkNotebookClient.
+
+These tests exercise the real Kaggle API (authentication, push, status
+polling, fork, output download) and are excluded from CI because they
+require valid Kaggle credentials (~/.kaggle/kaggle.json) and internet
+access.
+
+Tests are organized to mirror the typical user journey:
+
+  1. Authenticate        →  TestAuth
+  2. Fork a benchmark    →  TestFork
+  3. Publish & run       →  TestPublish
+  4. Poll & get results  →  TestGetResults
+  5. Error handling      →  TestErrorHandling
+
+Usage:
+    uv run --group test pytest golden_tests/test_kaggle_client.py -v
+    uv run --group test pytest golden_tests/test_kaggle_client.py::TestAuth
+    uv run --group test pytest golden_tests/test_kaggle_client.py::TestGetResults::test_full_round_trip
+"""
+
+import json
+import threading
+import time
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from kaggle_benchmarks.kaggle_client.notebook_api import (
+    BenchmarkNotebookClient,
+    ConcurrentRunError,
+    KaggleAuthError,
+    RunResult,
+)
+
+# ---------------------------------------------------------------------------
+# Constants & Helpers
+# ---------------------------------------------------------------------------
+
+# A minimal benchmark script that runs a subtraction task twice, producing
+# two *.run.json output files for end-to-end verification.
+MINIMAL_BENCHMARK_SCRIPT = """\
+# %%
+import kaggle_benchmarks as kbench
+
+@kbench.task("subtraction")
+def test_subtraction(llm):
+    llm.stream_responses = True
+    response = llm.prompt("9.9 - 9.11 = ?")
+    kbench.assertions.assert_in("0.79", response, expectation="Expect 9.9-9.11=0.79")
+
+# Execute the task twice to generate two run.json files
+test_subtraction.run(llm=kbench.llm)
+test_subtraction.run(llm=kbench.llm)
+"""
+
+
+def _make_client(base_dir):
+    """Create a BenchmarkNotebookClient rooted in a given directory."""
+    return BenchmarkNotebookClient(base_dir=base_dir)
+
+
+def _prepare_workspace(client, slug=None, script=MINIMAL_BENCHMARK_SCRIPT):
+    """Create a workspace with a benchmark script.  Returns (workspace, slug)."""
+    slug = slug or f"kbench-golden-{uuid.uuid4().hex[:8]}"
+    workspace = client._workspace(slug)
+    workspace.mkdir(parents=True, exist_ok=True)
+    benchmark_py = workspace / BenchmarkNotebookClient.BENCHMARK_FILENAME
+    benchmark_py.write_text(script, encoding="utf-8")
+    return workspace, slug
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def client(tmp_path_factory):
+    """Module-scoped client — shared across tests that don't need isolation."""
+    base = tmp_path_factory.mktemp("kaggle_client_golden")
+    return _make_client(base)
+
+
+@pytest.fixture
+def fresh_client(tmp_path):
+    """Function-scoped client — for tests that need a clean API state."""
+    return _make_client(tmp_path)
+
+
+@pytest.fixture(scope="module")
+def fork_source_notebook_id(client):
+    """Publish a dummy notebook that fork tests can reliably pull from."""
+    _, slug = _prepare_workspace(
+        client,
+        slug=f"kbench-golden-source-{uuid.uuid4().hex[:8]}",
+        script='print("dummy notebook for fork test")\n',
+    )
+    client.publish_and_run(slug, force=True)
+    return f"{client.username}/{slug}"
+
+
+# ===========================================================================
+# Phase 1: AUTHENTICATE
+#
+# The very first thing a user does — verify they can talk to Kaggle.
+# ===========================================================================
+
+
+class TestAuth:
+    """Credential validation against the real Kaggle API.
+
+    Docs: https://github.com/Kaggle/kaggle-cli/blob/main/docs/README.md#authentication
+    """
+
+    def test_client_authenticates(self, client):
+        """Creating a client should authenticate without error."""
+        assert client.api is not None
+
+    def test_username_is_populated(self, client):
+        """Client should derive a non-empty username from credentials."""
+        assert isinstance(client.username, str)
+        assert len(client.username) > 0
+
+    def test_validate_and_get_username(self, client):
+        """validate_and_get_username() returns the authenticated username."""
+        username = client.validate_and_get_username()
+        assert isinstance(username, str)
+        assert len(username) > 0
+        assert username == client.username
+
+    def test_bad_credentials_raise_auth_error(self, client):
+        """validate_and_get_username() raises KaggleAuthError on bad creds."""
+        with patch.object(client.api, "get_config_value", return_value=""):
+            with pytest.raises(KaggleAuthError, match="invalid or missing"):
+                client.validate_and_get_username()
+
+
+# ===========================================================================
+# Phase 2: FORK AN EXISTING BENCHMARK
+#
+# Users often start by forking a public benchmark, then modifying it.
+# ===========================================================================
+
+
+class TestFork:
+    """Forking (pulling) an existing notebook from Kaggle."""
+
+    def test_fork_creates_workspace_with_files(self, client, fork_source_notebook_id):
+        """fork() pulls the notebook, metadata, and converts .ipynb → .py."""
+        workspace = client.fork(
+            fork_source_notebook_id,
+            dest_notebook_slug=f"kbench-golden-fork-{uuid.uuid4().hex[:8]}",
+            overwrite=True,
+        )
+
+        assert workspace.exists() and workspace.is_dir()
+
+        # Metadata should be present
+        meta_path = workspace / BenchmarkNotebookClient.METADATA_FILENAME
+        assert meta_path.exists()
+
+        # Should have a .py or .ipynb file (depending on source notebook type)
+        py_path = workspace / BenchmarkNotebookClient.BENCHMARK_FILENAME
+        ipynb_files = list(workspace.glob("*.ipynb"))
+        assert py_path.exists() or len(ipynb_files) > 0, (
+            f"Expected benchmark.py or .ipynb in {workspace}"
+        )
+
+    def test_fork_raises_on_existing_workspace(self, client, fork_source_notebook_id):
+        """fork(overwrite=False) raises FileExistsError if workspace exists."""
+        slug = f"kbench-golden-fork-{uuid.uuid4().hex[:8]}"
+        client._workspace(slug).mkdir(parents=True, exist_ok=True)
+
+        with pytest.raises(FileExistsError, match="Workspace already exists"):
+            client.fork(
+                fork_source_notebook_id, dest_notebook_slug=slug, overwrite=False
+            )
+
+    def test_fork_raises_on_missing_notebook(self, client):
+        """fork() raises ValueError for a non-existent notebook."""
+        with pytest.raises(ValueError, match="Failed to pull notebook"):
+            client.fork("kaggle/this-notebook-does-not-exist-12345")
+
+    def test_fork_modify_publish_lifecycle(self, client, fork_source_notebook_id):
+        """Full lifecycle: fork → modify → publish_and_run → get_results."""
+        slug = f"kbench-golden-fork-lifecycle-{uuid.uuid4().hex[:8]}"
+        workspace = client.fork(
+            fork_source_notebook_id,
+            dest_notebook_slug=slug,
+            overwrite=True,
+        )
+
+        # Modify the script
+        benchmark_py = workspace / BenchmarkNotebookClient.BENCHMARK_FILENAME
+        with open(benchmark_py, "a", encoding="utf-8") as f:
+            f.write('\n# %%\nprint("modified after fork")\n')
+
+        # Publish and wait for results
+        client.publish_and_run(slug, force=True)
+        result = client.get_results(slug, poll_interval=30, timeout=600)
+
+        assert result.status == "complete", f"Error: {result.error}"
+
+
+# ===========================================================================
+# Phase 3: PUBLISH & RUN
+#
+# Prepare a script and push it to Kaggle for execution.
+# ===========================================================================
+
+
+class TestPublish:
+    """Publishing benchmark scripts to Kaggle."""
+
+    def test_publish_from_workspace(self, client):
+        """publish_and_run() converts .py → .ipynb, writes metadata, and pushes."""
+        workspace, slug = _prepare_workspace(client)
+
+        url = client.publish_and_run(slug, force=True)
+
+        # URL is well-formed
+        assert url.startswith("https://www.kaggle.com/")
+        assert client.username in url
+        assert slug in url
+
+        # Metadata was written with correct id and keyword
+        meta_path = workspace / BenchmarkNotebookClient.METADATA_FILENAME
+        metadata = json.loads(meta_path.read_text(encoding="utf-8"))
+        assert metadata["id"] == f"{client.username}/{slug}"
+        assert "personal-benchmark" in metadata.get("keywords", [])
+
+        # Notebook .ipynb was generated
+        assert (workspace / BenchmarkNotebookClient.NOTEBOOK_FILENAME).exists()
+
+    def test_publish_with_source_file(self, client, tmp_path):
+        """publish_and_run(source_file=...) copies the file into the workspace."""
+        slug = f"kbench-golden-source-file-{uuid.uuid4().hex[:8]}"
+
+        # Write a source file outside the workspace
+        source = tmp_path / "my_bench.py"
+        source.write_text('# %%\nprint("source file test")\n', encoding="utf-8")
+
+        url = client.publish_and_run(slug, source_file=source, force=True)
+        assert url is not None and slug in url
+
+        # Verify the file was copied and converted
+        workspace = client._workspace(slug)
+        bench_py = workspace / BenchmarkNotebookClient.BENCHMARK_FILENAME
+        assert bench_py.exists()
+        assert (
+            bench_py.read_text(encoding="utf-8") == '# %%\nprint("source file test")\n'
+        )
+
+        # Verify the .ipynb has the source code in a cell
+        notebook_data = json.loads(
+            (workspace / BenchmarkNotebookClient.NOTEBOOK_FILENAME).read_text(
+                encoding="utf-8"
+            )
+        )
+        source_found = any(
+            'print("source file test")' in "".join(cell.get("source", []))
+            for cell in notebook_data["cells"]
+            if cell.get("cell_type") == "code"
+        )
+        assert source_found, "Source code not found in generated notebook cells"
+
+    def test_publish_with_dataset_sources(self, client):
+        """publish_and_run(dataset_sources=...) includes them in metadata."""
+        workspace, slug = _prepare_workspace(
+            client, script='# %%\nprint("dataset test")\n'
+        )
+
+        datasets = ["kaggle/meta-kaggle", "kaggle/meta-kaggle-code"]
+        client.publish_and_run(slug, dataset_sources=datasets, force=True)
+
+        meta_path = workspace / BenchmarkNotebookClient.METADATA_FILENAME
+        metadata = json.loads(meta_path.read_text(encoding="utf-8"))
+        assert metadata["dataset_sources"] == datasets
+
+    def test_publish_raises_without_benchmark_file(self, client):
+        """publish_and_run() raises FileNotFoundError if no benchmark.py exists."""
+        slug = f"kbench-golden-no-source-{uuid.uuid4().hex[:8]}"
+
+        with pytest.raises(FileNotFoundError, match="Benchmark file not found"):
+            client.publish_and_run(slug, force=True)
+
+    def test_concurrent_guard_blocks_duplicate_push(self, fresh_client):
+        """publish_and_run(force=False) raises ConcurrentRunError if already running."""
+        from requests.exceptions import HTTPError
+
+        _prepare_workspace(fresh_client)
+        _, slug = _prepare_workspace(fresh_client)
+
+        # First push starts the run
+        fresh_client.publish_and_run(slug, force=True)
+
+        # Immediate second push without force should be blocked
+        # (unless Kaggle already finished the run — handle that edge case)
+        try:
+            fresh_client.publish_and_run(slug, force=False)
+        except ConcurrentRunError as e:
+            assert "already running" in str(e)
+        except HTTPError:
+            pass  # 404 race condition — guard still passed
+
+    def test_concurrent_guard_bypassed_with_force(self, fresh_client):
+        """publish_and_run(force=True) always succeeds regardless of run status."""
+        _, slug = _prepare_workspace(fresh_client)
+
+        url = fresh_client.publish_and_run(slug, force=True)
+        assert url is not None
+
+
+# ===========================================================================
+# Phase 4: POLL & GET RESULTS
+#
+# After publishing, poll for completion and download outputs.
+# ===========================================================================
+
+
+class TestGetResults:
+    """Polling for results and downloading output from Kaggle."""
+
+    def test_full_round_trip(self, client):
+        """Publish → poll → download → parse run.json: the complete happy path.
+
+        NOTE: This test takes several minutes while the notebook executes
+        on Kaggle.  Timeout is set to 10 minutes.
+        """
+        _, slug = _prepare_workspace(client)
+
+        client.publish_and_run(slug, force=True)
+
+        statuses_seen = []
+        result = client.get_results(
+            slug,
+            poll_interval=30,
+            timeout=600,
+            on_status=statuses_seen.append,
+        )
+
+        assert isinstance(result, RunResult)
+        assert result.tracking_url is not None
+        assert slug in result.tracking_url
+        assert result.status == "complete", (
+            f"Expected 'complete', got '{result.status}'. Error: {result.error}"
+        )
+        assert result.output_dir is not None
+        assert result.error is None
+
+        # Verify *.run.json files were downloaded and have expected structure
+        runs = dict(result.iter_runs())
+        assert len(runs) >= 2, (
+            f"Expected at least 2 run files, got {len(runs)}: {list(runs.keys())}"
+        )
+        for filename, run_data in runs.items():
+            assert run_data.get("state") == "BENCHMARK_TASK_RUN_STATE_COMPLETED", (
+                f"Run '{filename}' has unexpected state: {run_data.get('state')}"
+            )
+            assert run_data.get("taskVersion", {}).get("name") == "subtraction", (
+                f"Run '{filename}' has unexpected task name"
+            )
+
+    def test_custom_output_dir(self, client, tmp_path):
+        """get_results(output_dir=...) saves output to the given path."""
+        _, slug = _prepare_workspace(client)
+        client.publish_and_run(slug, force=True)
+
+        custom_output = tmp_path / "custom_output"
+        result = client.get_results(
+            slug, output_dir=str(custom_output), poll_interval=30, timeout=600
+        )
+
+        if result.status == "timeout":
+            pytest.skip("Notebook did not complete in time.")
+
+        if result.status == "complete":
+            assert result.output_dir == str(custom_output)
+            assert custom_output.exists()
+
+    def test_timeout_returns_early(self, fresh_client):
+        """get_results returns status='timeout' when the time limit is hit."""
+        _, slug = _prepare_workspace(fresh_client)
+        fresh_client.publish_and_run(slug, force=True)
+
+        result = fresh_client.get_results(slug, poll_interval=5, timeout=1)
+
+        assert isinstance(result, RunResult)
+        assert result.status == "timeout"
+
+    def test_cancel_event_returns_early(self, fresh_client):
+        """get_results respects cancel_event and returns 'cancelled'."""
+        _, slug = _prepare_workspace(fresh_client)
+
+        cancel = threading.Event()
+
+        def cancel_after_delay():
+            time.sleep(0.5)
+            cancel.set()
+
+        timer = threading.Thread(target=cancel_after_delay, daemon=True)
+        timer.start()
+
+        fresh_client.publish_and_run(slug, force=True)
+        result = fresh_client.get_results(slug, poll_interval=60, cancel_event=cancel)
+        timer.join(timeout=5)
+
+        assert isinstance(result, RunResult)
+        assert result.status == "cancelled"
+
+
+# ===========================================================================
+# Phase 5: ERROR HANDLING
+#
+# What happens when things go wrong on Kaggle.
+# ===========================================================================
+
+
+class TestErrorHandling:
+    """Tests for Kaggle-side execution errors."""
+
+    def test_crashing_script_returns_error(self, client):
+        """A script that raises at runtime should produce status='error'."""
+        _, slug = _prepare_workspace(
+            client, script='# %%\nraise ValueError("Deliberate crash")\n'
+        )
+
+        client.publish_and_run(slug, force=True)
+        result = client.get_results(slug, poll_interval=20, timeout=600)
+
+        assert result.status == "error"
+        assert result.error is not None
+        assert "finished with status: error" in result.error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ dependencies = [
 [project.optional-dependencies]
 kaggle-client = [
   "jupytext",
-  "kaggle",
+  "kagglesdk>=0.1.14,<1.0",
+  "kagglehub>=0.3.10",
 ]
 
 # Configuration for the build backend to find the version file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,15 @@ dependencies = [
   "google-genai>=1.38.0",
 ]
 
+[project.scripts]
+kaggle-bench = "kaggle_benchmarks.kaggle_client.cli:run"
+
+
 [project.optional-dependencies]
 kaggle-client = [
   "jupytext",
+  "kagglesdk>=0.1.14,<1.0",
+  "kagglehub>=0.3.10",
 ]
 
 # Configuration for the build backend to find the version file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 [project.optional-dependencies]
 kaggle-client = [
   "jupytext",
+  "kaggle",
 ]
 
 # Configuration for the build backend to find the version file

--- a/src/kaggle_benchmarks/kaggle_client/__init__.py
+++ b/src/kaggle_benchmarks/kaggle_client/__init__.py
@@ -11,3 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from kaggle_benchmarks.kaggle_client.notebook_api import (
+    BenchmarkNotebookClient,
+    ConcurrentRunError,
+    KaggleAuthError,
+    RunResult,
+)
+
+__all__ = [
+    "BenchmarkNotebookClient",
+    "ConcurrentRunError",
+    "KaggleAuthError",
+    "RunResult",
+]

--- a/src/kaggle_benchmarks/kaggle_client/cli.py
+++ b/src/kaggle_benchmarks/kaggle_client/cli.py
@@ -1,0 +1,145 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CLI entry points for kaggle-benchmarks."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _get_client(base_dir: str):
+    from kaggle_benchmarks.kaggle_client.notebook_api import BenchmarkNotebookClient
+    return BenchmarkNotebookClient(base_dir=base_dir)
+
+
+def run():
+    """Entry point for the kaggle-bench CLI."""
+    parser = argparse.ArgumentParser(
+        prog="kaggle-bench",
+        description="Manage Kaggle benchmark notebooks from the command line.",
+    )
+    parser.add_argument(
+        "--base-dir",
+        default=".",
+        help="Base directory for benchmark workspaces (default: current directory).",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # --- run subcommand ---
+    run_parser = subparsers.add_parser(
+        "run",
+        help="Publish and run a benchmark script on Kaggle.",
+    )
+    run_parser.add_argument(
+        "notebook_slug",
+        help="Short notebook name (e.g. 'my-benchmark').",
+    )
+    run_parser.add_argument(
+        "--source-file",
+        default=None,
+        help="Path to a local .py file to use as the benchmark.",
+    )
+    run_parser.add_argument(
+        "--dataset",
+        action="append",
+        dest="dataset_sources",
+        metavar="OWNER/DATASET",
+        help="Kaggle dataset slug to mount (can be repeated).",
+    )
+    run_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Push even if a run is already in progress.",
+    )
+    run_parser.add_argument(
+        "--wait",
+        action="store_true",
+        help="Wait for the run to finish and print results.",
+    )
+    run_parser.add_argument(
+        "--poll-interval",
+        type=int,
+        default=60,
+        help="Seconds between status checks when --wait is used (default: 60).",
+    )
+    run_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=None,
+        help="Max seconds to wait when --wait is used. Default: no timeout.",
+    )
+
+    # --- fork subcommand ---
+    fork_parser = subparsers.add_parser(
+        "fork",
+        help="Pull an existing Kaggle benchmark notebook for local editing.",
+    )
+    fork_parser.add_argument(
+        "source_notebook_id",
+        help="Full Kaggle notebook path (e.g. 'alice/riddle-benchmark').",
+    )
+    fork_parser.add_argument(
+        "--dest",
+        default=None,
+        dest="dest_notebook_slug",
+        help="Local workspace directory name. Defaults to the notebook slug.",
+    )
+    fork_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite an existing local workspace.",
+    )
+
+    args = parser.parse_args()
+    client = _get_client(args.base_dir)
+
+    if args.command == "run":
+        source = Path(args.source_file) if args.source_file else None
+        print(f"Publishing '{args.notebook_slug}' to Kaggle...")
+        tracking_url = client.publish_and_run(
+            notebook_slug=args.notebook_slug,
+            source_file=source,
+            dataset_sources=args.dataset_sources,
+            force=args.force,
+        )
+        print(f"Submitted. Tracking: {tracking_url}")
+        if args.wait:
+            print("Waiting for results (Ctrl+C to cancel)...")
+            result = client.get_results(
+                notebook_slug=args.notebook_slug,
+                poll_interval=args.poll_interval,
+                timeout=args.timeout,
+                on_status=lambda s: print(f"  Status: {s}"),
+            )
+            print(f"\nFinal status: {result.status}")
+            if result.tracking_url:
+                print(f"Notebook: {result.tracking_url}")
+            if result.output_dir:
+                print(f"Output saved to: {result.output_dir}")
+                for filename, data in result.iter_run_results():
+                    print(f"\n--- {filename} ---")
+                    print(json.dumps(data, indent=2))
+            if result.error:
+                print(f"Error: {result.error}", file=sys.stderr)
+                sys.exit(1)
+
+    elif args.command == "fork":
+        print(f"Forking '{args.source_notebook_id}'...")
+        workspace = client.fork(
+            source_notebook_id=args.source_notebook_id,
+            dest_notebook_slug=args.dest_notebook_slug,
+            overwrite=args.overwrite,
+        )
+        print(f"Workspace ready: {workspace}")

--- a/src/kaggle_benchmarks/kaggle_client/notebook_api.py
+++ b/src/kaggle_benchmarks/kaggle_client/notebook_api.py
@@ -1,0 +1,533 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Core client for the Kaggle benchmark notebook workflow."""
+
+import json
+import logging
+import shutil
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+from kaggle_benchmarks.kaggle_client.utils import (
+    convert_ipynb_to_py,
+    convert_py_to_ipynb,
+    resolve_metadata,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class KaggleAuthError(RuntimeError):
+    """Raised when Kaggle authentication fails or credentials are invalid."""
+
+
+class ConcurrentRunError(RuntimeError):
+    """Raised when a notebook is already running and force=False."""
+
+
+@dataclass
+class RunResult:
+    """Result of a benchmark notebook execution.
+
+    Attributes:
+        status: One of "queued", "running", "complete", "error",
+            "cancelled", or "timeout".
+        output_dir: String path to the output directory (not Path,
+            for JSON serialization). None if no output available.
+        tracking_url: URL to the notebook on Kaggle.
+        error: Error message (if any).
+    """
+
+    status: str
+    output_dir: str | None
+    tracking_url: str | None
+    error: str | None = None
+
+    def iter_runs(self) -> Iterator[tuple[str, dict[str, Any]]]:
+        """Yields (filename, parsed_data) for all *run.json files in the output directory."""
+        if not self.output_dir:
+            return
+
+        output_path = Path(self.output_dir)
+        if not output_path.exists():
+            return
+
+        for run_file in output_path.iterdir():
+            if run_file.name.endswith("run.json"):
+                yield run_file.name, json.loads(run_file.read_text(encoding="utf-8"))
+
+
+class BenchmarkNotebookClient:
+    """Client for the Kaggle benchmark notebook workflow.
+
+    Wraps the Kaggle API (KaggleApi from kaggle-python) to handle
+    publishing, running, and retrieving results from benchmark
+    notebooks (tagged with 'personal-benchmark' keyword).
+    """
+
+    BENCHMARK_FILENAME = "benchmark.py"
+    NOTEBOOK_FILENAME = "benchmark.ipynb"
+    METADATA_FILENAME = "kernel-metadata.json"
+    OUTPUT_DIRNAME = "output"
+
+    AUTH_ERROR_INSTRUCTIONS = (
+        "To authenticate, use one of the following methods:\n\n"
+        "  Option 1: Environment variable\n"
+        "    export KAGGLE_API_TOKEN=<your-token>\n\n"
+        "  Option 2: API token file\n"
+        "    Save your token to ~/.kaggle/access_token\n\n"
+        "  Option 3: Legacy credentials file\n"
+        "    Save kaggle.json to ~/.kaggle/kaggle.json\n\n"
+        "Get your API token at: https://www.kaggle.com/settings\n"
+        "Docs: https://github.com/Kaggle/kaggle-cli/blob/main/docs/README.md#authentication"
+    )
+
+    # Retry config for initial 404s from kernels_status after kernels_push.
+    # See: kaggle_api_example.py pull_notebook_output()
+    _STATUS_RETRIES = 5
+    _STATUS_RETRY_WAIT = 10  # seconds
+
+    def __init__(
+        self,
+        base_dir: str | Path = ".",
+    ):
+        """Initialize the BenchmarkNotebookClient.
+
+        Args:
+            base_dir: Parent directory for benchmark workspaces.
+        """
+        self.api = self._authenticate()
+        self.username = self.validate_and_get_username()
+        self.base_dir = Path(base_dir)
+
+    @staticmethod
+    def _authenticate():
+        """Authenticate with the Kaggle API.
+
+        Returns:
+            Authenticated KaggleApi instance.
+
+        Raises:
+            KaggleAuthError: If the kaggle package is not installed or
+                authentication fails.
+        """
+        try:
+            from kaggle.api.kaggle_api_extended import KaggleApi
+        except ImportError as e:
+            raise KaggleAuthError(
+                "The 'kaggle' package is required. Install with:\n"
+                "  pip install kaggle-benchmarks[kaggle-client]"
+            ) from e
+
+        api = KaggleApi()
+        try:
+            api.authenticate()
+        except OSError as e:
+            raise KaggleAuthError(
+                f"Kaggle authentication failed: {e}\n\n"
+                f"{BenchmarkNotebookClient.AUTH_ERROR_INSTRUCTIONS}"
+            ) from e
+        return api
+
+    def _workspace(self, notebook_slug: str) -> Path:
+        """Return the workspace directory for a notebook slug."""
+        return self.base_dir / notebook_slug
+
+    def _notebook_id(self, notebook_slug: str) -> str:
+        """Return the full notebook ID (username/slug)."""
+        return f"{self.username}/{notebook_slug}"
+
+    def _tracking_url(self, notebook_slug: str) -> str:
+        """Return the Kaggle tracking URL for a notebook."""
+        return f"https://www.kaggle.com/{self._notebook_id(notebook_slug)}"
+
+    @staticmethod
+    def _normalize_status(status: object) -> str:
+        """Normalize a Kaggle notebook status to a lowercase string.
+
+        The Kaggle API may return a KernelWorkerStatus enum
+        (e.g. "KernelWorkerStatus.complete") or a plain string.
+        This method normalizes both to a simple lowercase string
+        like "complete".
+        """
+        # Handle response wrappers with a .status attribute
+        status_raw = getattr(status, "status", status)
+        status_str = str(status_raw).lower()
+        # Strip enum class prefix (e.g. "kernelworkerstatus.complete" -> "complete")
+        if "." in status_str:
+            status_str = status_str.split(".")[-1]
+        return status_str
+
+    # --- Primary Operations ---
+
+    def publish_and_run(
+        self,
+        notebook_slug: str,
+        source_file: str | Path | None = None,
+        dataset_sources: list[str] | None = None,
+        force: bool = False,
+    ) -> str:
+        """Convert .py -> .ipynb, push to Kaggle, and trigger execution.
+
+        Workspace: <base_dir>/<notebook_slug>/
+
+        A notebook acts as the execution vehicle for your benchmark tasks. While you
+        can define and run multiple tasks within a single notebook, the Kaggle
+        leaderboard currently requires a single "main" task per notebook to be saved
+        and evaluated. You can use the `%choose <task_name>` magic command at the end
+        of your notebook to select which task's results to publish.
+
+        For more details on task selection, see:
+        https://github.com/Kaggle/kaggle-benchmarks/blob/ci/quick_start.md#82-using-choose-to-select-a-notebooks-task
+
+        Args:
+            notebook_slug: Short notebook name (e.g., 'my-benchmark').
+            source_file: Optional path to a .py file to copy into workspace. It will replace benchmark.py.
+            dataset_sources: Kaggle dataset slugs to mount at /kaggle/input/.
+            force: If True, push even if a previous run is in progress.
+
+        Returns:
+            Tracking URL for the running notebook.
+
+        Raises:
+            FileNotFoundError: If benchmark.py not found in workspace.
+            ConcurrentRunError: If a concurrent run is detected and force=False.
+        """
+        from requests.exceptions import HTTPError
+
+        workspace = self._workspace(notebook_slug)
+        workspace.mkdir(parents=True, exist_ok=True)
+        benchmark_py = workspace / self.BENCHMARK_FILENAME
+
+        # Copy source_file into workspace (if provided)
+        if source_file is not None:
+            source = Path(source_file)
+            if not source.exists():
+                raise FileNotFoundError(f"Source file not found: {source}")
+            shutil.copy2(source, benchmark_py)
+
+        if not benchmark_py.exists():
+            raise FileNotFoundError(
+                f"Benchmark file not found: {benchmark_py}. "
+                f"Create it or pass source_file to copy from."
+            )
+
+        # Resolve metadata (load existing kernel-metadata.json or generate new)
+        # 'personal-benchmark' keyword is ensured by resolve_metadata
+        metadata = resolve_metadata(
+            workspace_dir=workspace,
+            notebook_slug=notebook_slug,
+            username=self.username,
+            dataset_sources=dataset_sources,
+        )
+
+        # Convert benchmark.py (.py with # %% delimiters) to .ipynb
+        notebook_path = workspace / self.NOTEBOOK_FILENAME
+        convert_py_to_ipynb(benchmark_py, notebook_path)
+
+        # Concurrent run guard
+        notebook_id = self._notebook_id(notebook_slug)
+        if not force:
+            try:
+                raw_status = self.api.kernels_status(notebook_id)
+                status = self._normalize_status(raw_status)
+                if status in ("queued", "running"):
+                    raise ConcurrentRunError(
+                        f"Notebook '{notebook_id}' is already running "
+                        f"(status: {status}). "
+                        "Use force=True to push a new version anyway."
+                    )
+            except HTTPError as e:
+                if e.response.status_code == 404:
+                    pass  # No existing notebook — safe to push
+                else:
+                    raise
+
+        # Write metadata and push via api.kernels_push()
+        meta_path = workspace / self.METADATA_FILENAME
+        meta_path.write_text(json.dumps(metadata, indent=4), encoding="utf-8")
+
+        self.api.kernels_push(str(workspace))
+
+        return self._tracking_url(notebook_slug)
+
+    def _wait_for_notebook_creation(self, notebook_id: str) -> str | None:
+        """Wait for Kaggle to index a newly pushed notebook.
+
+        Returns:
+            The initial status string, or None if retries exceeded.
+        """
+        from requests.exceptions import HTTPError
+
+        for attempt in range(self._STATUS_RETRIES):
+            try:
+                raw_status = self.api.kernels_status(notebook_id)
+                return self._normalize_status(raw_status)
+            except HTTPError as e:
+                if e.response.status_code == 404:
+                    logger.info(
+                        "Notebook not found yet (attempt %d/%d), waiting...",
+                        attempt + 1,
+                        self._STATUS_RETRIES,
+                    )
+                    time.sleep(self._STATUS_RETRY_WAIT)
+                else:
+                    raise
+        return None
+
+    def _poll_notebook_status(
+        self,
+        notebook_id: str,
+        initial_status: str,
+        poll_interval: int,
+        timeout: int | None,
+        cancel_event: threading.Event | None,
+        on_status: Callable[[str], None] | None,
+    ) -> str:
+        """Poll notebook status until complete, error, cancelled, or timeout."""
+        status_str = initial_status
+        last_reported_status = None
+        start_time = time.monotonic()
+
+        while status_str not in ("complete", "error", "cancelled"):
+            if cancel_event is not None and cancel_event.is_set():
+                return "cancelled"
+
+            if timeout is not None and (time.monotonic() - start_time) >= timeout:
+                return "timeout"
+
+            if on_status is not None and status_str != last_reported_status:
+                on_status(status_str)
+                last_reported_status = status_str
+
+            # Wait with cancel_event support for early exit
+            if cancel_event is not None:
+                cancel_event.wait(poll_interval)
+                if cancel_event.is_set():
+                    return "cancelled"
+            else:
+                time.sleep(poll_interval)
+
+            raw_status = self.api.kernels_status(notebook_id)
+            status_str = self._normalize_status(raw_status)
+
+        # Report final status
+        if on_status is not None and status_str != last_reported_status:
+            on_status(status_str)
+
+        return status_str
+
+    def _download_notebook_output(
+        self, notebook_id: str, output_path: Path, clear_output: bool
+    ) -> None:
+        """Clear existing output (if requested) and download new output from Kaggle."""
+        if clear_output and output_path.exists():
+            shutil.rmtree(output_path)
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        self.api.kernels_output(kernel=notebook_id, path=str(output_path), force=True)
+
+    def get_results(
+        self,
+        notebook_slug: str,
+        output_dir: str | None = None,
+        poll_interval: int = 60,
+        timeout: int | None = None,
+        cancel_event: threading.Event | None = None,
+        on_status: Callable[[str], None] | None = None,
+        clear_output: bool = True,
+    ) -> RunResult:
+        """Poll execution status and download output files.
+
+        Workspace: <base_dir>/<notebook_slug>/
+
+        Polls api.kernels_status() until the notebook completes (or fails),
+        then downloads output via api.kernels_output().
+
+        Neither timeout nor cancel_event stops the Kaggle run itself —
+        the notebook continues executing on Kaggle. They only stop
+        the local polling.
+
+        Args:
+            notebook_slug: Short notebook name (e.g., 'my-benchmark').
+            output_dir: Where to save output files (defaults to
+                <base_dir>/<notebook_slug>/output/).
+            poll_interval: Seconds between status checks.
+            timeout: Maximum seconds to wait before returning
+                RunResult(status="timeout"). None means wait indefinitely.
+            cancel_event: A threading.Event; when set, the poll loop exits
+                with RunResult(status="cancelled").
+            on_status: Callback invoked when the notebook status changes.
+            clear_output: If True (default), clear the output directory
+                before downloading new output. If False, download into
+                the existing directory without clearing.
+
+        Returns:
+            RunResult with status, output path, and parsed run.json data.
+        """
+        notebook_id = self._notebook_id(notebook_slug)
+        workspace = self._workspace(notebook_slug)
+        tracking_url = self._tracking_url(notebook_slug)
+
+        if output_dir is None:
+            output_path = workspace / self.OUTPUT_DIRNAME
+        else:
+            output_path = Path(output_dir)
+
+        status_str = self._wait_for_notebook_creation(notebook_id)
+        if status_str is None:
+            return RunResult(
+                status="error",
+                output_dir=None,
+                tracking_url=tracking_url,
+                error=(
+                    f"Failed to find notebook '{notebook_id}' "
+                    f"after {self._STATUS_RETRIES} retries."
+                ),
+            )
+
+        final_status = self._poll_notebook_status(
+            notebook_id=notebook_id,
+            initial_status=status_str,
+            poll_interval=poll_interval,
+            timeout=timeout,
+            cancel_event=cancel_event,
+            on_status=on_status,
+        )
+
+        if final_status != "complete":
+            error_msg = None
+            if final_status not in ("timeout", "cancelled"):
+                error_msg = f"Notebook execution finished with status: {final_status}"
+
+            return RunResult(
+                status=final_status,
+                output_dir=None,
+                tracking_url=tracking_url,
+                error=error_msg,
+            )
+
+        self._download_notebook_output(notebook_id, output_path, clear_output)
+
+        return RunResult(
+            status="complete",
+            output_dir=str(output_path),
+            tracking_url=tracking_url,
+        )
+
+    def fork(
+        self,
+        source_notebook_id: str,
+        dest_notebook_slug: str | None = None,
+        overwrite: bool = False,
+    ) -> Path:
+        """Pull an existing benchmark from Kaggle as a starting point.
+
+        Workspace: <base_dir>/<dest_notebook_slug>/
+
+        Downloads via api.kernels_pull() and converts:
+        1. Pulls the .ipynb and kernel-metadata.json
+        2. Renames the pulled .ipynb to benchmark.ipynb to prevent Kaggle from pushing multiple notebooks during publish.
+        3. Converts benchmark.ipynb -> benchmark.py with # %% cell delimiters
+
+        The kernel-metadata.json is preserved so that publish_and_run()
+        can reuse it.
+
+        Args:
+            source_notebook_id: Full Kaggle notebook path including owner
+                (e.g., 'alice/riddle-benchmark').
+            dest_notebook_slug: Local name for the benchmark directory.
+                Defaults to the basename of source_notebook_id.
+            overwrite: If True, replace the existing workspace directory.
+                If False (default), raises FileExistsError.
+
+        Returns:
+            Path to the workspace directory containing the .py file.
+        """
+        if dest_notebook_slug is None:
+            dest_notebook_slug = source_notebook_id.split("/")[-1]
+
+        workspace = self._workspace(dest_notebook_slug)
+
+        if workspace.exists():
+            if not overwrite:
+                raise FileExistsError(
+                    f"Workspace already exists: {workspace}. "
+                    "Use overwrite=True to replace it."
+                )
+            shutil.rmtree(workspace)
+
+        workspace.mkdir(parents=True, exist_ok=True)
+
+        # Pull notebook and metadata from Kaggle
+        from requests.exceptions import HTTPError
+
+        try:
+            self.api.kernels_pull(
+                source_notebook_id, path=str(workspace), metadata=True
+            )
+        except HTTPError as e:
+            raise ValueError(
+                f"Failed to pull notebook '{source_notebook_id}'. "
+                "Ensure the notebook exists, is public (or you have access), "
+                "and you have accepted any necessary competition rules."
+            ) from e
+
+        # Convert .ipynb to .py with # %% cell delimiters
+        ipynb_files = list(workspace.glob("*.ipynb"))
+        if ipynb_files:
+            ipynb_path = ipynb_files[0]
+            py_path = workspace / self.BENCHMARK_FILENAME
+            convert_ipynb_to_py(ipynb_path, py_path)
+
+            std_ipynb_path = workspace / self.NOTEBOOK_FILENAME
+            if ipynb_path != std_ipynb_path:
+                ipynb_path.rename(std_ipynb_path)
+        else:
+            logger.warning(
+                "No .ipynb file found after pulling '%s'. "
+                "The notebook may be a script notebook.",
+                source_notebook_id,
+            )
+
+        return workspace
+
+    def validate_and_get_username(self) -> str:
+        """Validate Kaggle credentials and return the authenticated username.
+
+        Calls the Kaggle API to verify that the stored credentials
+        are valid and retrieves the authenticated username.
+
+        Returns:
+            The authenticated Kaggle username.
+
+        Raises:
+            KaggleAuthError: If credentials are missing or invalid,
+                with a message guiding the user to set up
+                authentication.
+        """
+        try:
+            username = self.api.get_config_value("username")
+            if not username:
+                raise ValueError("Kaggle username is empty")
+            return username
+        except Exception as e:
+            raise KaggleAuthError(
+                f"Kaggle credentials are invalid or missing: {e}\n\n"
+                f"{BenchmarkNotebookClient.AUTH_ERROR_INSTRUCTIONS}"
+            ) from e

--- a/src/kaggle_benchmarks/kaggle_client/notebook_api.py
+++ b/src/kaggle_benchmarks/kaggle_client/notebook_api.py
@@ -16,17 +16,24 @@
 
 import json
 import logging
+import os
 import shutil
+import tarfile
+import tempfile
 import threading
 import time
+import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Iterator
 
 from kaggle_benchmarks.kaggle_client.utils import (
+    KAGGLE_METADATA_MAP,
+    build_local_metadata,
     convert_ipynb_to_py,
     convert_py_to_ipynb,
-    resolve_metadata,
+    normalize_status,
+    parse_remote_metadata,
 )
 
 logger = logging.getLogger(__name__)
@@ -58,26 +65,108 @@ class RunResult:
     tracking_url: str | None
     error: str | None = None
 
-    def iter_runs(self) -> Iterator[tuple[str, dict[str, Any]]]:
+    def iter_run_results(self) -> Iterator[tuple[str, dict[str, Any]]]:
         """Yields (filename, parsed_data) for all *run.json files in the output directory."""
-        if not self.output_dir:
+        if not self.output_dir or not (output_path := Path(self.output_dir)).exists():
             return
 
-        output_path = Path(self.output_dir)
-        if not output_path.exists():
-            return
+        for run_file in output_path.glob("*run.json"):
+            yield run_file.name, json.loads(run_file.read_text(encoding="utf-8"))
 
-        for run_file in output_path.iterdir():
-            if run_file.name.endswith("run.json"):
-                yield run_file.name, json.loads(run_file.read_text(encoding="utf-8"))
+
+# =============================================================================
+# Module-level helper functions (authentication)
+# =============================================================================
+
+_AUTH_ERROR_INSTRUCTIONS = (
+    "To authenticate, use one of the following methods (in priority order):\n\n"
+    "  Option 1: Bearer token (recommended)\n"
+    "    export KAGGLE_API_TOKEN=<your-token>\n"
+    "    Or save your token to ~/.kaggle/access_token\n\n"
+    "  Option 2: Basic auth via environment variables\n"
+    "    export KAGGLE_USERNAME=<your-username>\n"
+    "    export KAGGLE_KEY=<your-api-key>\n\n"
+    "  Option 3: Basic auth via credentials file\n"
+    "    Save kaggle.json to ~/.kaggle/kaggle.json\n\n"
+    "Get your API token at: https://www.kaggle.com/settings\n"
+    "Docs: https://github.com/Kaggle/kagglehub/tree/main#authenticate"
+)
+
+
+def _authenticate() -> tuple[Any, str]:
+    """Authenticate with the Kaggle API and resolve the username.
+
+    Credential resolution relies on the kagglesdk for token introspection
+    and kagglehub for standard Basic auth/json fallbacks.
+
+    Returns:
+        A tuple of (KaggleClient, username).
+
+    Raises:
+        KaggleAuthError: If the SDK is missing, no credentials are found,
+            or the username cannot be determined.
+    """
+    try:
+        from kagglesdk.kaggle_client import KaggleClient
+        from kagglesdk.kaggle_env import get_access_token_from_env, get_env
+        from kagglesdk.security.types.oauth_service import IntrospectTokenRequest
+    except ImportError as e:
+        raise KaggleAuthError(
+            "The 'kagglesdk' package is required. Install with:\n"
+            "  pip install kaggle-benchmarks[kaggle-client]"
+        ) from e
+
+    try:
+        client = KaggleClient(env=get_env())
+    except Exception as e:
+        raise KaggleAuthError(
+            f"Kaggle authentication failed: {e}\n\n{_AUTH_ERROR_INSTRUCTIONS}"
+        ) from e
+
+    def get_token_user() -> str | None:
+        if api_token := get_access_token_from_env()[0]:
+            try:
+                req = IntrospectTokenRequest()
+                req.token = api_token
+                resp = client.security.oauth_client.introspect_token(req)
+                return resp.username if resp.active else None
+            except Exception:
+                pass
+        return None
+
+    def get_hub_user() -> str | None:
+        try:
+            import kagglehub
+
+            return (
+                creds.username
+                if (creds := kagglehub.config.get_kaggle_credentials())
+                else None
+            )
+        except Exception:
+            return None
+
+    username = client.username or get_token_user() or get_hub_user()
+
+    if not username:
+        raise KaggleAuthError(
+            f"No Kaggle credentials found or invalid.\n\n{_AUTH_ERROR_INSTRUCTIONS}"
+        )
+
+    return client, username
+
+
+# =============================================================================
+# Client class
+# =============================================================================
 
 
 class BenchmarkNotebookClient:
     """Client for the Kaggle benchmark notebook workflow.
 
-    Wraps the Kaggle API (KaggleApi from kaggle-python) to handle
-    publishing, running, and retrieving results from benchmark
-    notebooks (tagged with 'personal-benchmark' keyword).
+    Wraps the Kaggle SDK (kagglesdk) to handle publishing, running,
+    and retrieving results from benchmark notebooks (tagged with
+    'personal-benchmark' keyword).
     """
 
     BENCHMARK_FILENAME = "benchmark.py"
@@ -85,22 +174,13 @@ class BenchmarkNotebookClient:
     METADATA_FILENAME = "kernel-metadata.json"
     OUTPUT_DIRNAME = "output"
 
-    AUTH_ERROR_INSTRUCTIONS = (
-        "To authenticate, use one of the following methods:\n\n"
-        "  Option 1: Environment variable\n"
-        "    export KAGGLE_API_TOKEN=<your-token>\n\n"
-        "  Option 2: API token file\n"
-        "    Save your token to ~/.kaggle/access_token\n\n"
-        "  Option 3: Legacy credentials file\n"
-        "    Save kaggle.json to ~/.kaggle/kaggle.json\n\n"
-        "Get your API token at: https://www.kaggle.com/settings\n"
-        "Docs: https://github.com/Kaggle/kaggle-cli/blob/main/docs/README.md#authentication"
-    )
-
-    # Retry config for initial 404s from kernels_status after kernels_push.
-    # See: kaggle_api_example.py pull_notebook_output()
+    # Retry config for initial 404s from get_kernel_session_status after save_kernel.
     _STATUS_RETRIES = 5
     _STATUS_RETRY_WAIT = 10  # seconds
+
+    # =========================================================================
+    # Authentication & Identity
+    # =========================================================================
 
     def __init__(
         self,
@@ -111,69 +191,106 @@ class BenchmarkNotebookClient:
         Args:
             base_dir: Parent directory for benchmark workspaces.
         """
-        self.api = self._authenticate()
-        self.username = self.validate_and_get_username()
+        self.api, self.username = _authenticate()
         self.base_dir = Path(base_dir)
 
-    @staticmethod
-    def _authenticate():
-        """Authenticate with the Kaggle API.
+    # =========================================================================
+    # Forking
+    # =========================================================================
+
+    def fork(
+        self,
+        source_notebook_id: str,
+        dest_notebook_slug: str | None = None,
+        overwrite: bool = False,
+    ) -> Path:
+        """Pull an existing benchmark from Kaggle as a starting point.
+
+        Workspace: <base_dir>/<dest_notebook_slug>/
+
+        Downloads via get_kernel() and converts:
+        1. Pulls the .ipynb source and kernel metadata
+        2. Writes the source as benchmark.ipynb
+        3. Converts benchmark.ipynb -> benchmark.py with # %% cell delimiters
+        4. Reconstructs kernel-metadata.json from API response
+
+        The kernel-metadata.json is preserved so that publish_and_run()
+        can reuse it.
+
+        Args:
+            source_notebook_id: Full Kaggle notebook path including owner
+                (e.g., 'alice/riddle-benchmark').
+            dest_notebook_slug: Local name for the benchmark directory.
+                Defaults to the basename of source_notebook_id.
+            overwrite: If True, replace the existing workspace directory.
+                If False (default), raises FileExistsError.
 
         Returns:
-            Authenticated KaggleApi instance.
-
-        Raises:
-            KaggleAuthError: If the kaggle package is not installed or
-                authentication fails.
+            Path to the workspace directory containing the .py file.
         """
+        if dest_notebook_slug is None:
+            dest_notebook_slug = source_notebook_id.split("/")[-1]
+
+        workspace = self._workspace(dest_notebook_slug)
+
+        if workspace.exists():
+            if not overwrite:
+                raise FileExistsError(
+                    f"Workspace already exists: {workspace}. "
+                    "Use overwrite=True to replace it."
+                )
+            shutil.rmtree(workspace)
+
+        workspace.mkdir(parents=True, exist_ok=True)
+
+        # Pull notebook source and metadata from Kaggle via get_kernel()
+        from kagglesdk.kernels.types.kernels_api_service import (
+            ApiGetKernelRequest,
+        )
+        from requests.exceptions import HTTPError
+
         try:
-            from kaggle.api.kaggle_api_extended import KaggleApi
-        except ImportError as e:
-            raise KaggleAuthError(
-                "The 'kaggle' package is required. Install with:\n"
-                "  pip install kaggle-benchmarks[kaggle-client]"
+            req = ApiGetKernelRequest()
+            req.user_name, req.kernel_slug = source_notebook_id.split("/")
+            response = self.api.kernels.kernels_api_client.get_kernel(req)
+        except HTTPError as e:
+            raise ValueError(
+                f"Failed to pull notebook '{source_notebook_id}'. "
+                "Ensure the notebook exists, is public (or you have access), "
+                "and you have accepted any necessary competition rules."
             ) from e
 
-        api = KaggleApi()
-        try:
-            api.authenticate()
-        except OSError as e:
-            raise KaggleAuthError(
-                f"Kaggle authentication failed: {e}\n\n"
-                f"{BenchmarkNotebookClient.AUTH_ERROR_INSTRUCTIONS}"
-            ) from e
-        return api
+        # Write the notebook source to benchmark.ipynb
+        # response.blob.source is exactly the raw .ipynb JSON for notebook-type kernels
+        if response.blob and response.blob.source:
+            ipynb_path = workspace / self.NOTEBOOK_FILENAME
+            ipynb_path.write_text(response.blob.source, encoding="utf-8")
 
-    def _workspace(self, notebook_slug: str) -> Path:
-        """Return the workspace directory for a notebook slug."""
-        return self.base_dir / notebook_slug
+            # Convert .ipynb to .py with # %% cell delimiters
+            py_path = workspace / self.BENCHMARK_FILENAME
+            convert_ipynb_to_py(ipynb_path, py_path)
+        else:
+            logger.warning(
+                "No source found after pulling '%s'. "
+                "The notebook may be a script notebook.",
+                source_notebook_id,
+            )
 
-    def _notebook_id(self, notebook_slug: str) -> str:
-        """Return the full notebook ID (username/slug)."""
-        return f"{self.username}/{notebook_slug}"
+        # Reconstruct kernel-metadata.json from response.metadata
+        if response.metadata:
+            metadata = parse_remote_metadata(
+                meta=response.metadata,
+                default_id=source_notebook_id,
+                default_slug=dest_notebook_slug,
+            )
+            meta_path = workspace / self.METADATA_FILENAME
+            meta_path.write_text(json.dumps(metadata, indent=4), encoding="utf-8")
 
-    def _tracking_url(self, notebook_slug: str) -> str:
-        """Return the Kaggle tracking URL for a notebook."""
-        return f"https://www.kaggle.com/{self._notebook_id(notebook_slug)}"
+        return workspace
 
-    @staticmethod
-    def _normalize_status(status: object) -> str:
-        """Normalize a Kaggle notebook status to a lowercase string.
-
-        The Kaggle API may return a KernelWorkerStatus enum
-        (e.g. "KernelWorkerStatus.complete") or a plain string.
-        This method normalizes both to a simple lowercase string
-        like "complete".
-        """
-        # Handle response wrappers with a .status attribute
-        status_raw = getattr(status, "status", status)
-        status_str = str(status_raw).lower()
-        # Strip enum class prefix (e.g. "kernelworkerstatus.complete" -> "complete")
-        if "." in status_str:
-            status_str = status_str.split(".")[-1]
-        return status_str
-
-    # --- Primary Operations ---
+    # =========================================================================
+    # Publish & Run
+    # =========================================================================
 
     def publish_and_run(
         self,
@@ -198,7 +315,8 @@ class BenchmarkNotebookClient:
         Args:
             notebook_slug: Short notebook name (e.g., 'my-benchmark').
             source_file: Optional path to a .py file to copy into workspace. It will replace benchmark.py.
-            dataset_sources: Kaggle dataset slugs to mount at /kaggle/input/.
+            dataset_sources: Optional list of Kaggle dataset slugs (e.g., ``["owner/dataset-name"]``)
+                to mount at ``/kaggle/input/``.
             force: If True, push even if a previous run is in progress.
 
         Returns:
@@ -229,7 +347,7 @@ class BenchmarkNotebookClient:
 
         # Resolve metadata (load existing kernel-metadata.json or generate new)
         # 'personal-benchmark' keyword is ensured by resolve_metadata
-        metadata = resolve_metadata(
+        metadata = build_local_metadata(
             workspace_dir=workspace,
             notebook_slug=notebook_slug,
             username=self.username,
@@ -244,8 +362,7 @@ class BenchmarkNotebookClient:
         notebook_id = self._notebook_id(notebook_slug)
         if not force:
             try:
-                raw_status = self.api.kernels_status(notebook_id)
-                status = self._normalize_status(raw_status)
+                status = self._get_kernel_session_status(notebook_id)
                 if status in ("queued", "running"):
                     raise ConcurrentRunError(
                         f"Notebook '{notebook_id}' is already running "
@@ -258,89 +375,50 @@ class BenchmarkNotebookClient:
                 else:
                     raise
 
-        # Write metadata and push via api.kernels_push()
+        # Write metadata to disk (for local inspection and fork reuse)
         meta_path = workspace / self.METADATA_FILENAME
         meta_path.write_text(json.dumps(metadata, indent=4), encoding="utf-8")
 
-        self.api.kernels_push(str(workspace))
+        # Read the generated .ipynb and push inline via save_kernel
+        notebook_content = notebook_path.read_text(encoding="utf-8")
+        req = self._build_save_request(
+            notebook_id=self._notebook_id(notebook_slug),
+            notebook_content=notebook_content,
+            metadata=metadata,
+        )
+
+        response = self.api.kernels.kernels_api_client.save_kernel(req)
+        if response.error:
+            raise RuntimeError(f"Kaggle push failed: {response.error}")
 
         return self._tracking_url(notebook_slug)
 
-    def _wait_for_notebook_creation(self, notebook_id: str) -> str | None:
-        """Wait for Kaggle to index a newly pushed notebook.
-
-        Returns:
-            The initial status string, or None if retries exceeded.
-        """
-        from requests.exceptions import HTTPError
-
-        for attempt in range(self._STATUS_RETRIES):
-            try:
-                raw_status = self.api.kernels_status(notebook_id)
-                return self._normalize_status(raw_status)
-            except HTTPError as e:
-                if e.response.status_code == 404:
-                    logger.info(
-                        "Notebook not found yet (attempt %d/%d), waiting...",
-                        attempt + 1,
-                        self._STATUS_RETRIES,
-                    )
-                    time.sleep(self._STATUS_RETRY_WAIT)
-                else:
-                    raise
-        return None
-
-    def _poll_notebook_status(
+    def _build_save_request(
         self,
         notebook_id: str,
-        initial_status: str,
-        poll_interval: int,
-        timeout: int | None,
-        cancel_event: threading.Event | None,
-        on_status: Callable[[str], None] | None,
-    ) -> str:
-        """Poll notebook status until complete, error, cancelled, or timeout."""
-        status_str = initial_status
-        last_reported_status = None
-        start_time = time.monotonic()
+        notebook_content: str,
+        metadata: dict[str, Any],
+    ):
+        """Build the API request to save/push a notebook."""
+        from kagglesdk.kernels.types.kernels_api_service import ApiSaveKernelRequest
 
-        while status_str not in ("complete", "error", "cancelled"):
-            if cancel_event is not None and cancel_event.is_set():
-                return "cancelled"
+        req = ApiSaveKernelRequest()
 
-            if timeout is not None and (time.monotonic() - start_time) >= timeout:
-                return "timeout"
+        # Special required fields
+        req.slug = notebook_id
+        req.new_title = metadata.get("title", notebook_id.split("/")[-1])
+        req.text = notebook_content
 
-            if on_status is not None and status_str != last_reported_status:
-                on_status(status_str)
-                last_reported_status = status_str
+        # Map the remaining configured attributes dynamically
+        for json_key, (api_key, _) in KAGGLE_METADATA_MAP.items():
+            if json_key in metadata:
+                setattr(req, api_key, metadata[json_key])
 
-            # Wait with cancel_event support for early exit
-            if cancel_event is not None:
-                cancel_event.wait(poll_interval)
-                if cancel_event.is_set():
-                    return "cancelled"
-            else:
-                time.sleep(poll_interval)
+        return req
 
-            raw_status = self.api.kernels_status(notebook_id)
-            status_str = self._normalize_status(raw_status)
-
-        # Report final status
-        if on_status is not None and status_str != last_reported_status:
-            on_status(status_str)
-
-        return status_str
-
-    def _download_notebook_output(
-        self, notebook_id: str, output_path: Path, clear_output: bool
-    ) -> None:
-        """Clear existing output (if requested) and download new output from Kaggle."""
-        if clear_output and output_path.exists():
-            shutil.rmtree(output_path)
-        output_path.mkdir(parents=True, exist_ok=True)
-
-        self.api.kernels_output(kernel=notebook_id, path=str(output_path), force=True)
+    # =========================================================================
+    # Polling & Results
+    # =========================================================================
 
     def get_results(
         self,
@@ -356,8 +434,8 @@ class BenchmarkNotebookClient:
 
         Workspace: <base_dir>/<notebook_slug>/
 
-        Polls api.kernels_status() until the notebook completes (or fails),
-        then downloads output via api.kernels_output().
+        Polls get_kernel_session_status() until the notebook completes (or fails),
+        then downloads output via download_kernel_output().
 
         Neither timeout nor cancel_event stops the Kaggle run itself —
         the notebook continues executing on Kaggle. They only stop
@@ -430,104 +508,139 @@ class BenchmarkNotebookClient:
             tracking_url=tracking_url,
         )
 
-    def fork(
-        self,
-        source_notebook_id: str,
-        dest_notebook_slug: str | None = None,
-        overwrite: bool = False,
-    ) -> Path:
-        """Pull an existing benchmark from Kaggle as a starting point.
-
-        Workspace: <base_dir>/<dest_notebook_slug>/
-
-        Downloads via api.kernels_pull() and converts:
-        1. Pulls the .ipynb and kernel-metadata.json
-        2. Renames the pulled .ipynb to benchmark.ipynb to prevent Kaggle from pushing multiple notebooks during publish.
-        3. Converts benchmark.ipynb -> benchmark.py with # %% cell delimiters
-
-        The kernel-metadata.json is preserved so that publish_and_run()
-        can reuse it.
-
-        Args:
-            source_notebook_id: Full Kaggle notebook path including owner
-                (e.g., 'alice/riddle-benchmark').
-            dest_notebook_slug: Local name for the benchmark directory.
-                Defaults to the basename of source_notebook_id.
-            overwrite: If True, replace the existing workspace directory.
-                If False (default), raises FileExistsError.
+    def _wait_for_notebook_creation(self, notebook_id: str) -> str | None:
+        """Wait for Kaggle to index a newly pushed notebook.
 
         Returns:
-            Path to the workspace directory containing the .py file.
+            The initial status string, or None if retries exceeded.
         """
-        if dest_notebook_slug is None:
-            dest_notebook_slug = source_notebook_id.split("/")[-1]
-
-        workspace = self._workspace(dest_notebook_slug)
-
-        if workspace.exists():
-            if not overwrite:
-                raise FileExistsError(
-                    f"Workspace already exists: {workspace}. "
-                    "Use overwrite=True to replace it."
-                )
-            shutil.rmtree(workspace)
-
-        workspace.mkdir(parents=True, exist_ok=True)
-
-        # Pull notebook and metadata from Kaggle
         from requests.exceptions import HTTPError
 
+        for attempt in range(self._STATUS_RETRIES):
+            try:
+                return self._get_kernel_session_status(notebook_id)
+            except HTTPError as e:
+                if e.response.status_code == 404:
+                    logger.info(
+                        "Notebook not found yet (attempt %d/%d), waiting...",
+                        attempt + 1,
+                        self._STATUS_RETRIES,
+                    )
+                    time.sleep(self._STATUS_RETRY_WAIT)
+                else:
+                    raise
+        return None
+
+    def _poll_notebook_status(
+        self,
+        notebook_id: str,
+        initial_status: str,
+        poll_interval: int,
+        timeout: int | None,
+        cancel_event: threading.Event | None,
+        on_status: Callable[[str], None] | None,
+    ) -> str:
+        """Poll notebook status until complete, error, cancelled, or timeout."""
+        status_str = initial_status
+        last_reported_status = None
+        start_time = time.monotonic()
+
+        while status_str not in ("complete", "error", "cancelled"):
+            if cancel_event is not None and cancel_event.is_set():
+                return "cancelled"
+
+            if timeout is not None and (time.monotonic() - start_time) >= timeout:
+                return "timeout"
+
+            if on_status is not None and status_str != last_reported_status:
+                on_status(status_str)
+                last_reported_status = status_str
+
+            # Wait with cancel_event support for early exit
+            if cancel_event is not None:
+                cancel_event.wait(poll_interval)
+                if cancel_event.is_set():
+                    return "cancelled"
+            else:
+                time.sleep(poll_interval)
+
+            status_str = self._get_kernel_session_status(notebook_id)
+
+        # Report final status
+        if on_status is not None and status_str != last_reported_status:
+            on_status(status_str)
+
+        return status_str
+
+    def _download_notebook_output(
+        self, notebook_id: str, output_path: Path, clear_output: bool
+    ) -> None:
+        """Clear existing output (if requested) and download new output from Kaggle."""
+        from kagglesdk.kernels.types.kernels_api_service import (
+            ApiDownloadKernelOutputRequest,
+        )
+
+        if clear_output and output_path.exists():
+            shutil.rmtree(output_path)
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        # Build request (no file_path -> downloads all output as archive)
+        req = ApiDownloadKernelOutputRequest()
+        req.owner_slug, req.kernel_slug = notebook_id.split("/")
+
+        # download_kernel_output returns a streamed requests.Response
+        response = self.api.kernels.kernels_api_client.download_kernel_output(req)
+
+        # Save the archive to a temp file, then extract
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".archive") as tmp:
+            for chunk in response.iter_content(chunk_size=8192):
+                tmp.write(chunk)
+            archive_path = tmp.name
+
         try:
-            self.api.kernels_pull(
-                source_notebook_id, path=str(workspace), metadata=True
-            )
-        except HTTPError as e:
-            raise ValueError(
-                f"Failed to pull notebook '{source_notebook_id}'. "
-                "Ensure the notebook exists, is public (or you have access), "
-                "and you have accepted any necessary competition rules."
-            ) from e
+            if tarfile.is_tarfile(archive_path):
+                with tarfile.open(archive_path) as tf:
+                    tf.extractall(output_path)
+            elif zipfile.is_zipfile(archive_path):
+                with zipfile.ZipFile(archive_path, "r") as zf:
+                    zf.extractall(output_path)
+            else:
+                raise RuntimeError("Unexpected archive format from Kaggle API")
+        finally:
+            os.remove(archive_path)
 
-        # Convert .ipynb to .py with # %% cell delimiters
-        ipynb_files = list(workspace.glob("*.ipynb"))
-        if ipynb_files:
-            ipynb_path = ipynb_files[0]
-            py_path = workspace / self.BENCHMARK_FILENAME
-            convert_ipynb_to_py(ipynb_path, py_path)
+    def _get_kernel_session_status(self, notebook_id: str):
+        """Get the session status for a notebook via kagglesdk.
 
-            std_ipynb_path = workspace / self.NOTEBOOK_FILENAME
-            if ipynb_path != std_ipynb_path:
-                ipynb_path.rename(std_ipynb_path)
-        else:
-            logger.warning(
-                "No .ipynb file found after pulling '%s'. "
-                "The notebook may be a script notebook.",
-                source_notebook_id,
-            )
-
-        return workspace
-
-    def validate_and_get_username(self) -> str:
-        """Validate Kaggle credentials and return the authenticated username.
-
-        Calls the Kaggle API to verify that the stored credentials
-        are valid and retrieves the authenticated username.
+        Args:
+            notebook_id: Full notebook ID (format: "username/slug").
 
         Returns:
-            The authenticated Kaggle username.
-
-        Raises:
-            KaggleAuthError: If credentials are missing or invalid,
-                with a message guiding the user to set up
-                authentication.
+            The normalized status string.
         """
-        try:
-            username = self.api.get_config_value("username")
-            if not username:
-                raise ValueError("Kaggle username is empty")
-            return username
-        except Exception as e:
-            raise KaggleAuthError(
-                f"Kaggle credentials are invalid or missing: {e}\n\n"
-                f"{BenchmarkNotebookClient.AUTH_ERROR_INSTRUCTIONS}"
-            ) from e
+        from kagglesdk.kernels.types.kernels_api_service import (
+            ApiGetKernelSessionStatusRequest,
+        )
+
+        user_name, kernel_slug = notebook_id.split("/")
+        req = ApiGetKernelSessionStatusRequest()
+        req.user_name = user_name
+        req.kernel_slug = kernel_slug
+        response = self.api.kernels.kernels_api_client.get_kernel_session_status(req)
+        return normalize_status(response)
+
+    # =========================================================================
+    # Internal Utilities
+    # =========================================================================
+
+    def _workspace(self, notebook_slug: str) -> Path:
+        """Return the workspace directory for a notebook slug."""
+        return self.base_dir / notebook_slug
+
+    def _notebook_id(self, notebook_slug: str) -> str:
+        """Return the full notebook ID (username/slug)."""
+        return f"{self.username}/{notebook_slug}"
+
+    def _tracking_url(self, notebook_slug: str) -> str:
+        """Return the Kaggle tracking URL for a notebook."""
+        return f"https://www.kaggle.com/{self._notebook_id(notebook_slug)}"

--- a/src/kaggle_benchmarks/kaggle_client/notebook_api.py
+++ b/src/kaggle_benchmarks/kaggle_client/notebook_api.py
@@ -27,14 +27,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Iterator
 
-from kaggle_benchmarks.kaggle_client.utils import (
-    KAGGLE_METADATA_MAP,
-    build_local_metadata,
-    convert_ipynb_to_py,
-    convert_py_to_ipynb,
-    normalize_status,
-    parse_remote_metadata,
-)
+from kaggle_benchmarks.kaggle_client import utils as kaggle_utils
 
 logger = logging.getLogger(__name__)
 
@@ -268,7 +261,7 @@ class BenchmarkNotebookClient:
 
             # Convert .ipynb to .py with # %% cell delimiters
             py_path = workspace / self.BENCHMARK_FILENAME
-            convert_ipynb_to_py(ipynb_path, py_path)
+            kaggle_utils.convert_ipynb_to_py(ipynb_path, py_path)
         else:
             logger.warning(
                 "No source found after pulling '%s'. "
@@ -278,7 +271,7 @@ class BenchmarkNotebookClient:
 
         # Reconstruct kernel-metadata.json from response.metadata
         if response.metadata:
-            metadata = parse_remote_metadata(
+            metadata = kaggle_utils.parse_remote_metadata(
                 meta=response.metadata,
                 default_id=source_notebook_id,
                 default_slug=dest_notebook_slug,
@@ -347,7 +340,7 @@ class BenchmarkNotebookClient:
 
         # Resolve metadata (load existing kernel-metadata.json or generate new)
         # 'personal-benchmark' keyword is ensured by resolve_metadata
-        metadata = build_local_metadata(
+        metadata = kaggle_utils.build_local_metadata(
             workspace_dir=workspace,
             notebook_slug=notebook_slug,
             username=self.username,
@@ -356,7 +349,7 @@ class BenchmarkNotebookClient:
 
         # Convert benchmark.py (.py with # %% delimiters) to .ipynb
         notebook_path = workspace / self.NOTEBOOK_FILENAME
-        convert_py_to_ipynb(benchmark_py, notebook_path)
+        kaggle_utils.convert_py_to_ipynb(benchmark_py, notebook_path)
 
         # Concurrent run guard
         notebook_id = self._notebook_id(notebook_slug)
@@ -410,7 +403,7 @@ class BenchmarkNotebookClient:
         req.text = notebook_content
 
         # Map the remaining configured attributes dynamically
-        for json_key, (api_key, _) in KAGGLE_METADATA_MAP.items():
+        for json_key, (api_key, _) in kaggle_utils.KAGGLE_METADATA_MAP.items():
             if json_key in metadata:
                 setattr(req, api_key, metadata[json_key])
 
@@ -627,7 +620,7 @@ class BenchmarkNotebookClient:
         req.user_name = user_name
         req.kernel_slug = kernel_slug
         response = self.api.kernels.kernels_api_client.get_kernel_session_status(req)
-        return normalize_status(response)
+        return kaggle_utils.normalize_status(response)
 
     # =========================================================================
     # Internal Utilities

--- a/src/kaggle_benchmarks/kaggle_client/notebook_api.py
+++ b/src/kaggle_benchmarks/kaggle_client/notebook_api.py
@@ -1,0 +1,639 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Core client for the Kaggle benchmark notebook workflow."""
+
+import json
+import logging
+import os
+import shutil
+import tarfile
+import tempfile
+import threading
+import time
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+from kaggle_benchmarks.kaggle_client import utils as kaggle_utils
+
+logger = logging.getLogger(__name__)
+
+
+class KaggleAuthError(RuntimeError):
+    """Raised when Kaggle authentication fails or credentials are invalid."""
+
+
+class ConcurrentRunError(RuntimeError):
+    """Raised when a notebook is already running and force=False."""
+
+
+@dataclass
+class RunResult:
+    """Result of a benchmark notebook execution.
+
+    Attributes:
+        status: One of "queued", "running", "complete", "error",
+            "cancelled", or "timeout".
+        output_dir: String path to the output directory (not Path,
+            for JSON serialization). None if no output available.
+        tracking_url: URL to the notebook on Kaggle.
+        error: Error message (if any).
+    """
+
+    status: str
+    output_dir: str | None
+    tracking_url: str | None
+    error: str | None = None
+
+    def iter_run_results(self) -> Iterator[tuple[str, dict[str, Any]]]:
+        """Yields (filename, parsed_data) for all *run.json files in the output directory."""
+        if not self.output_dir or not (output_path := Path(self.output_dir)).exists():
+            return
+
+        for run_file in output_path.glob("*run.json"):
+            yield run_file.name, json.loads(run_file.read_text(encoding="utf-8"))
+
+
+# =============================================================================
+# Module-level helper functions (authentication)
+# =============================================================================
+
+_AUTH_ERROR_INSTRUCTIONS = (
+    "To authenticate, use one of the following methods (in priority order):\n\n"
+    "  Option 1: Bearer token (recommended)\n"
+    "    export KAGGLE_API_TOKEN=<your-token>\n"
+    "    Or save your token to ~/.kaggle/access_token\n\n"
+    "  Option 2: Basic auth via environment variables\n"
+    "    export KAGGLE_USERNAME=<your-username>\n"
+    "    export KAGGLE_KEY=<your-api-key>\n\n"
+    "  Option 3: Basic auth via credentials file\n"
+    "    Save kaggle.json to ~/.kaggle/kaggle.json\n\n"
+    "Get your API token at: https://www.kaggle.com/settings\n"
+    "Docs: https://github.com/Kaggle/kagglehub/tree/main#authenticate"
+)
+
+
+def _authenticate() -> tuple[Any, str]:
+    """Authenticate with the Kaggle API and resolve the username.
+
+    Credential resolution relies on the kagglesdk for token introspection
+    and kagglehub for standard Basic auth/json fallbacks.
+
+    Returns:
+        A tuple of (KaggleClient, username).
+
+    Raises:
+        KaggleAuthError: If the SDK is missing, no credentials are found,
+            or the username cannot be determined.
+    """
+    try:
+        from kagglesdk.kaggle_client import KaggleClient
+        from kagglesdk.kaggle_env import get_access_token_from_env, get_env
+        from kagglesdk.security.types.oauth_service import IntrospectTokenRequest
+    except ImportError as e:
+        raise KaggleAuthError(
+            "The 'kagglesdk' package is required. Install with:\n"
+            "  pip install kaggle-benchmarks[kaggle-client]"
+        ) from e
+
+    try:
+        client = KaggleClient(env=get_env())
+    except Exception as e:
+        raise KaggleAuthError(
+            f"Kaggle authentication failed: {e}\n\n{_AUTH_ERROR_INSTRUCTIONS}"
+        ) from e
+
+    def get_token_user() -> str | None:
+        if api_token := get_access_token_from_env()[0]:
+            try:
+                req = IntrospectTokenRequest()
+                req.token = api_token
+                resp = client.security.oauth_client.introspect_token(req)
+                return resp.username if resp.active else None
+            except Exception:
+                pass
+        return None
+
+    def get_hub_user() -> str | None:
+        try:
+            import kagglehub
+
+            return (
+                creds.username
+                if (creds := kagglehub.config.get_kaggle_credentials())
+                else None
+            )
+        except Exception:
+            return None
+
+    username = client.username or get_token_user() or get_hub_user()
+
+    if not username:
+        raise KaggleAuthError(
+            f"No Kaggle credentials found or invalid.\n\n{_AUTH_ERROR_INSTRUCTIONS}"
+        )
+
+    return client, username
+
+
+# =============================================================================
+# Client class
+# =============================================================================
+
+
+class BenchmarkNotebookClient:
+    """Client for the Kaggle benchmark notebook workflow.
+
+    Wraps the Kaggle SDK (kagglesdk) to handle publishing, running,
+    and retrieving results from benchmark notebooks (tagged with
+    'personal-benchmark' keyword).
+    """
+
+    BENCHMARK_FILENAME = "benchmark.py"
+    NOTEBOOK_FILENAME = "benchmark.ipynb"
+    METADATA_FILENAME = "kernel-metadata.json"
+    OUTPUT_DIRNAME = "output"
+
+    # Retry config for initial 404s from get_kernel_session_status after save_kernel.
+    _STATUS_RETRIES = 5
+    _STATUS_RETRY_WAIT = 10  # seconds
+
+    # =========================================================================
+    # Authentication & Identity
+    # =========================================================================
+
+    def __init__(
+        self,
+        base_dir: str | Path = ".",
+    ):
+        """Initialize the BenchmarkNotebookClient.
+
+        Args:
+            base_dir: Parent directory for benchmark workspaces.
+        """
+        self.api, self.username = _authenticate()
+        self.base_dir = Path(base_dir)
+
+    # =========================================================================
+    # Forking
+    # =========================================================================
+
+    def fork(
+        self,
+        source_notebook_id: str,
+        dest_notebook_slug: str | None = None,
+        overwrite: bool = False,
+    ) -> Path:
+        """Pull an existing benchmark from Kaggle as a starting point.
+
+        Workspace: <base_dir>/<dest_notebook_slug>/
+
+        Downloads via get_kernel() and converts:
+        1. Pulls the .ipynb source and kernel metadata
+        2. Writes the source as benchmark.ipynb
+        3. Converts benchmark.ipynb -> benchmark.py with # %% cell delimiters
+        4. Reconstructs kernel-metadata.json from API response
+
+        The kernel-metadata.json is preserved so that publish_and_run()
+        can reuse it.
+
+        Args:
+            source_notebook_id: Full Kaggle notebook path including owner
+                (e.g., 'alice/riddle-benchmark').
+            dest_notebook_slug: Local name for the benchmark directory.
+                Defaults to the basename of source_notebook_id.
+            overwrite: If True, replace the existing workspace directory.
+                If False (default), raises FileExistsError.
+
+        Returns:
+            Path to the workspace directory containing the .py file.
+        """
+        if dest_notebook_slug is None:
+            dest_notebook_slug = source_notebook_id.split("/")[-1]
+
+        workspace = self._workspace(dest_notebook_slug)
+
+        if workspace.exists():
+            if not overwrite:
+                raise FileExistsError(
+                    f"Workspace already exists: {workspace}. "
+                    "Use overwrite=True to replace it."
+                )
+            shutil.rmtree(workspace)
+
+        workspace.mkdir(parents=True, exist_ok=True)
+
+        # Pull notebook source and metadata from Kaggle via get_kernel()
+        from kagglesdk.kernels.types.kernels_api_service import (
+            ApiGetKernelRequest,
+        )
+        from requests.exceptions import HTTPError
+
+        try:
+            req = ApiGetKernelRequest()
+            req.user_name, req.kernel_slug = source_notebook_id.split("/")
+            response = self.api.kernels.kernels_api_client.get_kernel(req)
+        except HTTPError as e:
+            raise ValueError(
+                f"Failed to pull notebook '{source_notebook_id}'. "
+                "Ensure the notebook exists, is public (or you have access), "
+                "and you have accepted any necessary competition rules."
+            ) from e
+
+        # Write the notebook source to benchmark.ipynb
+        # response.blob.source is exactly the raw .ipynb JSON for notebook-type kernels
+        if response.blob and response.blob.source:
+            ipynb_path = workspace / self.NOTEBOOK_FILENAME
+            ipynb_path.write_text(response.blob.source, encoding="utf-8")
+
+            # Convert .ipynb to .py with # %% cell delimiters
+            py_path = workspace / self.BENCHMARK_FILENAME
+            kaggle_utils.convert_ipynb_to_py(ipynb_path, py_path)
+        else:
+            logger.warning(
+                "No source found after pulling '%s'. "
+                "The notebook may be a script notebook.",
+                source_notebook_id,
+            )
+
+        # Reconstruct kernel-metadata.json from response.metadata
+        if response.metadata:
+            metadata = kaggle_utils.parse_remote_metadata(
+                meta=response.metadata,
+                default_id=source_notebook_id,
+                default_slug=dest_notebook_slug,
+            )
+            meta_path = workspace / self.METADATA_FILENAME
+            meta_path.write_text(json.dumps(metadata, indent=4), encoding="utf-8")
+
+        return workspace
+
+    # =========================================================================
+    # Publish & Run
+    # =========================================================================
+
+    def publish_and_run(
+        self,
+        notebook_slug: str,
+        source_file: str | Path | None = None,
+        dataset_sources: list[str] | None = None,
+        force: bool = False,
+    ) -> str:
+        """Convert .py -> .ipynb, push to Kaggle, and trigger execution.
+
+        Workspace: <base_dir>/<notebook_slug>/
+
+        A notebook acts as the execution vehicle for your benchmark tasks. While you
+        can define and run multiple tasks within a single notebook, the Kaggle
+        leaderboard currently requires a single "main" task per notebook to be saved
+        and evaluated. You can use the `%choose <task_name>` magic command at the end
+        of your notebook to select which task's results to publish.
+
+        For more details on task selection, see:
+        https://github.com/Kaggle/kaggle-benchmarks/blob/ci/quick_start.md#82-using-choose-to-select-a-notebooks-task
+
+        Args:
+            notebook_slug: Short notebook name (e.g., 'my-benchmark').
+            source_file: Optional path to a .py file to copy into workspace. It will replace benchmark.py.
+            dataset_sources: Optional list of Kaggle dataset slugs (e.g., ``["owner/dataset-name"]``)
+                to mount at ``/kaggle/input/``.
+            force: If True, push even if a previous run is in progress.
+
+        Returns:
+            Tracking URL for the running notebook.
+
+        Raises:
+            FileNotFoundError: If benchmark.py not found in workspace.
+            ConcurrentRunError: If a concurrent run is detected and force=False.
+        """
+        from requests.exceptions import HTTPError
+
+        workspace = self._workspace(notebook_slug)
+        workspace.mkdir(parents=True, exist_ok=True)
+        benchmark_py = workspace / self.BENCHMARK_FILENAME
+
+        # Copy source_file into workspace (if provided)
+        if source_file is not None:
+            source = Path(source_file)
+            if not source.exists():
+                raise FileNotFoundError(f"Source file not found: {source}")
+            shutil.copy2(source, benchmark_py)
+
+        if not benchmark_py.exists():
+            raise FileNotFoundError(
+                f"Benchmark file not found: {benchmark_py}. "
+                f"Create it or pass source_file to copy from."
+            )
+
+        # Resolve metadata (load existing kernel-metadata.json or generate new)
+        # 'personal-benchmark' keyword is ensured by resolve_metadata
+        metadata = kaggle_utils.build_local_metadata(
+            workspace_dir=workspace,
+            notebook_slug=notebook_slug,
+            username=self.username,
+            dataset_sources=dataset_sources,
+        )
+
+        # Convert benchmark.py (.py with # %% delimiters) to .ipynb
+        notebook_path = workspace / self.NOTEBOOK_FILENAME
+        kaggle_utils.convert_py_to_ipynb(benchmark_py, notebook_path)
+
+        # Concurrent run guard
+        notebook_id = self._notebook_id(notebook_slug)
+        if not force:
+            try:
+                status = self._get_kernel_session_status(notebook_id)
+                if status in ("queued", "running"):
+                    raise ConcurrentRunError(
+                        f"Notebook '{notebook_id}' is already running "
+                        f"(status: {status}). "
+                        "Use force=True to push a new version anyway."
+                    )
+            except HTTPError as e:
+                if e.response.status_code == 404:
+                    pass  # No existing notebook — safe to push
+                else:
+                    raise
+
+        # Write metadata to disk (for local inspection and fork reuse)
+        meta_path = workspace / self.METADATA_FILENAME
+        meta_path.write_text(json.dumps(metadata, indent=4), encoding="utf-8")
+
+        # Read the generated .ipynb and push inline via save_kernel
+        notebook_content = notebook_path.read_text(encoding="utf-8")
+        req = self._build_save_request(
+            notebook_id=self._notebook_id(notebook_slug),
+            notebook_content=notebook_content,
+            metadata=metadata,
+        )
+
+        response = self.api.kernels.kernels_api_client.save_kernel(req)
+        if response.error:
+            raise RuntimeError(f"Kaggle push failed: {response.error}")
+
+        return self._tracking_url(notebook_slug)
+
+    def _build_save_request(
+        self,
+        notebook_id: str,
+        notebook_content: str,
+        metadata: dict[str, Any],
+    ):
+        """Build the API request to save/push a notebook."""
+        from kagglesdk.kernels.types.kernels_api_service import ApiSaveKernelRequest
+
+        req = ApiSaveKernelRequest()
+
+        # Special required fields
+        req.slug = notebook_id
+        req.new_title = metadata.get("title", notebook_id.split("/")[-1])
+        req.text = notebook_content
+
+        # Map the remaining configured attributes dynamically
+        for json_key, (api_key, _) in kaggle_utils.KAGGLE_METADATA_MAP.items():
+            if json_key in metadata:
+                setattr(req, api_key, metadata[json_key])
+
+        return req
+
+    # =========================================================================
+    # Polling & Results
+    # =========================================================================
+
+    def get_results(
+        self,
+        notebook_slug: str,
+        output_dir: str | None = None,
+        poll_interval: int = 60,
+        timeout: int | None = None,
+        cancel_event: threading.Event | None = None,
+        on_status: Callable[[str], None] | None = None,
+        clear_output: bool = True,
+    ) -> RunResult:
+        """Poll execution status and download output files.
+
+        Workspace: <base_dir>/<notebook_slug>/
+
+        Polls get_kernel_session_status() until the notebook completes (or fails),
+        then downloads output via download_kernel_output().
+
+        Neither timeout nor cancel_event stops the Kaggle run itself —
+        the notebook continues executing on Kaggle. They only stop
+        the local polling.
+
+        Args:
+            notebook_slug: Short notebook name (e.g., 'my-benchmark').
+            output_dir: Where to save output files (defaults to
+                <base_dir>/<notebook_slug>/output/).
+            poll_interval: Seconds between status checks.
+            timeout: Maximum seconds to wait before returning
+                RunResult(status="timeout"). None means wait indefinitely.
+            cancel_event: A threading.Event; when set, the poll loop exits
+                with RunResult(status="cancelled").
+            on_status: Callback invoked when the notebook status changes.
+            clear_output: If True (default), clear the output directory
+                before downloading new output. If False, download into
+                the existing directory without clearing.
+
+        Returns:
+            RunResult with status, output path, and parsed run.json data.
+        """
+        notebook_id = self._notebook_id(notebook_slug)
+        workspace = self._workspace(notebook_slug)
+        tracking_url = self._tracking_url(notebook_slug)
+
+        if output_dir is None:
+            output_path = workspace / self.OUTPUT_DIRNAME
+        else:
+            output_path = Path(output_dir)
+
+        status_str = self._wait_for_notebook_creation(notebook_id)
+        if status_str is None:
+            return RunResult(
+                status="error",
+                output_dir=None,
+                tracking_url=tracking_url,
+                error=(
+                    f"Failed to find notebook '{notebook_id}' "
+                    f"after {self._STATUS_RETRIES} retries."
+                ),
+            )
+
+        final_status = self._poll_notebook_status(
+            notebook_id=notebook_id,
+            initial_status=status_str,
+            poll_interval=poll_interval,
+            timeout=timeout,
+            cancel_event=cancel_event,
+            on_status=on_status,
+        )
+
+        if final_status != "complete":
+            error_msg = None
+            if final_status not in ("timeout", "cancelled"):
+                error_msg = f"Notebook execution finished with status: {final_status}"
+
+            return RunResult(
+                status=final_status,
+                output_dir=None,
+                tracking_url=tracking_url,
+                error=error_msg,
+            )
+
+        self._download_notebook_output(notebook_id, output_path, clear_output)
+
+        return RunResult(
+            status="complete",
+            output_dir=str(output_path),
+            tracking_url=tracking_url,
+        )
+
+    def _wait_for_notebook_creation(self, notebook_id: str) -> str | None:
+        """Wait for Kaggle to index a newly pushed notebook.
+
+        Returns:
+            The initial status string, or None if retries exceeded.
+        """
+        from requests.exceptions import HTTPError
+
+        for attempt in range(self._STATUS_RETRIES):
+            try:
+                return self._get_kernel_session_status(notebook_id)
+            except HTTPError as e:
+                if e.response.status_code == 404:
+                    logger.info(
+                        "Notebook not found yet (attempt %d/%d), waiting...",
+                        attempt + 1,
+                        self._STATUS_RETRIES,
+                    )
+                    time.sleep(self._STATUS_RETRY_WAIT)
+                else:
+                    raise
+        return None
+
+    def _poll_notebook_status(
+        self,
+        notebook_id: str,
+        initial_status: str,
+        poll_interval: int,
+        timeout: int | None,
+        cancel_event: threading.Event | None,
+        on_status: Callable[[str], None] | None,
+    ) -> str:
+        """Poll notebook status until complete, error, cancelled, or timeout."""
+        status_str = initial_status
+        last_reported_status = None
+        start_time = time.monotonic()
+
+        while status_str not in ("complete", "error", "cancelled"):
+            if cancel_event is not None and cancel_event.is_set():
+                return "cancelled"
+
+            if timeout is not None and (time.monotonic() - start_time) >= timeout:
+                return "timeout"
+
+            if on_status is not None and status_str != last_reported_status:
+                on_status(status_str)
+                last_reported_status = status_str
+
+            # Wait with cancel_event support for early exit
+            if cancel_event is not None:
+                cancel_event.wait(poll_interval)
+                if cancel_event.is_set():
+                    return "cancelled"
+            else:
+                time.sleep(poll_interval)
+
+            status_str = self._get_kernel_session_status(notebook_id)
+
+        # Report final status
+        if on_status is not None and status_str != last_reported_status:
+            on_status(status_str)
+
+        return status_str
+
+    def _download_notebook_output(
+        self, notebook_id: str, output_path: Path, clear_output: bool
+    ) -> None:
+        """Clear existing output (if requested) and download new output from Kaggle."""
+        from kagglesdk.kernels.types.kernels_api_service import (
+            ApiDownloadKernelOutputRequest,
+        )
+
+        if clear_output and output_path.exists():
+            shutil.rmtree(output_path)
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        # Build request (no file_path -> downloads all output as archive)
+        req = ApiDownloadKernelOutputRequest()
+        req.owner_slug, req.kernel_slug = notebook_id.split("/")
+
+        # download_kernel_output returns a streamed requests.Response
+        response = self.api.kernels.kernels_api_client.download_kernel_output(req)
+
+        # Save the archive to a temp file, then extract
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".archive") as tmp:
+            for chunk in response.iter_content(chunk_size=8192):
+                tmp.write(chunk)
+            archive_path = tmp.name
+
+        try:
+            if tarfile.is_tarfile(archive_path):
+                with tarfile.open(archive_path) as tf:
+                    tf.extractall(output_path)
+            elif zipfile.is_zipfile(archive_path):
+                with zipfile.ZipFile(archive_path, "r") as zf:
+                    zf.extractall(output_path)
+            else:
+                raise RuntimeError("Unexpected archive format from Kaggle API")
+        finally:
+            os.remove(archive_path)
+
+    def _get_kernel_session_status(self, notebook_id: str):
+        """Get the session status for a notebook via kagglesdk.
+
+        Args:
+            notebook_id: Full notebook ID (format: "username/slug").
+
+        Returns:
+            The normalized status string.
+        """
+        from kagglesdk.kernels.types.kernels_api_service import (
+            ApiGetKernelSessionStatusRequest,
+        )
+
+        user_name, kernel_slug = notebook_id.split("/")
+        req = ApiGetKernelSessionStatusRequest()
+        req.user_name = user_name
+        req.kernel_slug = kernel_slug
+        response = self.api.kernels.kernels_api_client.get_kernel_session_status(req)
+        return kaggle_utils.normalize_status(response)
+
+    # =========================================================================
+    # Internal Utilities
+    # =========================================================================
+
+    def _workspace(self, notebook_slug: str) -> Path:
+        """Return the workspace directory for a notebook slug."""
+        return self.base_dir / notebook_slug
+
+    def _notebook_id(self, notebook_slug: str) -> str:
+        """Return the full notebook ID (username/slug)."""
+        return f"{self.username}/{notebook_slug}"
+
+    def _tracking_url(self, notebook_slug: str) -> str:
+        """Return the Kaggle tracking URL for a notebook."""
+        return f"https://www.kaggle.com/{self._notebook_id(notebook_slug)}"

--- a/src/kaggle_benchmarks/kaggle_client/utils.py
+++ b/src/kaggle_benchmarks/kaggle_client/utils.py
@@ -39,6 +39,13 @@ def convert_py_to_ipynb(py_path: str | Path, ipynb_path: str | Path) -> None:
         )
 
     notebook = jupytext.reads(content, fmt="py:percent")
+
+    # Kaggle's notebook runner (papermill) requires a kernelspec to evaluate cells.
+    notebook.metadata.setdefault(
+        "kernelspec",
+        {"display_name": "Python 3", "language": "python", "name": "python3"},
+    )
+
     jupytext.write(notebook, ipynb_path)
 
 

--- a/src/kaggle_benchmarks/kaggle_client/utils.py
+++ b/src/kaggle_benchmarks/kaggle_client/utils.py
@@ -166,7 +166,7 @@ def parse_remote_metadata(
 # ---------------------------------------------------------------------------
 
 
-def normalize_status(status: object) -> str:
+def normalize_status(status: Any) -> str:
     """Normalize a Kaggle notebook status to a lowercase string.
 
     The Kaggle API may return a KernelWorkerStatus enum

--- a/src/kaggle_benchmarks/kaggle_client/utils.py
+++ b/src/kaggle_benchmarks/kaggle_client/utils.py
@@ -12,11 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Utility functions for the Kaggle benchmark client."""
+
 import json
 import re
 import warnings
 from pathlib import Path
 from typing import Any
+
+# ---------------------------------------------------------------------------
+# File format conversion
+# ---------------------------------------------------------------------------
 
 
 def convert_py_to_ipynb(py_path: str | Path, ipynb_path: str | Path) -> None:
@@ -39,6 +45,13 @@ def convert_py_to_ipynb(py_path: str | Path, ipynb_path: str | Path) -> None:
         )
 
     notebook = jupytext.reads(content, fmt="py:percent")
+
+    # Kaggle's notebook runner (papermill) requires a kernelspec to evaluate cells.
+    notebook.metadata.setdefault(
+        "kernelspec",
+        {"display_name": "Python 3", "language": "python", "name": "python3"},
+    )
+
     jupytext.write(notebook, ipynb_path)
 
 
@@ -50,7 +63,30 @@ def convert_ipynb_to_py(ipynb_path: str | Path, py_path: str | Path) -> None:
     jupytext.write(notebook, py_path, fmt="py:percent")
 
 
-def resolve_metadata(
+# ---------------------------------------------------------------------------
+# Metadata
+# ---------------------------------------------------------------------------
+
+
+# Maps kernel-metadata.json keys to (ApiSaveKernelRequest attribute, default value)
+KAGGLE_METADATA_MAP = {
+    "language": ("language", "python"),
+    "kernel_type": ("kernel_type", "notebook"),
+    "is_private": ("is_private", True),
+    "enable_gpu": ("enable_gpu", False),
+    "enable_tpu": ("enable_tpu", False),
+    "enable_internet": ("enable_internet", True),
+    "dataset_sources": ("dataset_data_sources", []),
+    "competition_sources": ("competition_data_sources", []),
+    "kernel_sources": ("kernel_data_sources", []),
+    "model_sources": ("model_data_sources", []),
+    "keywords": ("category_ids", []),
+    "docker_image": ("docker_image", None),
+    "machine_shape": ("machine_shape", "None"),
+}
+
+
+def build_local_metadata(
     workspace_dir: Path | str,
     notebook_slug: str,
     username: str,
@@ -59,32 +95,18 @@ def resolve_metadata(
     title: str | None = None,
     **kwargs,
 ) -> dict[str, Any]:
-    """Assembles the kernel-metadata.json payload for Kaggle.
+    """Builds the local `kernel-metadata.json` dictionary for pushing to Kaggle.
 
-    Loads existing metadata if present, applies overrides, and ensures
-    mandatory fields/tags are set.
+    Loads existing workspace metadata, merges runtime CLI overrides, and enforces
+    required benchmark schemas (such as the 'personal-benchmark' tag).
     """
     meta_path = Path(workspace_dir) / "kernel-metadata.json"
 
-    if meta_path.exists():
-        metadata = json.loads(meta_path.read_text(encoding="utf-8"))
-    else:
-        # Default metadata template for new notebooks.
-        # See: https://github.com/Kaggle/kaggle-cli/blob/main/docs/kernels_metadata.md
-        metadata = {
-            "language": "python",
-            "kernel_type": "notebook",
-            "enable_gpu": False,
-            "enable_tpu": False,
-            "enable_internet": True,  # Required for LLM API calls
-            "dataset_sources": [],  # Kaggle datasets to mount at /kaggle/input/
-            "competition_sources": [],
-            "kernel_sources": [],
-            "model_sources": [],
-            "keywords": [],  # Tags; we ensure "personal-benchmark" is added
-            "docker_image": None,  # Custom docker image (future use)
-            "machine_shape": "None",  # "None" = default, "gpu", "tpu" etc.
-        }
+    metadata = (
+        json.loads(meta_path.read_text(encoding="utf-8")) if meta_path.exists() else {}
+    )
+    for json_key, (_, default_val) in KAGGLE_METADATA_MAP.items():
+        metadata.setdefault(json_key, default_val)
 
     # --- Mandatory overrides ---
     overrides = {
@@ -109,8 +131,48 @@ def resolve_metadata(
     metadata.update(overrides)
 
     # Ensure "personal-benchmark" tag is present.
-    keywords = metadata.setdefault("keywords", [])
-    if "personal-benchmark" not in keywords:
+    if "personal-benchmark" not in (keywords := metadata.setdefault("keywords", [])):
         keywords.append("personal-benchmark")
 
     return metadata
+
+
+def parse_remote_metadata(
+    meta: Any, default_id: str, default_slug: str
+) -> dict[str, Any]:
+    """Converts a Kaggle API `Kernel` object into a local `kernel-metadata.json` dictionary.
+
+    Translates SDK-specific attribute names (like `dataset_data_sources`) back into
+    standard Kaggle JSON fields to allow for local editing on disk.
+    """
+    meta_dict = {
+        "id": getattr(meta, "ref", default_id),
+        "title": getattr(meta, "title", default_slug),
+    }
+
+    for json_key, (api_key, default_val) in KAGGLE_METADATA_MAP.items():
+        val = getattr(meta, api_key, None)
+        # Handle repeated enum/list types cleanly by defaulting to []
+        if isinstance(default_val, list):
+            meta_dict[json_key] = list(val or [])
+        else:
+            meta_dict[json_key] = val if val is not None else default_val
+
+    return meta_dict
+
+
+# ---------------------------------------------------------------------------
+# Status normalization
+# ---------------------------------------------------------------------------
+
+
+def normalize_status(status: Any) -> str:
+    """Normalize a Kaggle notebook status to a lowercase string.
+
+    The Kaggle API may return a KernelWorkerStatus enum
+    (e.g. "KernelWorkerStatus.complete") or a plain string.
+    This method normalizes both to a simple lowercase string
+    like "complete".
+    """
+    status_raw = getattr(status, "status", status)
+    return str(status_raw).lower().split(".")[-1]

--- a/src/kaggle_benchmarks/kaggle_client/utils.py
+++ b/src/kaggle_benchmarks/kaggle_client/utils.py
@@ -12,11 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Utility functions for the Kaggle benchmark client."""
+
 import json
 import re
 import warnings
 from pathlib import Path
 from typing import Any
+
+# ---------------------------------------------------------------------------
+# File format conversion
+# ---------------------------------------------------------------------------
 
 
 def convert_py_to_ipynb(py_path: str | Path, ipynb_path: str | Path) -> None:
@@ -57,7 +63,30 @@ def convert_ipynb_to_py(ipynb_path: str | Path, py_path: str | Path) -> None:
     jupytext.write(notebook, py_path, fmt="py:percent")
 
 
-def resolve_metadata(
+# ---------------------------------------------------------------------------
+# Metadata
+# ---------------------------------------------------------------------------
+
+
+# Maps kernel-metadata.json keys to (ApiSaveKernelRequest attribute, default value)
+KAGGLE_METADATA_MAP = {
+    "language": ("language", "python"),
+    "kernel_type": ("kernel_type", "notebook"),
+    "is_private": ("is_private", True),
+    "enable_gpu": ("enable_gpu", False),
+    "enable_tpu": ("enable_tpu", False),
+    "enable_internet": ("enable_internet", True),
+    "dataset_sources": ("dataset_data_sources", []),
+    "competition_sources": ("competition_data_sources", []),
+    "kernel_sources": ("kernel_data_sources", []),
+    "model_sources": ("model_data_sources", []),
+    "keywords": ("category_ids", []),
+    "docker_image": ("docker_image", None),
+    "machine_shape": ("machine_shape", "None"),
+}
+
+
+def build_local_metadata(
     workspace_dir: Path | str,
     notebook_slug: str,
     username: str,
@@ -66,32 +95,18 @@ def resolve_metadata(
     title: str | None = None,
     **kwargs,
 ) -> dict[str, Any]:
-    """Assembles the kernel-metadata.json payload for Kaggle.
+    """Builds the local `kernel-metadata.json` dictionary for pushing to Kaggle.
 
-    Loads existing metadata if present, applies overrides, and ensures
-    mandatory fields/tags are set.
+    Loads existing workspace metadata, merges runtime CLI overrides, and enforces
+    required benchmark schemas (such as the 'personal-benchmark' tag).
     """
     meta_path = Path(workspace_dir) / "kernel-metadata.json"
 
-    if meta_path.exists():
-        metadata = json.loads(meta_path.read_text(encoding="utf-8"))
-    else:
-        # Default metadata template for new notebooks.
-        # See: https://github.com/Kaggle/kaggle-cli/blob/main/docs/kernels_metadata.md
-        metadata = {
-            "language": "python",
-            "kernel_type": "notebook",
-            "enable_gpu": False,
-            "enable_tpu": False,
-            "enable_internet": True,  # Required for LLM API calls
-            "dataset_sources": [],  # Kaggle datasets to mount at /kaggle/input/
-            "competition_sources": [],
-            "kernel_sources": [],
-            "model_sources": [],
-            "keywords": [],  # Tags; we ensure "personal-benchmark" is added
-            "docker_image": None,  # Custom docker image (future use)
-            "machine_shape": "None",  # "None" = default, "gpu", "tpu" etc.
-        }
+    metadata = (
+        json.loads(meta_path.read_text(encoding="utf-8")) if meta_path.exists() else {}
+    )
+    for json_key, (_, default_val) in KAGGLE_METADATA_MAP.items():
+        metadata.setdefault(json_key, default_val)
 
     # --- Mandatory overrides ---
     overrides = {
@@ -116,8 +131,48 @@ def resolve_metadata(
     metadata.update(overrides)
 
     # Ensure "personal-benchmark" tag is present.
-    keywords = metadata.setdefault("keywords", [])
-    if "personal-benchmark" not in keywords:
+    if "personal-benchmark" not in (keywords := metadata.setdefault("keywords", [])):
         keywords.append("personal-benchmark")
 
     return metadata
+
+
+def parse_remote_metadata(
+    meta: Any, default_id: str, default_slug: str
+) -> dict[str, Any]:
+    """Converts a Kaggle API `Kernel` object into a local `kernel-metadata.json` dictionary.
+
+    Translates SDK-specific attribute names (like `dataset_data_sources`) back into
+    standard Kaggle JSON fields to allow for local editing on disk.
+    """
+    meta_dict = {
+        "id": getattr(meta, "ref", default_id),
+        "title": getattr(meta, "title", default_slug),
+    }
+
+    for json_key, (api_key, default_val) in KAGGLE_METADATA_MAP.items():
+        val = getattr(meta, api_key, None)
+        # Handle repeated enum/list types cleanly by defaulting to []
+        if isinstance(default_val, list):
+            meta_dict[json_key] = list(val or [])
+        else:
+            meta_dict[json_key] = val if val is not None else default_val
+
+    return meta_dict
+
+
+# ---------------------------------------------------------------------------
+# Status normalization
+# ---------------------------------------------------------------------------
+
+
+def normalize_status(status: object) -> str:
+    """Normalize a Kaggle notebook status to a lowercase string.
+
+    The Kaggle API may return a KernelWorkerStatus enum
+    (e.g. "KernelWorkerStatus.complete") or a plain string.
+    This method normalizes both to a simple lowercase string
+    like "complete".
+    """
+    status_raw = getattr(status, "status", status)
+    return str(status_raw).lower().split(".")[-1]

--- a/tests/kaggle_client/test_cli.py
+++ b/tests/kaggle_client/test_cli.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the kaggle-bench CLI entry point."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+def test_cli_help(capsys):
+    """kaggle-bench --help exits cleanly and shows subcommands."""
+    from kaggle_benchmarks.kaggle_client.cli import run
+    with pytest.raises(SystemExit) as exc:
+        with patch("sys.argv", ["kaggle-bench", "--help"]):
+            run()
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    assert "run" in captured.out
+    assert "fork" in captured.out
+
+
+def test_cli_run_help(capsys):
+    """kaggle-bench run --help shows run-specific options."""
+    from kaggle_benchmarks.kaggle_client.cli import run
+    with pytest.raises(SystemExit) as exc:
+        with patch("sys.argv", ["kaggle-bench", "run", "--help"]):
+            run()
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    assert "notebook_slug" in captured.out
+    assert "--force" in captured.out
+    assert "--wait" in captured.out
+
+
+def test_cli_fork_help(capsys):
+    """kaggle-bench fork --help shows fork-specific options."""
+    from kaggle_benchmarks.kaggle_client.cli import run
+    with pytest.raises(SystemExit) as exc:
+        with patch("sys.argv", ["kaggle-bench", "fork", "--help"]):
+            run()
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    assert "source_notebook_id" in captured.out
+    assert "--overwrite" in captured.out
+
+
+def test_cli_run_calls_publish_and_run(tmp_path):
+    """kaggle-bench run invokes publish_and_run with correct args."""
+    from kaggle_benchmarks.kaggle_client.cli import run
+    mock_client = MagicMock()
+    mock_client.publish_and_run.return_value = "https://kaggle.com/gastondana627/my-bench"
+    with patch("kaggle_benchmarks.kaggle_client.cli._get_client", return_value=mock_client):
+        with patch("sys.argv", ["kaggle-bench", "run", "my-bench"]):
+            run()
+    mock_client.publish_and_run.assert_called_once_with(
+        notebook_slug="my-bench",
+        source_file=None,
+        dataset_sources=None,
+        force=False,
+    )
+
+
+def test_cli_fork_calls_fork(tmp_path):
+    """kaggle-bench fork invokes client.fork with correct args."""
+    from kaggle_benchmarks.kaggle_client.cli import run
+    mock_client = MagicMock()
+    mock_client.fork.return_value = tmp_path
+    with patch("kaggle_benchmarks.kaggle_client.cli._get_client", return_value=mock_client):
+        with patch("sys.argv", ["kaggle-bench", "fork", "alice/riddle-benchmark"]):
+            run()
+    mock_client.fork.assert_called_once_with(
+        source_notebook_id="alice/riddle-benchmark",
+        dest_notebook_slug=None,
+        overwrite=False,
+    )

--- a/tests/kaggle_client/test_kaggle_client_utils.py
+++ b/tests/kaggle_client/test_kaggle_client_utils.py
@@ -251,38 +251,45 @@ def test_build_local_metadata_malformed_json(tmp_path):
 
 def test_parse_remote_metadata_from_api_response():
     """Extracts all fields from a fully populated API metadata object."""
-    meta = MagicMock()
-    meta.ref = "alice/my-benchmark"
-    meta.title = "My Benchmark"
-    meta.language = "python"
-    meta.kernel_type = "notebook"
-    meta.is_private = False
-    meta.enable_gpu = True
-    meta.enable_internet = True
-    meta.enable_tpu = False
-    meta.dataset_data_sources = ["alice/dataset"]
-    meta.competition_data_sources = ["comp1"]
-    meta.kernel_data_sources = ["alice/kernel"]
-    meta.model_data_sources = ["alice/model"]
-    meta.category_ids = ["personal-benchmark", "nlp"]
+    meta = MagicMock(
+        ref="alice/my-benchmark",
+        title="My Benchmark",
+        language="python",
+        kernel_type="notebook",
+        is_private=False,
+        enable_gpu=True,
+        enable_internet=True,
+        enable_tpu=False,
+        dataset_data_sources=["alice/dataset"],
+        competition_data_sources=["comp1"],
+        kernel_data_sources=["alice/kernel"],
+        model_data_sources=["alice/model"],
+        category_ids=["personal-benchmark", "nlp"],
+        docker_image="custom-image:latest",
+        machine_shape="T4",
+    )
 
     result = kaggle_utils.parse_remote_metadata(
         meta, default_id="fallback/id", default_slug="fallback"
     )
 
-    assert result["id"] == "alice/my-benchmark"
-    assert result["title"] == "My Benchmark"
-    assert result["language"] == "python"
-    assert result["kernel_type"] == "notebook"
-    assert result["is_private"] is False
-    assert result["enable_gpu"] is True
-    assert result["enable_internet"] is True
-    assert result["enable_tpu"] is False
-    assert result["dataset_sources"] == ["alice/dataset"]
-    assert result["competition_sources"] == ["comp1"]
-    assert result["kernel_sources"] == ["alice/kernel"]
-    assert result["model_sources"] == ["alice/model"]
-    assert result["keywords"] == ["personal-benchmark", "nlp"]
+    assert result == {
+        "id": "alice/my-benchmark",
+        "title": "My Benchmark",
+        "language": "python",
+        "kernel_type": "notebook",
+        "is_private": False,
+        "enable_gpu": True,
+        "enable_tpu": False,
+        "enable_internet": True,
+        "dataset_sources": ["alice/dataset"],
+        "competition_sources": ["comp1"],
+        "kernel_sources": ["alice/kernel"],
+        "model_sources": ["alice/model"],
+        "keywords": ["personal-benchmark", "nlp"],
+        "docker_image": "custom-image:latest",
+        "machine_shape": "T4",
+    }
 
 
 def test_parse_remote_metadata_uses_defaults_for_missing_attrs():
@@ -293,47 +300,66 @@ def test_parse_remote_metadata_uses_defaults_for_missing_attrs():
         meta, default_id="owner/slug", default_slug="my-slug"
     )
 
-    assert result["id"] == "owner/slug"
-    assert result["title"] == "my-slug"
-    assert result["language"] == "python"
-    assert result["kernel_type"] == "notebook"
-    assert result["is_private"] is True
-    assert result["enable_gpu"] is False
-    assert result["enable_internet"] is True
-    assert result["enable_tpu"] is False
-    assert result["dataset_sources"] == []
-    assert result["competition_sources"] == []
-    assert result["kernel_sources"] == []
-    assert result["model_sources"] == []
-    assert result["keywords"] == []
+    assert result == {
+        "id": "owner/slug",
+        "title": "my-slug",
+        "language": "python",
+        "kernel_type": "notebook",
+        "is_private": True,
+        "enable_gpu": False,
+        "enable_tpu": False,
+        "enable_internet": True,
+        "dataset_sources": [],
+        "competition_sources": [],
+        "kernel_sources": [],
+        "model_sources": [],
+        "keywords": [],
+        "docker_image": None,
+        "machine_shape": "None",
+    }
 
 
 def test_parse_remote_metadata_handles_none_lists():
     """Converts None list fields to empty lists."""
-    meta = MagicMock()
-    meta.ref = "alice/bench"
-    meta.title = "Bench"
-    meta.language = "python"
-    meta.kernel_type = "notebook"
-    meta.is_private = True
-    meta.enable_gpu = False
-    meta.enable_internet = True
-    meta.enable_tpu = False
-    meta.dataset_data_sources = None
-    meta.competition_data_sources = None
-    meta.kernel_data_sources = None
-    meta.model_data_sources = None
-    meta.category_ids = None
+    meta = MagicMock(
+        ref="alice/bench",
+        title="Bench",
+        language="python",
+        kernel_type="notebook",
+        is_private=True,
+        enable_gpu=False,
+        enable_tpu=False,
+        enable_internet=True,
+        dataset_data_sources=None,
+        competition_data_sources=None,
+        kernel_data_sources=None,
+        model_data_sources=None,
+        category_ids=None,
+        docker_image=None,
+        machine_shape=None,
+    )
 
     result = kaggle_utils.parse_remote_metadata(
         meta, default_id="x/y", default_slug="y"
     )
 
-    assert result["dataset_sources"] == []
-    assert result["competition_sources"] == []
-    assert result["kernel_sources"] == []
-    assert result["model_sources"] == []
-    assert result["keywords"] == []
+    assert result == {
+        "id": "alice/bench",
+        "title": "Bench",
+        "language": "python",
+        "kernel_type": "notebook",
+        "is_private": True,
+        "enable_gpu": False,
+        "enable_tpu": False,
+        "enable_internet": True,
+        "dataset_sources": [],
+        "competition_sources": [],
+        "kernel_sources": [],
+        "model_sources": [],
+        "keywords": [],
+        "docker_image": None,
+        "machine_shape": "None",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/kaggle_client/test_kaggle_client_utils.py
+++ b/tests/kaggle_client/test_kaggle_client_utils.py
@@ -17,15 +17,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from kaggle_benchmarks.kaggle_client.utils import (
-    build_local_metadata,
-    convert_ipynb_to_py,
-    convert_py_to_ipynb,
-    normalize_status,
-    parse_remote_metadata,
-)
-
-_MOD = "kaggle_benchmarks.kaggle_client.utils"
+from kaggle_benchmarks.kaggle_client import utils as kaggle_utils
 
 # ---------------------------------------------------------------------------
 # File format conversion
@@ -44,7 +36,7 @@ print("Hello")
 """
     py_file.write_text(content)
 
-    convert_py_to_ipynb(py_file, ipynb_file)
+    kaggle_utils.convert_py_to_ipynb(py_file, ipynb_file)
 
     assert ipynb_file.exists()
     with open(ipynb_file, "r") as f:
@@ -73,7 +65,7 @@ print("World")
     py_file.write_text(content)
 
     with pytest.warns(UserWarning, match="has no '# %%' cell delimiters"):
-        convert_py_to_ipynb(py_file, ipynb_file)
+        kaggle_utils.convert_py_to_ipynb(py_file, ipynb_file)
 
     assert ipynb_file.exists()
 
@@ -101,7 +93,7 @@ def test_convert_ipynb_to_py(tmp_path):
     with open(ipynb_file, "w") as f:
         json.dump(notebook, f)
 
-    convert_ipynb_to_py(ipynb_file, py_file)
+    kaggle_utils.convert_ipynb_to_py(ipynb_file, py_file)
 
     assert py_file.exists()
     content = py_file.read_text()
@@ -128,8 +120,8 @@ x = 42
 """
     py_file.write_text(content)
 
-    convert_py_to_ipynb(py_file, ipynb_file)
-    convert_ipynb_to_py(ipynb_file, py_roundtrip)
+    kaggle_utils.convert_py_to_ipynb(py_file, ipynb_file)
+    kaggle_utils.convert_ipynb_to_py(ipynb_file, py_roundtrip)
 
     roundtrip_content = py_roundtrip.read_text()
     assert "# %% [markdown]" in roundtrip_content
@@ -148,7 +140,7 @@ def test_build_local_metadata_new(tmp_path):
     slug = "my-bench"
     username = "alice"
 
-    metadata = build_local_metadata(workspace, slug, username)
+    metadata = kaggle_utils.build_local_metadata(workspace, slug, username)
 
     assert metadata["id"] == "alice/my-bench"
     assert metadata["title"] == "my-bench"  # Defaults to slug
@@ -165,7 +157,7 @@ def test_build_local_metadata_custom_title(tmp_path):
     slug = "my-bench"
     username = "alice"
 
-    metadata = build_local_metadata(
+    metadata = kaggle_utils.build_local_metadata(
         workspace, slug, username, title="My Awesome Benchmark"
     )
 
@@ -189,7 +181,7 @@ def test_build_local_metadata_existing(tmp_path):
     with open(workspace / "kernel-metadata.json", "w") as f:
         json.dump(existing, f)
 
-    metadata = build_local_metadata(
+    metadata = kaggle_utils.build_local_metadata(
         workspace, slug, username, dataset_sources=["alice/data"]
     )
 
@@ -207,7 +199,7 @@ def test_build_local_metadata_overrides(tmp_path):
     slug = "my-bench"
     username = "alice"
 
-    metadata = build_local_metadata(
+    metadata = kaggle_utils.build_local_metadata(
         workspace,
         slug,
         username,
@@ -237,7 +229,7 @@ def test_build_local_metadata_idempotent_keywords(tmp_path):
     with open(workspace / "kernel-metadata.json", "w") as f:
         json.dump(existing, f)
 
-    metadata = build_local_metadata(workspace, slug, username)
+    metadata = kaggle_utils.build_local_metadata(workspace, slug, username)
 
     assert metadata["keywords"].count("personal-benchmark") == 1
     assert "foo" in metadata["keywords"]
@@ -249,7 +241,7 @@ def test_build_local_metadata_malformed_json(tmp_path):
     (workspace / "kernel-metadata.json").write_text("not valid json")
 
     with pytest.raises(json.JSONDecodeError):
-        build_local_metadata(workspace, "my-bench", "alice")
+        kaggle_utils.build_local_metadata(workspace, "my-bench", "alice")
 
 
 # ---------------------------------------------------------------------------
@@ -274,7 +266,7 @@ def test_parse_remote_metadata_from_api_response():
     meta.model_data_sources = ["alice/model"]
     meta.category_ids = ["personal-benchmark", "nlp"]
 
-    result = parse_remote_metadata(
+    result = kaggle_utils.parse_remote_metadata(
         meta, default_id="fallback/id", default_slug="fallback"
     )
 
@@ -297,7 +289,7 @@ def test_parse_remote_metadata_uses_defaults_for_missing_attrs():
     """Falls back to defaults when API metadata has missing attributes."""
     meta = MagicMock(spec=[])  # spec=[] means no attributes exist
 
-    result = parse_remote_metadata(
+    result = kaggle_utils.parse_remote_metadata(
         meta, default_id="owner/slug", default_slug="my-slug"
     )
 
@@ -333,7 +325,9 @@ def test_parse_remote_metadata_handles_none_lists():
     meta.model_data_sources = None
     meta.category_ids = None
 
-    result = parse_remote_metadata(meta, default_id="x/y", default_slug="y")
+    result = kaggle_utils.parse_remote_metadata(
+        meta, default_id="x/y", default_slug="y"
+    )
 
     assert result["dataset_sources"] == []
     assert result["competition_sources"] == []
@@ -359,7 +353,7 @@ def test_parse_remote_metadata_handles_none_lists():
 )
 def test_normalize_status_strings(raw_status, expected):
     """normalize_status should strip enum prefixes and lower-case."""
-    assert normalize_status(raw_status) == expected
+    assert kaggle_utils.normalize_status(raw_status) == expected
 
 
 def test_normalize_status_object_with_attribute():
@@ -368,4 +362,4 @@ def test_normalize_status_object_with_attribute():
     class FakeStatus:
         status = "running"
 
-    assert normalize_status(FakeStatus()) == "running"
+    assert kaggle_utils.normalize_status(FakeStatus()) == "running"

--- a/tests/kaggle_client/test_kaggle_client_utils.py
+++ b/tests/kaggle_client/test_kaggle_client_utils.py
@@ -13,14 +13,23 @@
 # limitations under the License.
 
 import json
+from unittest.mock import MagicMock
 
 import pytest
 
 from kaggle_benchmarks.kaggle_client.utils import (
+    build_local_metadata,
     convert_ipynb_to_py,
     convert_py_to_ipynb,
-    resolve_metadata,
+    normalize_status,
+    parse_remote_metadata,
 )
+
+_MOD = "kaggle_benchmarks.kaggle_client.utils"
+
+# ---------------------------------------------------------------------------
+# File format conversion
+# ---------------------------------------------------------------------------
 
 
 def test_convert_py_to_ipynb(tmp_path):
@@ -102,113 +111,6 @@ def test_convert_ipynb_to_py(tmp_path):
     assert "print('Hello')" in content
 
 
-def test_resolve_metadata_new(tmp_path):
-    workspace = tmp_path
-    slug = "my-bench"
-    username = "alice"
-
-    metadata = resolve_metadata(workspace, slug, username)
-
-    assert metadata["id"] == "alice/my-bench"
-    assert metadata["title"] == "my-bench"  # Defaults to slug
-    assert metadata["id_no"] is None
-    assert "personal-benchmark" in metadata["keywords"]
-    assert metadata["is_private"] is True
-    assert "model_sources" in metadata
-    assert metadata["docker_image"] is None
-
-
-def test_resolve_metadata_custom_title(tmp_path):
-    """Test that title can be customized separately from slug."""
-    workspace = tmp_path
-    slug = "my-bench"
-    username = "alice"
-
-    metadata = resolve_metadata(workspace, slug, username, title="My Awesome Benchmark")
-
-    assert metadata["id"] == "alice/my-bench"  # slug used for id
-    assert metadata["title"] == "My Awesome Benchmark"  # custom title
-
-
-def test_resolve_metadata_existing(tmp_path):
-    workspace = tmp_path
-    slug = "my-bench"
-    username = "alice"
-
-    existing = {
-        "id": "bob/old-bench",
-        "title": "old-bench",
-        "id_no": 12345,
-        "keywords": ["foo"],
-        "docker_image": "some-image",
-    }
-
-    with open(workspace / "kernel-metadata.json", "w") as f:
-        json.dump(existing, f)
-
-    metadata = resolve_metadata(
-        workspace, slug, username, dataset_sources=["alice/data"]
-    )
-
-    assert metadata["id"] == "alice/my-bench"
-    assert metadata["title"] == "my-bench"
-    assert metadata["id_no"] is None
-    assert "personal-benchmark" in metadata["keywords"]
-    assert "foo" in metadata["keywords"]
-    assert metadata["docker_image"] == "some-image"
-    assert metadata["dataset_sources"] == ["alice/data"]
-
-
-def test_resolve_metadata_overrides(tmp_path):
-    workspace = tmp_path
-    slug = "my-bench"
-    username = "alice"
-
-    metadata = resolve_metadata(
-        workspace,
-        slug,
-        username,
-        enable_gpu=True,
-        enable_internet=False,
-        is_private=False,
-        docker_image="custom-image",
-    )
-
-    assert metadata["id"] == "alice/my-bench"
-    assert metadata["enable_gpu"] is True
-    assert metadata["enable_internet"] is False
-    assert metadata["is_private"] is False
-    assert metadata["docker_image"] == "custom-image"
-    assert metadata["enable_tpu"] is False  # Default
-
-
-def test_resolve_metadata_idempotent_keywords(tmp_path):
-    """Test that calling resolve_metadata doesn't duplicate 'personal-benchmark'."""
-    workspace = tmp_path
-    slug = "my-bench"
-    username = "alice"
-
-    existing = {
-        "keywords": ["personal-benchmark", "foo"],
-    }
-    with open(workspace / "kernel-metadata.json", "w") as f:
-        json.dump(existing, f)
-
-    metadata = resolve_metadata(workspace, slug, username)
-
-    assert metadata["keywords"].count("personal-benchmark") == 1
-    assert "foo" in metadata["keywords"]
-
-
-def test_resolve_metadata_malformed_json(tmp_path):
-    """Test behavior when kernel-metadata.json contains invalid JSON."""
-    workspace = tmp_path
-    (workspace / "kernel-metadata.json").write_text("not valid json")
-
-    with pytest.raises(json.JSONDecodeError):
-        resolve_metadata(workspace, "my-bench", "alice")
-
-
 def test_roundtrip_conversion(tmp_path):
     """Test that py -> ipynb -> py preserves cell structure."""
     py_file = tmp_path / "benchmark.py"
@@ -234,3 +136,236 @@ x = 42
     assert "# # Title" in roundtrip_content
     assert 'print("Hello")' in roundtrip_content
     assert "x = 42" in roundtrip_content
+
+
+# ---------------------------------------------------------------------------
+# build_local_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_build_local_metadata_new(tmp_path):
+    workspace = tmp_path
+    slug = "my-bench"
+    username = "alice"
+
+    metadata = build_local_metadata(workspace, slug, username)
+
+    assert metadata["id"] == "alice/my-bench"
+    assert metadata["title"] == "my-bench"  # Defaults to slug
+    assert metadata["id_no"] is None
+    assert "personal-benchmark" in metadata["keywords"]
+    assert metadata["is_private"] is True
+    assert "model_sources" in metadata
+    assert metadata["docker_image"] is None
+
+
+def test_build_local_metadata_custom_title(tmp_path):
+    """Test that title can be customized separately from slug."""
+    workspace = tmp_path
+    slug = "my-bench"
+    username = "alice"
+
+    metadata = build_local_metadata(
+        workspace, slug, username, title="My Awesome Benchmark"
+    )
+
+    assert metadata["id"] == "alice/my-bench"  # slug used for id
+    assert metadata["title"] == "My Awesome Benchmark"  # custom title
+
+
+def test_build_local_metadata_existing(tmp_path):
+    workspace = tmp_path
+    slug = "my-bench"
+    username = "alice"
+
+    existing = {
+        "id": "bob/old-bench",
+        "title": "old-bench",
+        "id_no": 12345,
+        "keywords": ["foo"],
+        "docker_image": "some-image",
+    }
+
+    with open(workspace / "kernel-metadata.json", "w") as f:
+        json.dump(existing, f)
+
+    metadata = build_local_metadata(
+        workspace, slug, username, dataset_sources=["alice/data"]
+    )
+
+    assert metadata["id"] == "alice/my-bench"
+    assert metadata["title"] == "my-bench"
+    assert metadata["id_no"] is None
+    assert "personal-benchmark" in metadata["keywords"]
+    assert "foo" in metadata["keywords"]
+    assert metadata["docker_image"] == "some-image"
+    assert metadata["dataset_sources"] == ["alice/data"]
+
+
+def test_build_local_metadata_overrides(tmp_path):
+    workspace = tmp_path
+    slug = "my-bench"
+    username = "alice"
+
+    metadata = build_local_metadata(
+        workspace,
+        slug,
+        username,
+        enable_gpu=True,
+        enable_internet=False,
+        is_private=False,
+        docker_image="custom-image",
+    )
+
+    assert metadata["id"] == "alice/my-bench"
+    assert metadata["enable_gpu"] is True
+    assert metadata["enable_internet"] is False
+    assert metadata["is_private"] is False
+    assert metadata["docker_image"] == "custom-image"
+    assert metadata["enable_tpu"] is False  # Default
+
+
+def test_build_local_metadata_idempotent_keywords(tmp_path):
+    """Test that calling build_local_metadata doesn't duplicate 'personal-benchmark'."""
+    workspace = tmp_path
+    slug = "my-bench"
+    username = "alice"
+
+    existing = {
+        "keywords": ["personal-benchmark", "foo"],
+    }
+    with open(workspace / "kernel-metadata.json", "w") as f:
+        json.dump(existing, f)
+
+    metadata = build_local_metadata(workspace, slug, username)
+
+    assert metadata["keywords"].count("personal-benchmark") == 1
+    assert "foo" in metadata["keywords"]
+
+
+def test_build_local_metadata_malformed_json(tmp_path):
+    """Test behavior when kernel-metadata.json contains invalid JSON."""
+    workspace = tmp_path
+    (workspace / "kernel-metadata.json").write_text("not valid json")
+
+    with pytest.raises(json.JSONDecodeError):
+        build_local_metadata(workspace, "my-bench", "alice")
+
+
+# ---------------------------------------------------------------------------
+# parse_remote_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_parse_remote_metadata_from_api_response():
+    """Extracts all fields from a fully populated API metadata object."""
+    meta = MagicMock()
+    meta.ref = "alice/my-benchmark"
+    meta.title = "My Benchmark"
+    meta.language = "python"
+    meta.kernel_type = "notebook"
+    meta.is_private = False
+    meta.enable_gpu = True
+    meta.enable_internet = True
+    meta.enable_tpu = False
+    meta.dataset_data_sources = ["alice/dataset"]
+    meta.competition_data_sources = ["comp1"]
+    meta.kernel_data_sources = ["alice/kernel"]
+    meta.model_data_sources = ["alice/model"]
+    meta.category_ids = ["personal-benchmark", "nlp"]
+
+    result = parse_remote_metadata(
+        meta, default_id="fallback/id", default_slug="fallback"
+    )
+
+    assert result["id"] == "alice/my-benchmark"
+    assert result["title"] == "My Benchmark"
+    assert result["language"] == "python"
+    assert result["kernel_type"] == "notebook"
+    assert result["is_private"] is False
+    assert result["enable_gpu"] is True
+    assert result["enable_internet"] is True
+    assert result["enable_tpu"] is False
+    assert result["dataset_sources"] == ["alice/dataset"]
+    assert result["competition_sources"] == ["comp1"]
+    assert result["kernel_sources"] == ["alice/kernel"]
+    assert result["model_sources"] == ["alice/model"]
+    assert result["keywords"] == ["personal-benchmark", "nlp"]
+
+
+def test_parse_remote_metadata_uses_defaults_for_missing_attrs():
+    """Falls back to defaults when API metadata has missing attributes."""
+    meta = MagicMock(spec=[])  # spec=[] means no attributes exist
+
+    result = parse_remote_metadata(
+        meta, default_id="owner/slug", default_slug="my-slug"
+    )
+
+    assert result["id"] == "owner/slug"
+    assert result["title"] == "my-slug"
+    assert result["language"] == "python"
+    assert result["kernel_type"] == "notebook"
+    assert result["is_private"] is True
+    assert result["enable_gpu"] is False
+    assert result["enable_internet"] is True
+    assert result["enable_tpu"] is False
+    assert result["dataset_sources"] == []
+    assert result["competition_sources"] == []
+    assert result["kernel_sources"] == []
+    assert result["model_sources"] == []
+    assert result["keywords"] == []
+
+
+def test_parse_remote_metadata_handles_none_lists():
+    """Converts None list fields to empty lists."""
+    meta = MagicMock()
+    meta.ref = "alice/bench"
+    meta.title = "Bench"
+    meta.language = "python"
+    meta.kernel_type = "notebook"
+    meta.is_private = True
+    meta.enable_gpu = False
+    meta.enable_internet = True
+    meta.enable_tpu = False
+    meta.dataset_data_sources = None
+    meta.competition_data_sources = None
+    meta.kernel_data_sources = None
+    meta.model_data_sources = None
+    meta.category_ids = None
+
+    result = parse_remote_metadata(meta, default_id="x/y", default_slug="y")
+
+    assert result["dataset_sources"] == []
+    assert result["competition_sources"] == []
+    assert result["kernel_sources"] == []
+    assert result["model_sources"] == []
+    assert result["keywords"] == []
+
+
+# ---------------------------------------------------------------------------
+# normalize_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw_status, expected",
+    [
+        ("complete", "complete"),
+        ("Complete", "complete"),
+        ("KernelWorkerStatus.complete", "complete"),
+        ("kernelworkerstatus.running", "running"),
+        ("error", "error"),
+    ],
+)
+def test_normalize_status_strings(raw_status, expected):
+    """normalize_status should strip enum prefixes and lower-case."""
+    assert normalize_status(raw_status) == expected
+
+
+def test_normalize_status_object_with_attribute():
+    """Simulates an API response object with a .status attribute."""
+
+    class FakeStatus:
+        status = "running"
+
+    assert normalize_status(FakeStatus()) == "running"

--- a/tests/kaggle_client/test_kaggle_client_utils.py
+++ b/tests/kaggle_client/test_kaggle_client_utils.py
@@ -45,6 +45,14 @@ print("Hello")
     assert notebook["cells"][0]["cell_type"] == "markdown"
     assert notebook["cells"][1]["cell_type"] == "code"
 
+    # Verify the kernelspec is added so papermill can run the notebook
+    assert "kernelspec" in notebook["metadata"]
+    assert notebook["metadata"]["kernelspec"] == {
+        "display_name": "Python 3",
+        "language": "python",
+        "name": "python3",
+    }
+
 
 def test_convert_py_to_ipynb_warning(tmp_path):
     py_file = tmp_path / "benchmark.py"

--- a/tests/kaggle_client/test_kaggle_client_utils.py
+++ b/tests/kaggle_client/test_kaggle_client_utils.py
@@ -13,14 +13,15 @@
 # limitations under the License.
 
 import json
+from unittest.mock import MagicMock
 
 import pytest
 
-from kaggle_benchmarks.kaggle_client.utils import (
-    convert_ipynb_to_py,
-    convert_py_to_ipynb,
-    resolve_metadata,
-)
+from kaggle_benchmarks.kaggle_client import utils as kaggle_utils
+
+# ---------------------------------------------------------------------------
+# File format conversion
+# ---------------------------------------------------------------------------
 
 
 def test_convert_py_to_ipynb(tmp_path):
@@ -35,7 +36,7 @@ print("Hello")
 """
     py_file.write_text(content)
 
-    convert_py_to_ipynb(py_file, ipynb_file)
+    kaggle_utils.convert_py_to_ipynb(py_file, ipynb_file)
 
     assert ipynb_file.exists()
     with open(ipynb_file, "r") as f:
@@ -44,6 +45,14 @@ print("Hello")
     assert len(notebook["cells"]) == 2
     assert notebook["cells"][0]["cell_type"] == "markdown"
     assert notebook["cells"][1]["cell_type"] == "code"
+
+    # Verify the kernelspec is added so papermill can run the notebook
+    assert "kernelspec" in notebook["metadata"]
+    assert notebook["metadata"]["kernelspec"] == {
+        "display_name": "Python 3",
+        "language": "python",
+        "name": "python3",
+    }
 
 
 def test_convert_py_to_ipynb_warning(tmp_path):
@@ -56,7 +65,7 @@ print("World")
     py_file.write_text(content)
 
     with pytest.warns(UserWarning, match="has no '# %%' cell delimiters"):
-        convert_py_to_ipynb(py_file, ipynb_file)
+        kaggle_utils.convert_py_to_ipynb(py_file, ipynb_file)
 
     assert ipynb_file.exists()
 
@@ -84,7 +93,7 @@ def test_convert_ipynb_to_py(tmp_path):
     with open(ipynb_file, "w") as f:
         json.dump(notebook, f)
 
-    convert_ipynb_to_py(ipynb_file, py_file)
+    kaggle_utils.convert_ipynb_to_py(ipynb_file, py_file)
 
     assert py_file.exists()
     content = py_file.read_text()
@@ -92,113 +101,6 @@ def test_convert_ipynb_to_py(tmp_path):
     assert "# # Title" in content
     assert "# %%" in content
     assert "print('Hello')" in content
-
-
-def test_resolve_metadata_new(tmp_path):
-    workspace = tmp_path
-    slug = "my-bench"
-    username = "alice"
-
-    metadata = resolve_metadata(workspace, slug, username)
-
-    assert metadata["id"] == "alice/my-bench"
-    assert metadata["title"] == "my-bench"  # Defaults to slug
-    assert metadata["id_no"] is None
-    assert "personal-benchmark" in metadata["keywords"]
-    assert metadata["is_private"] is True
-    assert "model_sources" in metadata
-    assert metadata["docker_image"] is None
-
-
-def test_resolve_metadata_custom_title(tmp_path):
-    """Test that title can be customized separately from slug."""
-    workspace = tmp_path
-    slug = "my-bench"
-    username = "alice"
-
-    metadata = resolve_metadata(workspace, slug, username, title="My Awesome Benchmark")
-
-    assert metadata["id"] == "alice/my-bench"  # slug used for id
-    assert metadata["title"] == "My Awesome Benchmark"  # custom title
-
-
-def test_resolve_metadata_existing(tmp_path):
-    workspace = tmp_path
-    slug = "my-bench"
-    username = "alice"
-
-    existing = {
-        "id": "bob/old-bench",
-        "title": "old-bench",
-        "id_no": 12345,
-        "keywords": ["foo"],
-        "docker_image": "some-image",
-    }
-
-    with open(workspace / "kernel-metadata.json", "w") as f:
-        json.dump(existing, f)
-
-    metadata = resolve_metadata(
-        workspace, slug, username, dataset_sources=["alice/data"]
-    )
-
-    assert metadata["id"] == "alice/my-bench"
-    assert metadata["title"] == "my-bench"
-    assert metadata["id_no"] is None
-    assert "personal-benchmark" in metadata["keywords"]
-    assert "foo" in metadata["keywords"]
-    assert metadata["docker_image"] == "some-image"
-    assert metadata["dataset_sources"] == ["alice/data"]
-
-
-def test_resolve_metadata_overrides(tmp_path):
-    workspace = tmp_path
-    slug = "my-bench"
-    username = "alice"
-
-    metadata = resolve_metadata(
-        workspace,
-        slug,
-        username,
-        enable_gpu=True,
-        enable_internet=False,
-        is_private=False,
-        docker_image="custom-image",
-    )
-
-    assert metadata["id"] == "alice/my-bench"
-    assert metadata["enable_gpu"] is True
-    assert metadata["enable_internet"] is False
-    assert metadata["is_private"] is False
-    assert metadata["docker_image"] == "custom-image"
-    assert metadata["enable_tpu"] is False  # Default
-
-
-def test_resolve_metadata_idempotent_keywords(tmp_path):
-    """Test that calling resolve_metadata doesn't duplicate 'personal-benchmark'."""
-    workspace = tmp_path
-    slug = "my-bench"
-    username = "alice"
-
-    existing = {
-        "keywords": ["personal-benchmark", "foo"],
-    }
-    with open(workspace / "kernel-metadata.json", "w") as f:
-        json.dump(existing, f)
-
-    metadata = resolve_metadata(workspace, slug, username)
-
-    assert metadata["keywords"].count("personal-benchmark") == 1
-    assert "foo" in metadata["keywords"]
-
-
-def test_resolve_metadata_malformed_json(tmp_path):
-    """Test behavior when kernel-metadata.json contains invalid JSON."""
-    workspace = tmp_path
-    (workspace / "kernel-metadata.json").write_text("not valid json")
-
-    with pytest.raises(json.JSONDecodeError):
-        resolve_metadata(workspace, "my-bench", "alice")
 
 
 def test_roundtrip_conversion(tmp_path):
@@ -218,11 +120,272 @@ x = 42
 """
     py_file.write_text(content)
 
-    convert_py_to_ipynb(py_file, ipynb_file)
-    convert_ipynb_to_py(ipynb_file, py_roundtrip)
+    kaggle_utils.convert_py_to_ipynb(py_file, ipynb_file)
+    kaggle_utils.convert_ipynb_to_py(ipynb_file, py_roundtrip)
 
     roundtrip_content = py_roundtrip.read_text()
     assert "# %% [markdown]" in roundtrip_content
     assert "# # Title" in roundtrip_content
     assert 'print("Hello")' in roundtrip_content
     assert "x = 42" in roundtrip_content
+
+
+# ---------------------------------------------------------------------------
+# build_local_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_build_local_metadata_new(tmp_path):
+    workspace = tmp_path
+    slug = "my-bench"
+    username = "alice"
+
+    metadata = kaggle_utils.build_local_metadata(workspace, slug, username)
+
+    assert metadata["id"] == "alice/my-bench"
+    assert metadata["title"] == "my-bench"  # Defaults to slug
+    assert metadata["id_no"] is None
+    assert "personal-benchmark" in metadata["keywords"]
+    assert metadata["is_private"] is True
+    assert "model_sources" in metadata
+    assert metadata["docker_image"] is None
+
+
+def test_build_local_metadata_custom_title(tmp_path):
+    """Test that title can be customized separately from slug."""
+    workspace = tmp_path
+    slug = "my-bench"
+    username = "alice"
+
+    metadata = kaggle_utils.build_local_metadata(
+        workspace, slug, username, title="My Awesome Benchmark"
+    )
+
+    assert metadata["id"] == "alice/my-bench"  # slug used for id
+    assert metadata["title"] == "My Awesome Benchmark"  # custom title
+
+
+def test_build_local_metadata_existing(tmp_path):
+    workspace = tmp_path
+    slug = "my-bench"
+    username = "alice"
+
+    existing = {
+        "id": "bob/old-bench",
+        "title": "old-bench",
+        "id_no": 12345,
+        "keywords": ["foo"],
+        "docker_image": "some-image",
+    }
+
+    with open(workspace / "kernel-metadata.json", "w") as f:
+        json.dump(existing, f)
+
+    metadata = kaggle_utils.build_local_metadata(
+        workspace, slug, username, dataset_sources=["alice/data"]
+    )
+
+    assert metadata["id"] == "alice/my-bench"
+    assert metadata["title"] == "my-bench"
+    assert metadata["id_no"] is None
+    assert "personal-benchmark" in metadata["keywords"]
+    assert "foo" in metadata["keywords"]
+    assert metadata["docker_image"] == "some-image"
+    assert metadata["dataset_sources"] == ["alice/data"]
+
+
+def test_build_local_metadata_overrides(tmp_path):
+    workspace = tmp_path
+    slug = "my-bench"
+    username = "alice"
+
+    metadata = kaggle_utils.build_local_metadata(
+        workspace,
+        slug,
+        username,
+        enable_gpu=True,
+        enable_internet=False,
+        is_private=False,
+        docker_image="custom-image",
+    )
+
+    assert metadata["id"] == "alice/my-bench"
+    assert metadata["enable_gpu"] is True
+    assert metadata["enable_internet"] is False
+    assert metadata["is_private"] is False
+    assert metadata["docker_image"] == "custom-image"
+    assert metadata["enable_tpu"] is False  # Default
+
+
+def test_build_local_metadata_idempotent_keywords(tmp_path):
+    """Test that calling build_local_metadata doesn't duplicate 'personal-benchmark'."""
+    workspace = tmp_path
+    slug = "my-bench"
+    username = "alice"
+
+    existing = {
+        "keywords": ["personal-benchmark", "foo"],
+    }
+    with open(workspace / "kernel-metadata.json", "w") as f:
+        json.dump(existing, f)
+
+    metadata = kaggle_utils.build_local_metadata(workspace, slug, username)
+
+    assert metadata["keywords"].count("personal-benchmark") == 1
+    assert "foo" in metadata["keywords"]
+
+
+def test_build_local_metadata_malformed_json(tmp_path):
+    """Test behavior when kernel-metadata.json contains invalid JSON."""
+    workspace = tmp_path
+    (workspace / "kernel-metadata.json").write_text("not valid json")
+
+    with pytest.raises(json.JSONDecodeError):
+        kaggle_utils.build_local_metadata(workspace, "my-bench", "alice")
+
+
+# ---------------------------------------------------------------------------
+# parse_remote_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_parse_remote_metadata_from_api_response():
+    """Extracts all fields from a fully populated API metadata object."""
+    meta = MagicMock(
+        ref="alice/my-benchmark",
+        title="My Benchmark",
+        language="python",
+        kernel_type="notebook",
+        is_private=False,
+        enable_gpu=True,
+        enable_internet=True,
+        enable_tpu=False,
+        dataset_data_sources=["alice/dataset"],
+        competition_data_sources=["comp1"],
+        kernel_data_sources=["alice/kernel"],
+        model_data_sources=["alice/model"],
+        category_ids=["personal-benchmark", "nlp"],
+        docker_image="custom-image:latest",
+        machine_shape="T4",
+    )
+
+    result = kaggle_utils.parse_remote_metadata(
+        meta, default_id="fallback/id", default_slug="fallback"
+    )
+
+    assert result == {
+        "id": "alice/my-benchmark",
+        "title": "My Benchmark",
+        "language": "python",
+        "kernel_type": "notebook",
+        "is_private": False,
+        "enable_gpu": True,
+        "enable_tpu": False,
+        "enable_internet": True,
+        "dataset_sources": ["alice/dataset"],
+        "competition_sources": ["comp1"],
+        "kernel_sources": ["alice/kernel"],
+        "model_sources": ["alice/model"],
+        "keywords": ["personal-benchmark", "nlp"],
+        "docker_image": "custom-image:latest",
+        "machine_shape": "T4",
+    }
+
+
+def test_parse_remote_metadata_uses_defaults_for_missing_attrs():
+    """Falls back to defaults when API metadata has missing attributes."""
+    meta = MagicMock(spec=[])  # spec=[] means no attributes exist
+
+    result = kaggle_utils.parse_remote_metadata(
+        meta, default_id="owner/slug", default_slug="my-slug"
+    )
+
+    assert result == {
+        "id": "owner/slug",
+        "title": "my-slug",
+        "language": "python",
+        "kernel_type": "notebook",
+        "is_private": True,
+        "enable_gpu": False,
+        "enable_tpu": False,
+        "enable_internet": True,
+        "dataset_sources": [],
+        "competition_sources": [],
+        "kernel_sources": [],
+        "model_sources": [],
+        "keywords": [],
+        "docker_image": None,
+        "machine_shape": "None",
+    }
+
+
+def test_parse_remote_metadata_handles_none_lists():
+    """Converts None list fields to empty lists."""
+    meta = MagicMock(
+        ref="alice/bench",
+        title="Bench",
+        language="python",
+        kernel_type="notebook",
+        is_private=True,
+        enable_gpu=False,
+        enable_tpu=False,
+        enable_internet=True,
+        dataset_data_sources=None,
+        competition_data_sources=None,
+        kernel_data_sources=None,
+        model_data_sources=None,
+        category_ids=None,
+        docker_image=None,
+        machine_shape=None,
+    )
+
+    result = kaggle_utils.parse_remote_metadata(
+        meta, default_id="x/y", default_slug="y"
+    )
+
+    assert result == {
+        "id": "alice/bench",
+        "title": "Bench",
+        "language": "python",
+        "kernel_type": "notebook",
+        "is_private": True,
+        "enable_gpu": False,
+        "enable_tpu": False,
+        "enable_internet": True,
+        "dataset_sources": [],
+        "competition_sources": [],
+        "kernel_sources": [],
+        "model_sources": [],
+        "keywords": [],
+        "docker_image": None,
+        "machine_shape": "None",
+    }
+
+
+# ---------------------------------------------------------------------------
+# normalize_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw_status, expected",
+    [
+        ("complete", "complete"),
+        ("Complete", "complete"),
+        ("KernelWorkerStatus.complete", "complete"),
+        ("kernelworkerstatus.running", "running"),
+        ("error", "error"),
+    ],
+)
+def test_normalize_status_strings(raw_status, expected):
+    """normalize_status should strip enum prefixes and lower-case."""
+    assert kaggle_utils.normalize_status(raw_status) == expected
+
+
+def test_normalize_status_object_with_attribute():
+    """Simulates an API response object with a .status attribute."""
+
+    class FakeStatus:
+        status = "running"
+
+    assert kaggle_utils.normalize_status(FakeStatus()) == "running"

--- a/tests/kaggle_client/test_notebook_api.py
+++ b/tests/kaggle_client/test_notebook_api.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import json
+import tarfile
 import threading
 import time
 from pathlib import Path
@@ -26,7 +28,10 @@ from kaggle_benchmarks.kaggle_client.notebook_api import (
     ConcurrentRunError,
     KaggleAuthError,
     RunResult,
+    _authenticate,
 )
+
+_API_MOD = "kaggle_benchmarks.kaggle_client.notebook_api"
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -35,16 +40,18 @@ from kaggle_benchmarks.kaggle_client.notebook_api import (
 
 @pytest.fixture
 def mock_api():
-    """Create a mock Kaggle API."""
+    """Create a mock KaggleClient (kagglesdk)."""
     api = MagicMock()
-    api.get_config_value.return_value = "testuser"
+    # Set username for Basic auth scenarios
+    api.username = "testuser"
+    api.api_token = None
     return api
 
 
 @pytest.fixture
 def client(mock_api, tmp_path):
     """Create a BenchmarkNotebookClient with a mocked API."""
-    with patch.object(BenchmarkNotebookClient, "_authenticate", return_value=mock_api):
+    with patch(f"{_API_MOD}._authenticate", return_value=(mock_api, "testuser")):
         return BenchmarkNotebookClient(base_dir=tmp_path)
 
 
@@ -66,24 +73,93 @@ def _make_benchmark_py(workspace: Path) -> None:
     (workspace / "benchmark.py").write_text("# %%\nprint('hello')\n")
 
 
-def _fake_kernels_output(kernel, path, force):
-    """Simulate kernels_output by creating the output directory."""
-    Path(path).mkdir(parents=True, exist_ok=True)
+def _make_save_kernel_response(error=""):
+    """Create a mock ApiSaveKernelResponse."""
+    resp = MagicMock()
+    resp.error = error
+    resp.invalid_tags = []
+    return resp
 
 
-def _fake_kernels_output_with_run_json(kernel, path, force):
-    """Simulate kernels_output that produces a run.json."""
-    p = Path(path)
-    p.mkdir(parents=True, exist_ok=True)
-    (p / "run.json").write_text('{"score": 0.95}')
+def _make_status_response(status_str):
+    """Create a mock ApiGetKernelSessionStatusResponse."""
+
+    class FakeStatus:
+        status = status_str
+
+    return FakeStatus()
 
 
-def _fake_kernels_output_with_multiple_run_jsons(kernel, path, force):
-    """Simulate kernels_output that produces multiple *.run.json files."""
-    p = Path(path)
-    p.mkdir(parents=True, exist_ok=True)
-    (p / "task_1.run.json").write_text('{"score": 1}')
-    (p / "task_2.run.json").write_text('{"score": 2}')
+def _make_archive_response(*files):
+    """Create a mock streamed response with a tar archive containing the given files.
+
+    Args:
+        *files: Tuples of (filename, content_string) to include in the archive.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, content in files:
+            data = content.encode("utf-8")
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    buf.seek(0)
+
+    response = MagicMock()
+    response.iter_content = lambda chunk_size=8192: iter([buf.read()])
+    return response
+
+
+def _make_get_kernel_response(
+    source_json=None, metadata_dict=None, ipynb_name="notebook.ipynb"
+):
+    """Create a mock ApiGetKernelResponse.
+
+    Args:
+        source_json: The notebook source (raw .ipynb JSON dict). If None, uses a default.
+        metadata_dict: The metadata dict. If None, uses a default.
+        ipynb_name: Used to construct the default metadata 'ref'.
+    """
+    if source_json is None:
+        source_json = {
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "source": ["print('hello')\n"],
+                    "metadata": {},
+                    "outputs": [],
+                    "execution_count": None,
+                }
+            ],
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 5,
+        }
+
+    if metadata_dict is None:
+        metadata_dict = {
+            "ref": f"source/{ipynb_name.replace('.ipynb', '')}",
+            "title": ipynb_name.replace(".ipynb", ""),
+            "language": "python",
+            "kernel_type": "notebook",
+            "is_private": True,
+            "enable_gpu": False,
+            "enable_internet": True,
+            "enable_tpu": False,
+            "dataset_data_sources": [],
+            "competition_data_sources": [],
+            "kernel_data_sources": [],
+            "model_data_sources": [],
+            "category_ids": [],
+        }
+
+    import types
+
+    resp = MagicMock()
+    resp.blob.source = json.dumps(source_json)
+    # Use SimpleNamespace so getattr(meta, "missing_field", None) returns None correctly
+    resp.metadata = types.SimpleNamespace(**metadata_dict)
+    return resp
 
 
 # ---------------------------------------------------------------------------
@@ -111,35 +187,6 @@ def test_workspace_path(client, tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# _normalize_status
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "raw_status, expected",
-    [
-        ("complete", "complete"),
-        ("Complete", "complete"),
-        ("KernelWorkerStatus.complete", "complete"),
-        ("kernelworkerstatus.running", "running"),
-        ("error", "error"),
-    ],
-)
-def test_normalize_status_strings(raw_status, expected):
-    """_normalize_status should strip enum prefixes and lower-case."""
-    assert BenchmarkNotebookClient._normalize_status(raw_status) == expected
-
-
-def test_normalize_status_object_with_attribute():
-    """Simulates an API response object with a .status attribute."""
-
-    class FakeStatus:
-        status = "running"
-
-    assert BenchmarkNotebookClient._normalize_status(FakeStatus()) == "running"
-
-
-# ---------------------------------------------------------------------------
 # publish_and_run
 # ---------------------------------------------------------------------------
 
@@ -150,12 +197,22 @@ def test_publish_and_run_basic(client, mock_api, tmp_path):
     _make_benchmark_py(tmp_path / slug)
 
     # No existing kernel (404)
-    mock_api.kernels_status.side_effect = _make_404_error()
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.side_effect = (
+        _make_404_error()
+    )
+    mock_api.kernels.kernels_api_client.save_kernel.return_value = (
+        _make_save_kernel_response()
+    )
 
     url = client.publish_and_run(slug)
 
     assert "testuser/test-bench" in url
-    mock_api.kernels_push.assert_called_once_with(str(tmp_path / slug))
+    mock_api.kernels.kernels_api_client.save_kernel.assert_called_once()
+
+    # Verify the save_kernel request has correct slug
+    call_args = mock_api.kernels.kernels_api_client.save_kernel.call_args
+    req = call_args[0][0]
+    assert req.slug == "testuser/test-bench"
 
     # Verify metadata was written
     meta = json.loads((tmp_path / slug / "kernel-metadata.json").read_text())
@@ -172,21 +229,31 @@ def test_publish_and_run_with_source_file(client, mock_api, tmp_path):
     source = tmp_path / "my_script.py"
     source.write_text("# %%\nimport kaggle_benchmarks as kbench\n")
 
-    mock_api.kernels_status.side_effect = _make_404_error()
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.side_effect = (
+        _make_404_error()
+    )
+    mock_api.kernels.kernels_api_client.save_kernel.return_value = (
+        _make_save_kernel_response()
+    )
 
     _ = client.publish_and_run(slug, source_file=str(source))
 
     workspace = tmp_path / slug
     assert (workspace / "benchmark.py").exists()
     assert (workspace / "benchmark.ipynb").exists()
-    mock_api.kernels_push.assert_called_once()
+    mock_api.kernels.kernels_api_client.save_kernel.assert_called_once()
 
 
 def test_publish_and_run_dataset_sources(client, mock_api, tmp_path):
     """Dataset sources are passed through to metadata."""
     slug = "test-bench"
     _make_benchmark_py(tmp_path / slug)
-    mock_api.kernels_status.side_effect = _make_404_error()
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.side_effect = (
+        _make_404_error()
+    )
+    mock_api.kernels.kernels_api_client.save_kernel.return_value = (
+        _make_save_kernel_response()
+    )
 
     client.publish_and_run(slug, dataset_sources=["alice/data", "bob/more-data"])
 
@@ -199,12 +266,14 @@ def test_publish_and_run_concurrent_guard(client, mock_api, tmp_path):
     slug = "test-bench"
     _make_benchmark_py(tmp_path / slug)
 
-    mock_api.kernels_status.return_value = "running"
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("running")
+    )
 
     with pytest.raises(ConcurrentRunError, match="already running"):
         client.publish_and_run(slug)
 
-    mock_api.kernels_push.assert_not_called()
+    mock_api.kernels.kernels_api_client.save_kernel.assert_not_called()
 
 
 def test_publish_and_run_concurrent_guard_queued(client, mock_api, tmp_path):
@@ -212,7 +281,9 @@ def test_publish_and_run_concurrent_guard_queued(client, mock_api, tmp_path):
     slug = "test-bench"
     _make_benchmark_py(tmp_path / slug)
 
-    mock_api.kernels_status.return_value = "queued"
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("queued")
+    )
 
     with pytest.raises(ConcurrentRunError, match="already running"):
         client.publish_and_run(slug)
@@ -223,12 +294,14 @@ def test_publish_and_run_concurrent_guard_non_404_error(client, mock_api, tmp_pa
     slug = "test-bench"
     _make_benchmark_py(tmp_path / slug)
 
-    mock_api.kernels_status.side_effect = _make_http_error(500)
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.side_effect = (
+        _make_http_error(500)
+    )
 
     with pytest.raises(HTTPError):
         client.publish_and_run(slug)
 
-    mock_api.kernels_push.assert_not_called()
+    mock_api.kernels.kernels_api_client.save_kernel.assert_not_called()
 
 
 def test_publish_and_run_force(client, mock_api, tmp_path):
@@ -236,11 +309,15 @@ def test_publish_and_run_force(client, mock_api, tmp_path):
     slug = "test-bench"
     _make_benchmark_py(tmp_path / slug)
 
+    mock_api.kernels.kernels_api_client.save_kernel.return_value = (
+        _make_save_kernel_response()
+    )
+
     _ = client.publish_and_run(slug, force=True)
 
-    # kernels_status should NOT be called (guard skipped)
-    mock_api.kernels_status.assert_not_called()
-    mock_api.kernels_push.assert_called_once()
+    # get_kernel_session_status should NOT be called (guard skipped)
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.assert_not_called()
+    mock_api.kernels.kernels_api_client.save_kernel.assert_called_once()
 
 
 def test_publish_and_run_missing_file(client, tmp_path):
@@ -265,8 +342,12 @@ def test_get_results_complete_immediately(client, mock_api, tmp_path):
     slug = "test-bench"
     (tmp_path / slug).mkdir()
 
-    mock_api.kernels_status.return_value = "complete"
-    mock_api.kernels_output.side_effect = _fake_kernels_output_with_run_json
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("complete")
+    )
+    mock_api.kernels.kernels_api_client.download_kernel_output.return_value = (
+        _make_archive_response(("run.json", '{"score": 0.95}'))
+    )
 
     result = client.get_results(slug)
 
@@ -274,7 +355,7 @@ def test_get_results_complete_immediately(client, mock_api, tmp_path):
     assert result.output_dir is not None
     assert result.error is None
     # Tests that it works with the single legacy `run.json` as well
-    runs = dict(result.iter_runs())
+    runs = dict(result.iter_run_results())
     assert len(runs) == 1
     assert runs["run.json"] == {"score": 0.95}
 
@@ -284,15 +365,22 @@ def test_get_results_multiple_run_files(client, mock_api, tmp_path):
     slug = "test-bench"
     (tmp_path / slug).mkdir()
 
-    mock_api.kernels_status.return_value = "complete"
-    mock_api.kernels_output.side_effect = _fake_kernels_output_with_multiple_run_jsons
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("complete")
+    )
+    mock_api.kernels.kernels_api_client.download_kernel_output.return_value = (
+        _make_archive_response(
+            ("task_1.run.json", '{"score": 1}'),
+            ("task_2.run.json", '{"score": 2}'),
+        )
+    )
 
     result = client.get_results(slug)
 
     assert result.status == "complete"
     assert result.output_dir is not None
 
-    runs = dict(result.iter_runs())
+    runs = dict(result.iter_run_results())
     assert len(runs) == 2
     assert runs["task_1.run.json"] == {"score": 1}
     assert runs["task_2.run.json"] == {"score": 2}
@@ -304,9 +392,19 @@ def test_get_results_polls_until_complete(client, mock_api, tmp_path, monkeypatc
     (tmp_path / slug).mkdir()
     monkeypatch.setattr(time, "sleep", lambda s: None)
 
-    statuses = iter(["queued", "running", "complete"])
-    mock_api.kernels_status.side_effect = lambda *a, **k: next(statuses)
-    mock_api.kernels_output.side_effect = _fake_kernels_output
+    statuses = iter(
+        [
+            _make_status_response("queued"),
+            _make_status_response("running"),
+            _make_status_response("complete"),
+        ]
+    )
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.side_effect = (
+        lambda *a, **k: next(statuses)
+    )
+    mock_api.kernels.kernels_api_client.download_kernel_output.return_value = (
+        _make_archive_response()
+    )
 
     collected = []
     result = client.get_results(slug, poll_interval=0.01, on_status=collected.append)
@@ -322,7 +420,9 @@ def test_get_results_timeout(client, mock_api, tmp_path, monkeypatch):
     (tmp_path / slug).mkdir()
     monkeypatch.setattr(time, "sleep", lambda s: None)
 
-    mock_api.kernels_status.return_value = "running"
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("running")
+    )
 
     result = client.get_results(slug, poll_interval=1, timeout=0)
 
@@ -335,7 +435,9 @@ def test_get_results_cancel(client, mock_api, tmp_path):
     slug = "test-bench"
     (tmp_path / slug).mkdir()
 
-    mock_api.kernels_status.return_value = "running"
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("running")
+    )
 
     cancel_event = threading.Event()
     cancel_event.set()  # Set immediately
@@ -350,7 +452,9 @@ def test_get_results_cancel_mid_wait(client, mock_api, tmp_path):
     slug = "test-bench"
     (tmp_path / slug).mkdir()
 
-    mock_api.kernels_status.return_value = "running"
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("running")
+    )
 
     cancel_event = threading.Event()
 
@@ -377,7 +481,9 @@ def test_get_results_error_status(client, mock_api, tmp_path):
     slug = "test-bench"
     (tmp_path / slug).mkdir()
 
-    mock_api.kernels_status.return_value = "error"
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("error")
+    )
 
     result = client.get_results(slug)
 
@@ -400,10 +506,14 @@ def test_get_results_initial_404_retries(client, mock_api, tmp_path, monkeypatch
         call_count += 1
         if call_count <= 2:
             raise _make_404_error()
-        return "complete"
+        return _make_status_response("complete")
 
-    mock_api.kernels_status.side_effect = status_side_effect
-    mock_api.kernels_output.side_effect = _fake_kernels_output
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.side_effect = (
+        status_side_effect
+    )
+    mock_api.kernels.kernels_api_client.download_kernel_output.return_value = (
+        _make_archive_response()
+    )
 
     result = client.get_results(slug, poll_interval=0.01)
 
@@ -417,7 +527,9 @@ def test_get_results_all_retries_exhausted(client, mock_api, tmp_path, monkeypat
     (tmp_path / slug).mkdir()
     monkeypatch.setattr(time, "sleep", lambda s: None)
 
-    mock_api.kernels_status.side_effect = _make_404_error()
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.side_effect = (
+        _make_404_error()
+    )
 
     result = client.get_results(slug)
 
@@ -433,7 +545,9 @@ def test_get_results_non_404_error_during_retries(
     (tmp_path / slug).mkdir()
     monkeypatch.setattr(time, "sleep", lambda s: None)
 
-    mock_api.kernels_status.side_effect = _make_http_error(500)
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.side_effect = (
+        _make_http_error(500)
+    )
 
     with pytest.raises(HTTPError):
         client.get_results(slug)
@@ -445,9 +559,19 @@ def test_get_results_on_status_callback(client, mock_api, tmp_path, monkeypatch)
     (tmp_path / slug).mkdir()
     monkeypatch.setattr(time, "sleep", lambda s: None)
 
-    statuses = iter(["running", "running", "complete"])
-    mock_api.kernels_status.side_effect = lambda *a, **k: next(statuses)
-    mock_api.kernels_output.side_effect = _fake_kernels_output
+    statuses = iter(
+        [
+            _make_status_response("running"),
+            _make_status_response("running"),
+            _make_status_response("complete"),
+        ]
+    )
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.side_effect = (
+        lambda *a, **k: next(statuses)
+    )
+    mock_api.kernels.kernels_api_client.download_kernel_output.return_value = (
+        _make_archive_response()
+    )
 
     collected = []
     result = client.get_results(slug, poll_interval=0.01, on_status=collected.append)
@@ -457,17 +581,21 @@ def test_get_results_on_status_callback(client, mock_api, tmp_path, monkeypatch)
 
 
 def test_get_results_no_run_json(client, mock_api, tmp_path):
-    """iter_runs() yields nothing when no run.json is produced."""
+    """iter_run_results() yields nothing when no run.json is produced."""
     slug = "test-bench"
     (tmp_path / slug).mkdir()
 
-    mock_api.kernels_status.return_value = "complete"
-    mock_api.kernels_output.side_effect = _fake_kernels_output
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("complete")
+    )
+    mock_api.kernels.kernels_api_client.download_kernel_output.return_value = (
+        _make_archive_response()
+    )
 
     result = client.get_results(slug)
 
     assert result.status == "complete"
-    assert not dict(result.iter_runs())
+    assert not dict(result.iter_run_results())
 
 
 def test_get_results_custom_output_dir(client, mock_api, tmp_path):
@@ -477,8 +605,12 @@ def test_get_results_custom_output_dir(client, mock_api, tmp_path):
 
     custom_output = tmp_path / "my_custom_output"
 
-    mock_api.kernels_status.return_value = "complete"
-    mock_api.kernels_output.side_effect = _fake_kernels_output_with_run_json
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("complete")
+    )
+    mock_api.kernels.kernels_api_client.download_kernel_output.return_value = (
+        _make_archive_response(("run.json", '{"score": 0.95}'))
+    )
 
     result = client.get_results(slug, output_dir=str(custom_output))
 
@@ -486,7 +618,7 @@ def test_get_results_custom_output_dir(client, mock_api, tmp_path):
     assert result.output_dir == str(custom_output)
     assert custom_output.exists()
 
-    runs = dict(result.iter_runs())
+    runs = dict(result.iter_run_results())
     assert len(runs) == 1
 
 
@@ -501,8 +633,12 @@ def test_get_results_clears_existing_output(client, mock_api, tmp_path):
     old_file = output_dir / "old_result.txt"
     old_file.write_text("stale data")
 
-    mock_api.kernels_status.return_value = "complete"
-    mock_api.kernels_output.side_effect = _fake_kernels_output_with_run_json
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("complete")
+    )
+    mock_api.kernels.kernels_api_client.download_kernel_output.return_value = (
+        _make_archive_response(("run.json", '{"score": 0.95}'))
+    )
 
     result = client.get_results(slug)
 
@@ -522,8 +658,12 @@ def test_get_results_no_clear_output(client, mock_api, tmp_path):
     old_file = output_dir / "old_result.txt"
     old_file.write_text("keep me")
 
-    mock_api.kernels_status.return_value = "complete"
-    mock_api.kernels_output.side_effect = _fake_kernels_output_with_run_json
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("complete")
+    )
+    mock_api.kernels.kernels_api_client.download_kernel_output.return_value = (
+        _make_archive_response(("run.json", '{"score": 0.95}'))
+    )
 
     result = client.get_results(slug, clear_output=False)
 
@@ -532,35 +672,35 @@ def test_get_results_no_clear_output(client, mock_api, tmp_path):
     assert old_file.exists()
     assert old_file.read_text() == "keep me"
     # New file should also exist
-    runs = dict(result.iter_runs())
+    runs = dict(result.iter_run_results())
     assert len(runs) == 1
 
 
 # ---------------------------------------------------------------------------
-# RunResult.iter_runs edge cases
+# RunResult.iter_run_results edge cases
 # ---------------------------------------------------------------------------
 
 
-def test_iter_runs_nonexistent_output_dir(tmp_path):
-    """iter_runs() yields nothing when output_dir does not exist."""
+def test_iter_run_results_nonexistent_output_dir(tmp_path):
+    """iter_run_results() yields nothing when output_dir does not exist."""
     result = RunResult(
         status="complete",
         output_dir=str(tmp_path / "nonexistent"),
         tracking_url=None,
     )
-    assert list(result.iter_runs()) == []
-    assert dict(result.iter_runs()) == {}
+    assert list(result.iter_run_results()) == []
+    assert dict(result.iter_run_results()) == {}
 
 
-def test_iter_runs_none_output_dir():
-    """iter_runs() yields nothing when output_dir is None."""
+def test_iter_run_results_none_output_dir():
+    """iter_run_results() yields nothing when output_dir is None."""
     result = RunResult(
         status="error",
         output_dir=None,
         tracking_url=None,
     )
-    assert list(result.iter_runs()) == []
-    assert dict(result.iter_runs()) == {}
+    assert list(result.iter_run_results()) == []
+    assert dict(result.iter_run_results()) == {}
 
 
 # ---------------------------------------------------------------------------
@@ -568,54 +708,11 @@ def test_iter_runs_none_output_dir():
 # ---------------------------------------------------------------------------
 
 
-def _make_fake_pull(ipynb_name="notebook.ipynb"):
-    """Create a fake kernels_pull that writes a notebook and metadata."""
-
-    def fake_pull(notebook, path, metadata):
-        p = Path(path)
-        p.mkdir(parents=True, exist_ok=True)
-        notebook_data = {
-            "cells": [
-                {
-                    "cell_type": "code",
-                    "source": ["print('hello')\n"],
-                    "metadata": {},
-                    "outputs": [],
-                    "execution_count": None,
-                }
-            ],
-            "metadata": {},
-            "nbformat": 4,
-            "nbformat_minor": 5,
-        }
-        (p / ipynb_name).write_text(json.dumps(notebook_data))
-        if metadata:
-            (p / "kernel-metadata.json").write_text(
-                json.dumps({"id": f"source/{ipynb_name.replace('.ipynb', '')}"})
-            )
-
-    return fake_pull
-
-
-def _make_fake_pull_no_ipynb():
-    """Create a fake kernels_pull that writes only metadata (no .ipynb)."""
-
-    def fake_pull(notebook, path, metadata):
-        p = Path(path)
-        p.mkdir(parents=True, exist_ok=True)
-        # Write a plain .py script file instead of .ipynb
-        (p / "script.py").write_text("print('hello')\n")
-        if metadata:
-            (p / "kernel-metadata.json").write_text(
-                json.dumps({"id": "source/script-notebook", "code_file": "script.py"})
-            )
-
-    return fake_pull
-
-
 def test_fork_basic(client, mock_api, tmp_path):
     """Happy path: pulls notebook and converts to .py."""
-    mock_api.kernels_pull.side_effect = _make_fake_pull("riddle-benchmark.ipynb")
+    mock_api.kernels.kernels_api_client.get_kernel.return_value = (
+        _make_get_kernel_response(ipynb_name="riddle-benchmark.ipynb")
+    )
 
     result = client.fork("alice/riddle-benchmark")
 
@@ -632,7 +729,9 @@ def test_fork_basic(client, mock_api, tmp_path):
 
 def test_fork_custom_slug(client, mock_api, tmp_path):
     """Custom notebook_slug overrides the default."""
-    mock_api.kernels_pull.side_effect = _make_fake_pull("notebook.ipynb")
+    mock_api.kernels.kernels_api_client.get_kernel.return_value = (
+        _make_get_kernel_response(ipynb_name="notebook.ipynb")
+    )
 
     result = client.fork("alice/riddle-benchmark", dest_notebook_slug="my-riddle")
 
@@ -654,7 +753,9 @@ def test_fork_overwrite(client, mock_api, tmp_path):
     workspace.mkdir()
     (workspace / "old-file.txt").write_text("old content")
 
-    mock_api.kernels_pull.side_effect = _make_fake_pull("riddle-benchmark.ipynb")
+    mock_api.kernels.kernels_api_client.get_kernel.return_value = (
+        _make_get_kernel_response(ipynb_name="riddle-benchmark.ipynb")
+    )
 
     _ = client.fork("alice/riddle-benchmark", overwrite=True)
 
@@ -664,7 +765,7 @@ def test_fork_overwrite(client, mock_api, tmp_path):
 
 def test_fork_missing_notebook_raises_value_error(client, mock_api):
     """fork() should raise a friendly ValueError for any HTTPError."""
-    mock_api.kernels_pull.side_effect = _make_404_error()
+    mock_api.kernels.kernels_api_client.get_kernel.side_effect = _make_404_error()
 
     with pytest.raises(
         ValueError, match="Failed to pull notebook 'kaggle/does-not-exist'"
@@ -674,15 +775,18 @@ def test_fork_missing_notebook_raises_value_error(client, mock_api):
 
 def test_fork_http_error_500_raises_value_error(client, mock_api):
     """fork() wraps any HTTPError (including 500) in ValueError."""
-    mock_api.kernels_pull.side_effect = _make_http_error(500)
+    mock_api.kernels.kernels_api_client.get_kernel.side_effect = _make_http_error(500)
 
     with pytest.raises(ValueError, match="Failed to pull notebook"):
         client.fork("kaggle/server-error-notebook")
 
 
-def test_fork_no_ipynb_file(client, mock_api, tmp_path, caplog):
-    """fork() should log a warning when no .ipynb file is found (script notebook)."""
-    mock_api.kernels_pull.side_effect = _make_fake_pull_no_ipynb()
+def test_fork_no_source(client, mock_api, tmp_path, caplog):
+    """fork() should log a warning when no source is found (empty blob)."""
+    resp = MagicMock()
+    resp.blob.source = None
+    resp.metadata = None  # No metadata either
+    mock_api.kernels.kernels_api_client.get_kernel.return_value = resp
 
     import logging
 
@@ -690,85 +794,41 @@ def test_fork_no_ipynb_file(client, mock_api, tmp_path, caplog):
         result = client.fork("alice/script-notebook")
 
     assert result == tmp_path / "script-notebook"
-    assert (result / "kernel-metadata.json").exists()
-    # No .ipynb → no benchmark.py conversion
+    # No source → no benchmark.py conversion
     assert not (result / "benchmark.py").exists()
     # Warning should be logged
-    assert "No .ipynb file found" in caplog.text
+    assert "No source found" in caplog.text
 
 
 # ---------------------------------------------------------------------------
-# validate_and_get_username
-# ---------------------------------------------------------------------------
-
-
-def test_validate_and_get_username_success(client, mock_api):
-    """Returns the username when credentials are valid."""
-    assert client.validate_and_get_username() == "testuser"
-    mock_api.get_config_value.assert_called_with("username")
-
-
-def test_validate_and_get_username_failure(client, mock_api):
-    """Raises KaggleAuthError when credentials are invalid."""
-    mock_api.get_config_value.side_effect = Exception("Invalid credentials")
-
-    with pytest.raises(KaggleAuthError, match="invalid or missing"):
-        client.validate_and_get_username()
-
-
-def test_validate_and_get_username_empty(client, mock_api):
-    """Raises KaggleAuthError when username is empty."""
-    mock_api.get_config_value.return_value = ""
-
-    with pytest.raises(KaggleAuthError, match="invalid or missing"):
-        client.validate_and_get_username()
-
-
-# ---------------------------------------------------------------------------
-# _authenticate
+# _authenticate (integration of the above)
 # ---------------------------------------------------------------------------
 
 
 def test_authenticate_import_error():
-    """Raises KaggleAuthError when kaggle package is not installed."""
+    """Raises KaggleAuthError when kagglesdk package is not installed."""
     with patch.dict(
         "sys.modules",
-        {"kaggle": None, "kaggle.api": None, "kaggle.api.kaggle_api_extended": None},
+        {
+            "kagglesdk": None,
+            "kagglesdk.kaggle_client": None,
+            "kagglesdk.kaggle_env": None,
+        },
     ):
         # Force ImportError by removing the module from sys.modules cache
         import sys
 
         saved = {}
         for mod_name in list(sys.modules):
-            if mod_name.startswith("kaggle"):
+            if mod_name.startswith("kagglesdk"):
                 saved[mod_name] = sys.modules.pop(mod_name)
 
         try:
             with patch(
                 "builtins.__import__",
-                side_effect=ImportError("No module named 'kaggle'"),
+                side_effect=ImportError("No module named 'kagglesdk'"),
             ):
-                with pytest.raises(KaggleAuthError, match="kaggle.*required"):
-                    BenchmarkNotebookClient._authenticate()
+                with pytest.raises(KaggleAuthError, match="kagglesdk.*required"):
+                    _authenticate()
         finally:
             sys.modules.update(saved)
-
-
-def test_authenticate_os_error():
-    """Raises KaggleAuthError when authentication credentials fail."""
-    mock_kaggle_api_cls = MagicMock()
-    mock_api_instance = MagicMock()
-    mock_api_instance.authenticate.side_effect = OSError("No such file: kaggle.json")
-    mock_kaggle_api_cls.return_value = mock_api_instance
-
-    # Test the actual _authenticate method with mocked import
-    with patch.dict(
-        "sys.modules",
-        {
-            "kaggle": MagicMock(),
-            "kaggle.api": MagicMock(),
-            "kaggle.api.kaggle_api_extended": MagicMock(KaggleApi=mock_kaggle_api_cls),
-        },
-    ):
-        with pytest.raises(KaggleAuthError, match="authentication failed"):
-            BenchmarkNotebookClient._authenticate()

--- a/tests/kaggle_client/test_notebook_api.py
+++ b/tests/kaggle_client/test_notebook_api.py
@@ -1,0 +1,834 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import json
+import tarfile
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from requests.exceptions import HTTPError
+
+from kaggle_benchmarks.kaggle_client.notebook_api import (
+    BenchmarkNotebookClient,
+    ConcurrentRunError,
+    KaggleAuthError,
+    RunResult,
+    _authenticate,
+)
+
+_API_MOD = "kaggle_benchmarks.kaggle_client.notebook_api"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_api():
+    """Create a mock KaggleClient (kagglesdk)."""
+    api = MagicMock()
+    # Set username for Basic auth scenarios
+    api.username = "testuser"
+    api.api_token = None
+    return api
+
+
+@pytest.fixture
+def client(mock_api, tmp_path):
+    """Create a BenchmarkNotebookClient with a mocked API."""
+    with patch(f"{_API_MOD}._authenticate", return_value=(mock_api, "testuser")):
+        return BenchmarkNotebookClient(base_dir=tmp_path)
+
+
+def _make_http_error(status_code):
+    """Create a mock HTTPError with the given response status code."""
+    response = MagicMock()
+    response.status_code = status_code
+    return HTTPError(response=response)
+
+
+def _make_404_error():
+    """Create a mock HTTPError with a 404 response."""
+    return _make_http_error(404)
+
+
+def _make_benchmark_py(workspace: Path) -> None:
+    """Write a minimal benchmark.py with cell delimiters."""
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / "benchmark.py").write_text("# %%\nprint('hello')\n")
+
+
+def _make_save_kernel_response(error=""):
+    """Create a mock ApiSaveKernelResponse."""
+    resp = MagicMock()
+    resp.error = error
+    resp.invalid_tags = []
+    return resp
+
+
+def _make_status_response(status_str):
+    """Create a mock ApiGetKernelSessionStatusResponse."""
+
+    class FakeStatus:
+        status = status_str
+
+    return FakeStatus()
+
+
+def _make_archive_response(*files):
+    """Create a mock streamed response with a tar archive containing the given files.
+
+    Args:
+        *files: Tuples of (filename, content_string) to include in the archive.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, content in files:
+            data = content.encode("utf-8")
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    buf.seek(0)
+
+    response = MagicMock()
+    response.iter_content = lambda chunk_size=8192: iter([buf.read()])
+    return response
+
+
+def _make_get_kernel_response(
+    source_json=None, metadata_dict=None, ipynb_name="notebook.ipynb"
+):
+    """Create a mock ApiGetKernelResponse.
+
+    Args:
+        source_json: The notebook source (raw .ipynb JSON dict). If None, uses a default.
+        metadata_dict: The metadata dict. If None, uses a default.
+        ipynb_name: Used to construct the default metadata 'ref'.
+    """
+    if source_json is None:
+        source_json = {
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "source": ["print('hello')\n"],
+                    "metadata": {},
+                    "outputs": [],
+                    "execution_count": None,
+                }
+            ],
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 5,
+        }
+
+    if metadata_dict is None:
+        metadata_dict = {
+            "ref": f"source/{ipynb_name.replace('.ipynb', '')}",
+            "title": ipynb_name.replace(".ipynb", ""),
+            "language": "python",
+            "kernel_type": "notebook",
+            "is_private": True,
+            "enable_gpu": False,
+            "enable_internet": True,
+            "enable_tpu": False,
+            "dataset_data_sources": [],
+            "competition_data_sources": [],
+            "kernel_data_sources": [],
+            "model_data_sources": [],
+            "category_ids": [],
+        }
+
+    import types
+
+    resp = MagicMock()
+    resp.blob.source = json.dumps(source_json)
+    # Use SimpleNamespace so getattr(meta, "missing_field", None) returns None correctly
+    resp.metadata = types.SimpleNamespace(**metadata_dict)
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Internal Helpers
+# ---------------------------------------------------------------------------
+
+
+def test_notebook_id(client):
+    """_notebook_id should be username/slug."""
+    assert client._notebook_id("my-notebook") == "testuser/my-notebook"
+
+
+def test_tracking_url(client):
+    """_tracking_url should build a valid Kaggle URL."""
+    assert (
+        client._tracking_url("my-notebook")
+        == "https://www.kaggle.com/testuser/my-notebook"
+    )
+
+
+def test_workspace_path(client, tmp_path):
+    """_workspace should return base_dir / slug."""
+    ws = client._workspace("my-notebook")
+    assert ws == tmp_path / "my-notebook"
+
+
+# ---------------------------------------------------------------------------
+# publish_and_run
+# ---------------------------------------------------------------------------
+
+
+def test_publish_and_run_basic(client, mock_api, tmp_path):
+    """Happy path: workspace exists, benchmark.py exists, no prior kernel."""
+    slug = "test-bench"
+    _make_benchmark_py(tmp_path / slug)
+
+    # No existing kernel (404)
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.side_effect = (
+        _make_404_error()
+    )
+    mock_api.kernels.kernels_api_client.save_kernel.return_value = (
+        _make_save_kernel_response()
+    )
+
+    url = client.publish_and_run(slug)
+
+    assert "testuser/test-bench" in url
+    mock_api.kernels.kernels_api_client.save_kernel.assert_called_once()
+
+    # Verify the save_kernel request has correct slug
+    call_args = mock_api.kernels.kernels_api_client.save_kernel.call_args
+    req = call_args[0][0]
+    assert req.slug == "testuser/test-bench"
+
+    # Verify metadata was written
+    meta = json.loads((tmp_path / slug / "kernel-metadata.json").read_text())
+    assert meta["id"] == "testuser/test-bench"
+    assert "personal-benchmark" in meta["keywords"]
+
+    # Verify .ipynb was created
+    assert (tmp_path / slug / "benchmark.ipynb").exists()
+
+
+def test_publish_and_run_with_source_file(client, mock_api, tmp_path):
+    """Source file is copied into the workspace before processing."""
+    slug = "test-bench"
+    source = tmp_path / "my_script.py"
+    source.write_text("# %%\nimport kaggle_benchmarks as kbench\n")
+
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.side_effect = (
+        _make_404_error()
+    )
+    mock_api.kernels.kernels_api_client.save_kernel.return_value = (
+        _make_save_kernel_response()
+    )
+
+    _ = client.publish_and_run(slug, source_file=str(source))
+
+    workspace = tmp_path / slug
+    assert (workspace / "benchmark.py").exists()
+    assert (workspace / "benchmark.ipynb").exists()
+    mock_api.kernels.kernels_api_client.save_kernel.assert_called_once()
+
+
+def test_publish_and_run_dataset_sources(client, mock_api, tmp_path):
+    """Dataset sources are passed through to metadata."""
+    slug = "test-bench"
+    _make_benchmark_py(tmp_path / slug)
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.side_effect = (
+        _make_404_error()
+    )
+    mock_api.kernels.kernels_api_client.save_kernel.return_value = (
+        _make_save_kernel_response()
+    )
+
+    client.publish_and_run(slug, dataset_sources=["alice/data", "bob/more-data"])
+
+    meta = json.loads((tmp_path / slug / "kernel-metadata.json").read_text())
+    assert meta["dataset_sources"] == ["alice/data", "bob/more-data"]
+
+
+def test_publish_and_run_concurrent_guard(client, mock_api, tmp_path):
+    """Raises ConcurrentRunError when notebook is already running."""
+    slug = "test-bench"
+    _make_benchmark_py(tmp_path / slug)
+
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("running")
+    )
+
+    with pytest.raises(ConcurrentRunError, match="already running"):
+        client.publish_and_run(slug)
+
+    mock_api.kernels.kernels_api_client.save_kernel.assert_not_called()
+
+
+def test_publish_and_run_concurrent_guard_queued(client, mock_api, tmp_path):
+    """Raises ConcurrentRunError when notebook is queued."""
+    slug = "test-bench"
+    _make_benchmark_py(tmp_path / slug)
+
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("queued")
+    )
+
+    with pytest.raises(ConcurrentRunError, match="already running"):
+        client.publish_and_run(slug)
+
+
+def test_publish_and_run_concurrent_guard_non_404_error(client, mock_api, tmp_path):
+    """Non-404 HTTPError during status check should propagate as HTTPError."""
+    slug = "test-bench"
+    _make_benchmark_py(tmp_path / slug)
+
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.side_effect = (
+        _make_http_error(500)
+    )
+
+    with pytest.raises(HTTPError):
+        client.publish_and_run(slug)
+
+    mock_api.kernels.kernels_api_client.save_kernel.assert_not_called()
+
+
+def test_publish_and_run_force(client, mock_api, tmp_path):
+    """force=True bypasses the concurrent run guard entirely."""
+    slug = "test-bench"
+    _make_benchmark_py(tmp_path / slug)
+
+    mock_api.kernels.kernels_api_client.save_kernel.return_value = (
+        _make_save_kernel_response()
+    )
+
+    _ = client.publish_and_run(slug, force=True)
+
+    # get_kernel_session_status should NOT be called (guard skipped)
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.assert_not_called()
+    mock_api.kernels.kernels_api_client.save_kernel.assert_called_once()
+
+
+def test_publish_and_run_missing_file(client, tmp_path):
+    """Raises FileNotFoundError when benchmark.py doesn't exist."""
+    with pytest.raises(FileNotFoundError, match="Benchmark file not found"):
+        client.publish_and_run("nonexistent")
+
+
+def test_publish_and_run_missing_source_file(client, tmp_path):
+    """Raises FileNotFoundError when source_file doesn't exist."""
+    with pytest.raises(FileNotFoundError, match="Source file not found"):
+        client.publish_and_run("test-bench", source_file="/nonexistent/path.py")
+
+
+# ---------------------------------------------------------------------------
+# get_results
+# ---------------------------------------------------------------------------
+
+
+def test_get_results_complete_immediately(client, mock_api, tmp_path):
+    """Kernel is already complete — downloads output immediately."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("complete")
+    )
+    mock_api.kernels.kernels_api_client.download_kernel_output.return_value = (
+        _make_archive_response(("run.json", '{"score": 0.95}'))
+    )
+
+    result = client.get_results(slug)
+
+    assert result.status == "complete"
+    assert result.output_dir is not None
+    assert result.error is None
+    # Tests that it works with the single legacy `run.json` as well
+    runs = dict(result.iter_run_results())
+    assert len(runs) == 1
+    assert runs["run.json"] == {"score": 0.95}
+
+
+def test_get_results_multiple_run_files(client, mock_api, tmp_path):
+    """Kernel completes and produces multiple *.run.json files."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("complete")
+    )
+    mock_api.kernels.kernels_api_client.download_kernel_output.return_value = (
+        _make_archive_response(
+            ("task_1.run.json", '{"score": 1}'),
+            ("task_2.run.json", '{"score": 2}'),
+        )
+    )
+
+    result = client.get_results(slug)
+
+    assert result.status == "complete"
+    assert result.output_dir is not None
+
+    runs = dict(result.iter_run_results())
+    assert len(runs) == 2
+    assert runs["task_1.run.json"] == {"score": 1}
+    assert runs["task_2.run.json"] == {"score": 2}
+
+
+def test_get_results_polls_until_complete(client, mock_api, tmp_path, monkeypatch):
+    """Polls through queued -> running -> complete."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    statuses = iter(
+        [
+            _make_status_response("queued"),
+            _make_status_response("running"),
+            _make_status_response("complete"),
+        ]
+    )
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.side_effect = (
+        lambda *a, **k: next(statuses)
+    )
+    mock_api.kernels.kernels_api_client.download_kernel_output.return_value = (
+        _make_archive_response()
+    )
+
+    collected = []
+    result = client.get_results(slug, poll_interval=0.01, on_status=collected.append)
+
+    assert result.status == "complete"
+    # Callbacks: "queued" (in-loop), "running" (in-loop), "complete" (post-loop)
+    assert collected == ["queued", "running", "complete"]
+
+
+def test_get_results_timeout(client, mock_api, tmp_path, monkeypatch):
+    """Returns timeout when exceeding the timeout limit."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("running")
+    )
+
+    result = client.get_results(slug, poll_interval=1, timeout=0)
+
+    assert result.status == "timeout"
+    assert result.output_dir is None
+
+
+def test_get_results_cancel(client, mock_api, tmp_path):
+    """Returns cancelled when cancel_event is set."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("running")
+    )
+
+    cancel_event = threading.Event()
+    cancel_event.set()  # Set immediately
+
+    result = client.get_results(slug, cancel_event=cancel_event)
+
+    assert result.status == "cancelled"
+
+
+def test_get_results_cancel_mid_wait(client, mock_api, tmp_path):
+    """Returns cancelled when cancel_event fires during poll wait."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("running")
+    )
+
+    cancel_event = threading.Event()
+
+    # Set the cancel event after a short delay to trigger during wait()
+    def cancel_after_delay():
+        time.sleep(0.05)
+        cancel_event.set()
+
+    timer = threading.Thread(target=cancel_after_delay, daemon=True)
+    timer.start()
+
+    result = client.get_results(
+        slug,
+        poll_interval=10,  # Long poll — cancel fires during the wait
+        cancel_event=cancel_event,
+    )
+    timer.join(timeout=5)
+
+    assert result.status == "cancelled"
+
+
+def test_get_results_error_status(client, mock_api, tmp_path):
+    """Returns error when Kaggle reports an error status."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("error")
+    )
+
+    result = client.get_results(slug)
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert "error" in result.error
+
+
+def test_get_results_initial_404_retries(client, mock_api, tmp_path, monkeypatch):
+    """Handles initial 404s after push with retries."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    # First 2 calls return 404, then "complete"
+    call_count = 0
+
+    def status_side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise _make_404_error()
+        return _make_status_response("complete")
+
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.side_effect = (
+        status_side_effect
+    )
+    mock_api.kernels.kernels_api_client.download_kernel_output.return_value = (
+        _make_archive_response()
+    )
+
+    result = client.get_results(slug, poll_interval=0.01)
+
+    assert result.status == "complete"
+    assert call_count == 3  # 2 retries + 1 success
+
+
+def test_get_results_all_retries_exhausted(client, mock_api, tmp_path, monkeypatch):
+    """Returns error when all 404 retries are exhausted."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.side_effect = (
+        _make_404_error()
+    )
+
+    result = client.get_results(slug)
+
+    assert result.status == "error"
+    assert "retries" in result.error
+
+
+def test_get_results_non_404_error_during_retries(
+    client, mock_api, tmp_path, monkeypatch
+):
+    """Non-404 HTTPError during initial retry loop should propagate immediately."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.side_effect = (
+        _make_http_error(500)
+    )
+
+    with pytest.raises(HTTPError):
+        client.get_results(slug)
+
+
+def test_get_results_on_status_callback(client, mock_api, tmp_path, monkeypatch):
+    """on_status callback receives intermediate and final statuses but deduplicates repeats."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    statuses = iter(
+        [
+            _make_status_response("running"),
+            _make_status_response("running"),
+            _make_status_response("complete"),
+        ]
+    )
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.side_effect = (
+        lambda *a, **k: next(statuses)
+    )
+    mock_api.kernels.kernels_api_client.download_kernel_output.return_value = (
+        _make_archive_response()
+    )
+
+    collected = []
+    result = client.get_results(slug, poll_interval=0.01, on_status=collected.append)
+
+    assert result.status == "complete"
+    assert collected == ["running", "complete"]
+
+
+def test_get_results_no_run_json(client, mock_api, tmp_path):
+    """iter_run_results() yields nothing when no run.json is produced."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("complete")
+    )
+    mock_api.kernels.kernels_api_client.download_kernel_output.return_value = (
+        _make_archive_response()
+    )
+
+    result = client.get_results(slug)
+
+    assert result.status == "complete"
+    assert not dict(result.iter_run_results())
+
+
+def test_get_results_custom_output_dir(client, mock_api, tmp_path):
+    """output_dir parameter overrides the default output path."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+
+    custom_output = tmp_path / "my_custom_output"
+
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("complete")
+    )
+    mock_api.kernels.kernels_api_client.download_kernel_output.return_value = (
+        _make_archive_response(("run.json", '{"score": 0.95}'))
+    )
+
+    result = client.get_results(slug, output_dir=str(custom_output))
+
+    assert result.status == "complete"
+    assert result.output_dir == str(custom_output)
+    assert custom_output.exists()
+
+    runs = dict(result.iter_run_results())
+    assert len(runs) == 1
+
+
+def test_get_results_clears_existing_output(client, mock_api, tmp_path):
+    """Existing output files are cleared before downloading by default."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+
+    # Create pre-existing output directory with an old file
+    output_dir = tmp_path / slug / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    old_file = output_dir / "old_result.txt"
+    old_file.write_text("stale data")
+
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("complete")
+    )
+    mock_api.kernels.kernels_api_client.download_kernel_output.return_value = (
+        _make_archive_response(("run.json", '{"score": 0.95}'))
+    )
+
+    result = client.get_results(slug)
+
+    assert result.status == "complete"
+    # Old file should have been removed
+    assert not old_file.exists()
+
+
+def test_get_results_no_clear_output(client, mock_api, tmp_path):
+    """clear_output=False preserves existing files in the output directory."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+
+    # Create pre-existing output directory with an old file
+    output_dir = tmp_path / slug / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    old_file = output_dir / "old_result.txt"
+    old_file.write_text("keep me")
+
+    mock_api.kernels.kernels_api_client.get_kernel_session_status.return_value = (
+        _make_status_response("complete")
+    )
+    mock_api.kernels.kernels_api_client.download_kernel_output.return_value = (
+        _make_archive_response(("run.json", '{"score": 0.95}'))
+    )
+
+    result = client.get_results(slug, clear_output=False)
+
+    assert result.status == "complete"
+    # Old file should still exist
+    assert old_file.exists()
+    assert old_file.read_text() == "keep me"
+    # New file should also exist
+    runs = dict(result.iter_run_results())
+    assert len(runs) == 1
+
+
+# ---------------------------------------------------------------------------
+# RunResult.iter_run_results edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_iter_run_results_nonexistent_output_dir(tmp_path):
+    """iter_run_results() yields nothing when output_dir does not exist."""
+    result = RunResult(
+        status="complete",
+        output_dir=str(tmp_path / "nonexistent"),
+        tracking_url=None,
+    )
+    assert list(result.iter_run_results()) == []
+    assert dict(result.iter_run_results()) == {}
+
+
+def test_iter_run_results_none_output_dir():
+    """iter_run_results() yields nothing when output_dir is None."""
+    result = RunResult(
+        status="error",
+        output_dir=None,
+        tracking_url=None,
+    )
+    assert list(result.iter_run_results()) == []
+    assert dict(result.iter_run_results()) == {}
+
+
+# ---------------------------------------------------------------------------
+# fork
+# ---------------------------------------------------------------------------
+
+
+def test_fork_basic(client, mock_api, tmp_path):
+    """Happy path: pulls notebook and converts to .py."""
+    mock_api.kernels.kernels_api_client.get_kernel.return_value = (
+        _make_get_kernel_response(ipynb_name="riddle-benchmark.ipynb")
+    )
+
+    result = client.fork("alice/riddle-benchmark")
+
+    assert result == tmp_path / "riddle-benchmark"
+    assert (result / "benchmark.py").exists()
+    assert (result / "kernel-metadata.json").exists()
+    assert (result / "benchmark.ipynb").exists()
+
+    # Verify the .py file has cell delimiters
+    py_content = (result / "benchmark.py").read_text()
+    assert "# %%" in py_content
+    assert "print('hello')" in py_content
+
+
+def test_fork_custom_slug(client, mock_api, tmp_path):
+    """Custom notebook_slug overrides the default."""
+    mock_api.kernels.kernels_api_client.get_kernel.return_value = (
+        _make_get_kernel_response(ipynb_name="notebook.ipynb")
+    )
+
+    result = client.fork("alice/riddle-benchmark", dest_notebook_slug="my-riddle")
+
+    assert result == tmp_path / "my-riddle"
+    assert (result / "benchmark.py").exists()
+
+
+def test_fork_exists_error(client, mock_api, tmp_path):
+    """Raises FileExistsError when workspace already exists."""
+    (tmp_path / "riddle-benchmark").mkdir()
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        client.fork("alice/riddle-benchmark")
+
+
+def test_fork_overwrite(client, mock_api, tmp_path):
+    """overwrite=True removes the existing workspace."""
+    workspace = tmp_path / "riddle-benchmark"
+    workspace.mkdir()
+    (workspace / "old-file.txt").write_text("old content")
+
+    mock_api.kernels.kernels_api_client.get_kernel.return_value = (
+        _make_get_kernel_response(ipynb_name="riddle-benchmark.ipynb")
+    )
+
+    _ = client.fork("alice/riddle-benchmark", overwrite=True)
+
+    assert not (workspace / "old-file.txt").exists()
+    assert (workspace / "benchmark.py").exists()
+
+
+def test_fork_missing_notebook_raises_value_error(client, mock_api):
+    """fork() should raise a friendly ValueError for any HTTPError."""
+    mock_api.kernels.kernels_api_client.get_kernel.side_effect = _make_404_error()
+
+    with pytest.raises(
+        ValueError, match="Failed to pull notebook 'kaggle/does-not-exist'"
+    ):
+        client.fork("kaggle/does-not-exist")
+
+
+def test_fork_http_error_500_raises_value_error(client, mock_api):
+    """fork() wraps any HTTPError (including 500) in ValueError."""
+    mock_api.kernels.kernels_api_client.get_kernel.side_effect = _make_http_error(500)
+
+    with pytest.raises(ValueError, match="Failed to pull notebook"):
+        client.fork("kaggle/server-error-notebook")
+
+
+def test_fork_no_source(client, mock_api, tmp_path, caplog):
+    """fork() should log a warning when no source is found (empty blob)."""
+    resp = MagicMock()
+    resp.blob.source = None
+    resp.metadata = None  # No metadata either
+    mock_api.kernels.kernels_api_client.get_kernel.return_value = resp
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        result = client.fork("alice/script-notebook")
+
+    assert result == tmp_path / "script-notebook"
+    # No source → no benchmark.py conversion
+    assert not (result / "benchmark.py").exists()
+    # Warning should be logged
+    assert "No source found" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# _authenticate (integration of the above)
+# ---------------------------------------------------------------------------
+
+
+def test_authenticate_import_error():
+    """Raises KaggleAuthError when kagglesdk package is not installed."""
+    with patch.dict(
+        "sys.modules",
+        {
+            "kagglesdk": None,
+            "kagglesdk.kaggle_client": None,
+            "kagglesdk.kaggle_env": None,
+        },
+    ):
+        # Force ImportError by removing the module from sys.modules cache
+        import sys
+
+        saved = {}
+        for mod_name in list(sys.modules):
+            if mod_name.startswith("kagglesdk"):
+                saved[mod_name] = sys.modules.pop(mod_name)
+
+        try:
+            with patch(
+                "builtins.__import__",
+                side_effect=ImportError("No module named 'kagglesdk'"),
+            ):
+                with pytest.raises(KaggleAuthError, match="kagglesdk.*required"):
+                    _authenticate()
+        finally:
+            sys.modules.update(saved)

--- a/tests/kaggle_client/test_notebook_api.py
+++ b/tests/kaggle_client/test_notebook_api.py
@@ -1,0 +1,774 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from requests.exceptions import HTTPError
+
+from kaggle_benchmarks.kaggle_client.notebook_api import (
+    BenchmarkNotebookClient,
+    ConcurrentRunError,
+    KaggleAuthError,
+    RunResult,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_api():
+    """Create a mock Kaggle API."""
+    api = MagicMock()
+    api.get_config_value.return_value = "testuser"
+    return api
+
+
+@pytest.fixture
+def client(mock_api, tmp_path):
+    """Create a BenchmarkNotebookClient with a mocked API."""
+    with patch.object(BenchmarkNotebookClient, "_authenticate", return_value=mock_api):
+        return BenchmarkNotebookClient(base_dir=tmp_path)
+
+
+def _make_http_error(status_code):
+    """Create a mock HTTPError with the given response status code."""
+    response = MagicMock()
+    response.status_code = status_code
+    return HTTPError(response=response)
+
+
+def _make_404_error():
+    """Create a mock HTTPError with a 404 response."""
+    return _make_http_error(404)
+
+
+def _make_benchmark_py(workspace: Path) -> None:
+    """Write a minimal benchmark.py with cell delimiters."""
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / "benchmark.py").write_text("# %%\nprint('hello')\n")
+
+
+def _fake_kernels_output(kernel, path, force):
+    """Simulate kernels_output by creating the output directory."""
+    Path(path).mkdir(parents=True, exist_ok=True)
+
+
+def _fake_kernels_output_with_run_json(kernel, path, force):
+    """Simulate kernels_output that produces a run.json."""
+    p = Path(path)
+    p.mkdir(parents=True, exist_ok=True)
+    (p / "run.json").write_text('{"score": 0.95}')
+
+
+def _fake_kernels_output_with_multiple_run_jsons(kernel, path, force):
+    """Simulate kernels_output that produces multiple *.run.json files."""
+    p = Path(path)
+    p.mkdir(parents=True, exist_ok=True)
+    (p / "task_1.run.json").write_text('{"score": 1}')
+    (p / "task_2.run.json").write_text('{"score": 2}')
+
+
+# ---------------------------------------------------------------------------
+# Internal Helpers
+# ---------------------------------------------------------------------------
+
+
+def test_notebook_id(client):
+    """_notebook_id should be username/slug."""
+    assert client._notebook_id("my-notebook") == "testuser/my-notebook"
+
+
+def test_tracking_url(client):
+    """_tracking_url should build a valid Kaggle URL."""
+    assert (
+        client._tracking_url("my-notebook")
+        == "https://www.kaggle.com/testuser/my-notebook"
+    )
+
+
+def test_workspace_path(client, tmp_path):
+    """_workspace should return base_dir / slug."""
+    ws = client._workspace("my-notebook")
+    assert ws == tmp_path / "my-notebook"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw_status, expected",
+    [
+        ("complete", "complete"),
+        ("Complete", "complete"),
+        ("KernelWorkerStatus.complete", "complete"),
+        ("kernelworkerstatus.running", "running"),
+        ("error", "error"),
+    ],
+)
+def test_normalize_status_strings(raw_status, expected):
+    """_normalize_status should strip enum prefixes and lower-case."""
+    assert BenchmarkNotebookClient._normalize_status(raw_status) == expected
+
+
+def test_normalize_status_object_with_attribute():
+    """Simulates an API response object with a .status attribute."""
+
+    class FakeStatus:
+        status = "running"
+
+    assert BenchmarkNotebookClient._normalize_status(FakeStatus()) == "running"
+
+
+# ---------------------------------------------------------------------------
+# publish_and_run
+# ---------------------------------------------------------------------------
+
+
+def test_publish_and_run_basic(client, mock_api, tmp_path):
+    """Happy path: workspace exists, benchmark.py exists, no prior kernel."""
+    slug = "test-bench"
+    _make_benchmark_py(tmp_path / slug)
+
+    # No existing kernel (404)
+    mock_api.kernels_status.side_effect = _make_404_error()
+
+    url = client.publish_and_run(slug)
+
+    assert "testuser/test-bench" in url
+    mock_api.kernels_push.assert_called_once_with(str(tmp_path / slug))
+
+    # Verify metadata was written
+    meta = json.loads((tmp_path / slug / "kernel-metadata.json").read_text())
+    assert meta["id"] == "testuser/test-bench"
+    assert "personal-benchmark" in meta["keywords"]
+
+    # Verify .ipynb was created
+    assert (tmp_path / slug / "benchmark.ipynb").exists()
+
+
+def test_publish_and_run_with_source_file(client, mock_api, tmp_path):
+    """Source file is copied into the workspace before processing."""
+    slug = "test-bench"
+    source = tmp_path / "my_script.py"
+    source.write_text("# %%\nimport kaggle_benchmarks as kbench\n")
+
+    mock_api.kernels_status.side_effect = _make_404_error()
+
+    _ = client.publish_and_run(slug, source_file=str(source))
+
+    workspace = tmp_path / slug
+    assert (workspace / "benchmark.py").exists()
+    assert (workspace / "benchmark.ipynb").exists()
+    mock_api.kernels_push.assert_called_once()
+
+
+def test_publish_and_run_dataset_sources(client, mock_api, tmp_path):
+    """Dataset sources are passed through to metadata."""
+    slug = "test-bench"
+    _make_benchmark_py(tmp_path / slug)
+    mock_api.kernels_status.side_effect = _make_404_error()
+
+    client.publish_and_run(slug, dataset_sources=["alice/data", "bob/more-data"])
+
+    meta = json.loads((tmp_path / slug / "kernel-metadata.json").read_text())
+    assert meta["dataset_sources"] == ["alice/data", "bob/more-data"]
+
+
+def test_publish_and_run_concurrent_guard(client, mock_api, tmp_path):
+    """Raises ConcurrentRunError when notebook is already running."""
+    slug = "test-bench"
+    _make_benchmark_py(tmp_path / slug)
+
+    mock_api.kernels_status.return_value = "running"
+
+    with pytest.raises(ConcurrentRunError, match="already running"):
+        client.publish_and_run(slug)
+
+    mock_api.kernels_push.assert_not_called()
+
+
+def test_publish_and_run_concurrent_guard_queued(client, mock_api, tmp_path):
+    """Raises ConcurrentRunError when notebook is queued."""
+    slug = "test-bench"
+    _make_benchmark_py(tmp_path / slug)
+
+    mock_api.kernels_status.return_value = "queued"
+
+    with pytest.raises(ConcurrentRunError, match="already running"):
+        client.publish_and_run(slug)
+
+
+def test_publish_and_run_concurrent_guard_non_404_error(client, mock_api, tmp_path):
+    """Non-404 HTTPError during status check should propagate as HTTPError."""
+    slug = "test-bench"
+    _make_benchmark_py(tmp_path / slug)
+
+    mock_api.kernels_status.side_effect = _make_http_error(500)
+
+    with pytest.raises(HTTPError):
+        client.publish_and_run(slug)
+
+    mock_api.kernels_push.assert_not_called()
+
+
+def test_publish_and_run_force(client, mock_api, tmp_path):
+    """force=True bypasses the concurrent run guard entirely."""
+    slug = "test-bench"
+    _make_benchmark_py(tmp_path / slug)
+
+    _ = client.publish_and_run(slug, force=True)
+
+    # kernels_status should NOT be called (guard skipped)
+    mock_api.kernels_status.assert_not_called()
+    mock_api.kernels_push.assert_called_once()
+
+
+def test_publish_and_run_missing_file(client, tmp_path):
+    """Raises FileNotFoundError when benchmark.py doesn't exist."""
+    with pytest.raises(FileNotFoundError, match="Benchmark file not found"):
+        client.publish_and_run("nonexistent")
+
+
+def test_publish_and_run_missing_source_file(client, tmp_path):
+    """Raises FileNotFoundError when source_file doesn't exist."""
+    with pytest.raises(FileNotFoundError, match="Source file not found"):
+        client.publish_and_run("test-bench", source_file="/nonexistent/path.py")
+
+
+# ---------------------------------------------------------------------------
+# get_results
+# ---------------------------------------------------------------------------
+
+
+def test_get_results_complete_immediately(client, mock_api, tmp_path):
+    """Kernel is already complete — downloads output immediately."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+
+    mock_api.kernels_status.return_value = "complete"
+    mock_api.kernels_output.side_effect = _fake_kernels_output_with_run_json
+
+    result = client.get_results(slug)
+
+    assert result.status == "complete"
+    assert result.output_dir is not None
+    assert result.error is None
+    # Tests that it works with the single legacy `run.json` as well
+    runs = dict(result.iter_runs())
+    assert len(runs) == 1
+    assert runs["run.json"] == {"score": 0.95}
+
+
+def test_get_results_multiple_run_files(client, mock_api, tmp_path):
+    """Kernel completes and produces multiple *.run.json files."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+
+    mock_api.kernels_status.return_value = "complete"
+    mock_api.kernels_output.side_effect = _fake_kernels_output_with_multiple_run_jsons
+
+    result = client.get_results(slug)
+
+    assert result.status == "complete"
+    assert result.output_dir is not None
+
+    runs = dict(result.iter_runs())
+    assert len(runs) == 2
+    assert runs["task_1.run.json"] == {"score": 1}
+    assert runs["task_2.run.json"] == {"score": 2}
+
+
+def test_get_results_polls_until_complete(client, mock_api, tmp_path, monkeypatch):
+    """Polls through queued -> running -> complete."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    statuses = iter(["queued", "running", "complete"])
+    mock_api.kernels_status.side_effect = lambda *a, **k: next(statuses)
+    mock_api.kernels_output.side_effect = _fake_kernels_output
+
+    collected = []
+    result = client.get_results(slug, poll_interval=0.01, on_status=collected.append)
+
+    assert result.status == "complete"
+    # Callbacks: "queued" (in-loop), "running" (in-loop), "complete" (post-loop)
+    assert collected == ["queued", "running", "complete"]
+
+
+def test_get_results_timeout(client, mock_api, tmp_path, monkeypatch):
+    """Returns timeout when exceeding the timeout limit."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    mock_api.kernels_status.return_value = "running"
+
+    result = client.get_results(slug, poll_interval=1, timeout=0)
+
+    assert result.status == "timeout"
+    assert result.output_dir is None
+
+
+def test_get_results_cancel(client, mock_api, tmp_path):
+    """Returns cancelled when cancel_event is set."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+
+    mock_api.kernels_status.return_value = "running"
+
+    cancel_event = threading.Event()
+    cancel_event.set()  # Set immediately
+
+    result = client.get_results(slug, cancel_event=cancel_event)
+
+    assert result.status == "cancelled"
+
+
+def test_get_results_cancel_mid_wait(client, mock_api, tmp_path):
+    """Returns cancelled when cancel_event fires during poll wait."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+
+    mock_api.kernels_status.return_value = "running"
+
+    cancel_event = threading.Event()
+
+    # Set the cancel event after a short delay to trigger during wait()
+    def cancel_after_delay():
+        time.sleep(0.05)
+        cancel_event.set()
+
+    timer = threading.Thread(target=cancel_after_delay, daemon=True)
+    timer.start()
+
+    result = client.get_results(
+        slug,
+        poll_interval=10,  # Long poll — cancel fires during the wait
+        cancel_event=cancel_event,
+    )
+    timer.join(timeout=5)
+
+    assert result.status == "cancelled"
+
+
+def test_get_results_error_status(client, mock_api, tmp_path):
+    """Returns error when Kaggle reports an error status."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+
+    mock_api.kernels_status.return_value = "error"
+
+    result = client.get_results(slug)
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert "error" in result.error
+
+
+def test_get_results_initial_404_retries(client, mock_api, tmp_path, monkeypatch):
+    """Handles initial 404s after push with retries."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    # First 2 calls return 404, then "complete"
+    call_count = 0
+
+    def status_side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise _make_404_error()
+        return "complete"
+
+    mock_api.kernels_status.side_effect = status_side_effect
+    mock_api.kernels_output.side_effect = _fake_kernels_output
+
+    result = client.get_results(slug, poll_interval=0.01)
+
+    assert result.status == "complete"
+    assert call_count == 3  # 2 retries + 1 success
+
+
+def test_get_results_all_retries_exhausted(client, mock_api, tmp_path, monkeypatch):
+    """Returns error when all 404 retries are exhausted."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    mock_api.kernels_status.side_effect = _make_404_error()
+
+    result = client.get_results(slug)
+
+    assert result.status == "error"
+    assert "retries" in result.error
+
+
+def test_get_results_non_404_error_during_retries(
+    client, mock_api, tmp_path, monkeypatch
+):
+    """Non-404 HTTPError during initial retry loop should propagate immediately."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    mock_api.kernels_status.side_effect = _make_http_error(500)
+
+    with pytest.raises(HTTPError):
+        client.get_results(slug)
+
+
+def test_get_results_on_status_callback(client, mock_api, tmp_path, monkeypatch):
+    """on_status callback receives intermediate and final statuses but deduplicates repeats."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    statuses = iter(["running", "running", "complete"])
+    mock_api.kernels_status.side_effect = lambda *a, **k: next(statuses)
+    mock_api.kernels_output.side_effect = _fake_kernels_output
+
+    collected = []
+    result = client.get_results(slug, poll_interval=0.01, on_status=collected.append)
+
+    assert result.status == "complete"
+    assert collected == ["running", "complete"]
+
+
+def test_get_results_no_run_json(client, mock_api, tmp_path):
+    """iter_runs() yields nothing when no run.json is produced."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+
+    mock_api.kernels_status.return_value = "complete"
+    mock_api.kernels_output.side_effect = _fake_kernels_output
+
+    result = client.get_results(slug)
+
+    assert result.status == "complete"
+    assert not dict(result.iter_runs())
+
+
+def test_get_results_custom_output_dir(client, mock_api, tmp_path):
+    """output_dir parameter overrides the default output path."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+
+    custom_output = tmp_path / "my_custom_output"
+
+    mock_api.kernels_status.return_value = "complete"
+    mock_api.kernels_output.side_effect = _fake_kernels_output_with_run_json
+
+    result = client.get_results(slug, output_dir=str(custom_output))
+
+    assert result.status == "complete"
+    assert result.output_dir == str(custom_output)
+    assert custom_output.exists()
+
+    runs = dict(result.iter_runs())
+    assert len(runs) == 1
+
+
+def test_get_results_clears_existing_output(client, mock_api, tmp_path):
+    """Existing output files are cleared before downloading by default."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+
+    # Create pre-existing output directory with an old file
+    output_dir = tmp_path / slug / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    old_file = output_dir / "old_result.txt"
+    old_file.write_text("stale data")
+
+    mock_api.kernels_status.return_value = "complete"
+    mock_api.kernels_output.side_effect = _fake_kernels_output_with_run_json
+
+    result = client.get_results(slug)
+
+    assert result.status == "complete"
+    # Old file should have been removed
+    assert not old_file.exists()
+
+
+def test_get_results_no_clear_output(client, mock_api, tmp_path):
+    """clear_output=False preserves existing files in the output directory."""
+    slug = "test-bench"
+    (tmp_path / slug).mkdir()
+
+    # Create pre-existing output directory with an old file
+    output_dir = tmp_path / slug / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    old_file = output_dir / "old_result.txt"
+    old_file.write_text("keep me")
+
+    mock_api.kernels_status.return_value = "complete"
+    mock_api.kernels_output.side_effect = _fake_kernels_output_with_run_json
+
+    result = client.get_results(slug, clear_output=False)
+
+    assert result.status == "complete"
+    # Old file should still exist
+    assert old_file.exists()
+    assert old_file.read_text() == "keep me"
+    # New file should also exist
+    runs = dict(result.iter_runs())
+    assert len(runs) == 1
+
+
+# ---------------------------------------------------------------------------
+# RunResult.iter_runs edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_iter_runs_nonexistent_output_dir(tmp_path):
+    """iter_runs() yields nothing when output_dir does not exist."""
+    result = RunResult(
+        status="complete",
+        output_dir=str(tmp_path / "nonexistent"),
+        tracking_url=None,
+    )
+    assert list(result.iter_runs()) == []
+    assert dict(result.iter_runs()) == {}
+
+
+def test_iter_runs_none_output_dir():
+    """iter_runs() yields nothing when output_dir is None."""
+    result = RunResult(
+        status="error",
+        output_dir=None,
+        tracking_url=None,
+    )
+    assert list(result.iter_runs()) == []
+    assert dict(result.iter_runs()) == {}
+
+
+# ---------------------------------------------------------------------------
+# fork
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_pull(ipynb_name="notebook.ipynb"):
+    """Create a fake kernels_pull that writes a notebook and metadata."""
+
+    def fake_pull(notebook, path, metadata):
+        p = Path(path)
+        p.mkdir(parents=True, exist_ok=True)
+        notebook_data = {
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "source": ["print('hello')\n"],
+                    "metadata": {},
+                    "outputs": [],
+                    "execution_count": None,
+                }
+            ],
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 5,
+        }
+        (p / ipynb_name).write_text(json.dumps(notebook_data))
+        if metadata:
+            (p / "kernel-metadata.json").write_text(
+                json.dumps({"id": f"source/{ipynb_name.replace('.ipynb', '')}"})
+            )
+
+    return fake_pull
+
+
+def _make_fake_pull_no_ipynb():
+    """Create a fake kernels_pull that writes only metadata (no .ipynb)."""
+
+    def fake_pull(notebook, path, metadata):
+        p = Path(path)
+        p.mkdir(parents=True, exist_ok=True)
+        # Write a plain .py script file instead of .ipynb
+        (p / "script.py").write_text("print('hello')\n")
+        if metadata:
+            (p / "kernel-metadata.json").write_text(
+                json.dumps({"id": "source/script-notebook", "code_file": "script.py"})
+            )
+
+    return fake_pull
+
+
+def test_fork_basic(client, mock_api, tmp_path):
+    """Happy path: pulls notebook and converts to .py."""
+    mock_api.kernels_pull.side_effect = _make_fake_pull("riddle-benchmark.ipynb")
+
+    result = client.fork("alice/riddle-benchmark")
+
+    assert result == tmp_path / "riddle-benchmark"
+    assert (result / "benchmark.py").exists()
+    assert (result / "kernel-metadata.json").exists()
+    assert (result / "benchmark.ipynb").exists()
+
+    # Verify the .py file has cell delimiters
+    py_content = (result / "benchmark.py").read_text()
+    assert "# %%" in py_content
+    assert "print('hello')" in py_content
+
+
+def test_fork_custom_slug(client, mock_api, tmp_path):
+    """Custom notebook_slug overrides the default."""
+    mock_api.kernels_pull.side_effect = _make_fake_pull("notebook.ipynb")
+
+    result = client.fork("alice/riddle-benchmark", dest_notebook_slug="my-riddle")
+
+    assert result == tmp_path / "my-riddle"
+    assert (result / "benchmark.py").exists()
+
+
+def test_fork_exists_error(client, mock_api, tmp_path):
+    """Raises FileExistsError when workspace already exists."""
+    (tmp_path / "riddle-benchmark").mkdir()
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        client.fork("alice/riddle-benchmark")
+
+
+def test_fork_overwrite(client, mock_api, tmp_path):
+    """overwrite=True removes the existing workspace."""
+    workspace = tmp_path / "riddle-benchmark"
+    workspace.mkdir()
+    (workspace / "old-file.txt").write_text("old content")
+
+    mock_api.kernels_pull.side_effect = _make_fake_pull("riddle-benchmark.ipynb")
+
+    _ = client.fork("alice/riddle-benchmark", overwrite=True)
+
+    assert not (workspace / "old-file.txt").exists()
+    assert (workspace / "benchmark.py").exists()
+
+
+def test_fork_missing_notebook_raises_value_error(client, mock_api):
+    """fork() should raise a friendly ValueError for any HTTPError."""
+    mock_api.kernels_pull.side_effect = _make_404_error()
+
+    with pytest.raises(
+        ValueError, match="Failed to pull notebook 'kaggle/does-not-exist'"
+    ):
+        client.fork("kaggle/does-not-exist")
+
+
+def test_fork_http_error_500_raises_value_error(client, mock_api):
+    """fork() wraps any HTTPError (including 500) in ValueError."""
+    mock_api.kernels_pull.side_effect = _make_http_error(500)
+
+    with pytest.raises(ValueError, match="Failed to pull notebook"):
+        client.fork("kaggle/server-error-notebook")
+
+
+def test_fork_no_ipynb_file(client, mock_api, tmp_path, caplog):
+    """fork() should log a warning when no .ipynb file is found (script notebook)."""
+    mock_api.kernels_pull.side_effect = _make_fake_pull_no_ipynb()
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        result = client.fork("alice/script-notebook")
+
+    assert result == tmp_path / "script-notebook"
+    assert (result / "kernel-metadata.json").exists()
+    # No .ipynb → no benchmark.py conversion
+    assert not (result / "benchmark.py").exists()
+    # Warning should be logged
+    assert "No .ipynb file found" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# validate_and_get_username
+# ---------------------------------------------------------------------------
+
+
+def test_validate_and_get_username_success(client, mock_api):
+    """Returns the username when credentials are valid."""
+    assert client.validate_and_get_username() == "testuser"
+    mock_api.get_config_value.assert_called_with("username")
+
+
+def test_validate_and_get_username_failure(client, mock_api):
+    """Raises KaggleAuthError when credentials are invalid."""
+    mock_api.get_config_value.side_effect = Exception("Invalid credentials")
+
+    with pytest.raises(KaggleAuthError, match="invalid or missing"):
+        client.validate_and_get_username()
+
+
+def test_validate_and_get_username_empty(client, mock_api):
+    """Raises KaggleAuthError when username is empty."""
+    mock_api.get_config_value.return_value = ""
+
+    with pytest.raises(KaggleAuthError, match="invalid or missing"):
+        client.validate_and_get_username()
+
+
+# ---------------------------------------------------------------------------
+# _authenticate
+# ---------------------------------------------------------------------------
+
+
+def test_authenticate_import_error():
+    """Raises KaggleAuthError when kaggle package is not installed."""
+    with patch.dict(
+        "sys.modules",
+        {"kaggle": None, "kaggle.api": None, "kaggle.api.kaggle_api_extended": None},
+    ):
+        # Force ImportError by removing the module from sys.modules cache
+        import sys
+
+        saved = {}
+        for mod_name in list(sys.modules):
+            if mod_name.startswith("kaggle"):
+                saved[mod_name] = sys.modules.pop(mod_name)
+
+        try:
+            with patch(
+                "builtins.__import__",
+                side_effect=ImportError("No module named 'kaggle'"),
+            ):
+                with pytest.raises(KaggleAuthError, match="kaggle.*required"):
+                    BenchmarkNotebookClient._authenticate()
+        finally:
+            sys.modules.update(saved)
+
+
+def test_authenticate_os_error():
+    """Raises KaggleAuthError when authentication credentials fail."""
+    mock_kaggle_api_cls = MagicMock()
+    mock_api_instance = MagicMock()
+    mock_api_instance.authenticate.side_effect = OSError("No such file: kaggle.json")
+    mock_kaggle_api_cls.return_value = mock_api_instance
+
+    # Test the actual _authenticate method with mocked import
+    with patch.dict(
+        "sys.modules",
+        {
+            "kaggle": MagicMock(),
+            "kaggle.api": MagicMock(),
+            "kaggle.api.kaggle_api_extended": MagicMock(KaggleApi=mock_kaggle_api_cls),
+        },
+    ):
+        with pytest.raises(KaggleAuthError, match="authentication failed"):
+            BenchmarkNotebookClient._authenticate()

--- a/uv.lock
+++ b/uv.lock
@@ -1870,6 +1870,26 @@ wheels = [
 ]
 
 [[package]]
+name = "kaggle"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bleach" },
+    { name = "kagglesdk" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "python-dateutil" },
+    { name = "python-slugify" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/c7/4e9e7b742b637e32b6afe2b7723e17195627f0bc25c6fffdd7d09fdfe33b/kaggle-2.0.0.tar.gz", hash = "sha256:34cb700cec37273a39ca54f4b18bebc3b6609d08bd03351fc205f9178f79f9ca", size = 136535, upload-time = "2026-02-11T19:46:12.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/b0/868ff7b15389a35fbe49769b383a683ade21deb16565e84b7ad45af976d3/kaggle-2.0.0-py3-none-any.whl", hash = "sha256:91b3f717e529e57dd40c6c44513e25218674636fb1b143031370ad33c5f1a7e2", size = 75462, upload-time = "2026-02-11T19:46:11.488Z" },
+]
+
+[[package]]
 name = "kaggle-benchmarks"
 source = { editable = "." }
 dependencies = [
@@ -1892,6 +1912,7 @@ dependencies = [
 [package.optional-dependencies]
 kaggle-client = [
     { name = "jupytext" },
+    { name = "kaggle" },
 ]
 
 [package.dev-dependencies]
@@ -1976,6 +1997,7 @@ requires-dist = [
     { name = "joblib" },
     { name = "jupyter" },
     { name = "jupytext", marker = "extra == 'kaggle-client'" },
+    { name = "kaggle", marker = "extra == 'kaggle-client'" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "openai", specifier = ">=1.66" },
     { name = "pandas" },
@@ -2075,6 +2097,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/12/e13c1c8b203535b15dacc420c0f1596dda67463175ff1e4404af21815bdd/kagglehub-0.3.13.tar.gz", hash = "sha256:d3c8b6250627d665096cd91a9487559bf5ed61be607eaf63d14511b20eea646e", size = 113694, upload-time = "2025-08-26T16:17:33.486Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/8e/4077b08b95a1f8302c694a8b399bd413815fbe89045c41e6e08cd7d9439a/kagglehub-0.3.13-py3-none-any.whl", hash = "sha256:e00dec8b81396cbad9c7b5eb62a33cf8ae27da26227abd196ed8f054c845ca00", size = 68257, upload-time = "2025-08-26T16:17:32.13Z" },
+]
+
+[[package]]
+name = "kagglesdk"
+version = "0.1.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/0e/51bf72a462e1e72fe3427b7c52b11c9c52cbcc63d7ce90f81a8f56d5a71b/kagglesdk-0.1.16.tar.gz", hash = "sha256:4a20da4ac6f4085e64b976a313ee136d4698737dc5be7c0f13009fadd41d5540", size = 121064, upload-time = "2026-02-27T19:32:34.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/6b/db30f17ad132391ac37a751fa45b32fd954a7ffa484fa3550eee9678334d/kagglesdk-0.1.16-py3-none-any.whl", hash = "sha256:a26ba7a754866f8eef1e327e78101f2960b6fe9b1b323183f2f61170abdb11ff", size = 160520, upload-time = "2026-02-27T19:32:32.721Z" },
 ]
 
 [[package]]
@@ -3795,6 +3830,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
+]
+
+[[package]]
 name = "pytokens"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4633,6 +4680,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", hash = "sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0", size = 14154, upload-time = "2024-03-12T14:34:36.569Z" },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1892,6 +1892,8 @@ dependencies = [
 [package.optional-dependencies]
 kaggle-client = [
     { name = "jupytext" },
+    { name = "kagglehub" },
+    { name = "kagglesdk" },
 ]
 
 [package.dev-dependencies]
@@ -1976,6 +1978,8 @@ requires-dist = [
     { name = "joblib" },
     { name = "jupyter" },
     { name = "jupytext", marker = "extra == 'kaggle-client'" },
+    { name = "kagglehub", marker = "extra == 'kaggle-client'", specifier = ">=0.3.10" },
+    { name = "kagglesdk", marker = "extra == 'kaggle-client'", specifier = ">=0.1.14,<1.0" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "openai", specifier = ">=1.66" },
     { name = "pandas" },
@@ -2075,6 +2079,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/12/e13c1c8b203535b15dacc420c0f1596dda67463175ff1e4404af21815bdd/kagglehub-0.3.13.tar.gz", hash = "sha256:d3c8b6250627d665096cd91a9487559bf5ed61be607eaf63d14511b20eea646e", size = 113694, upload-time = "2025-08-26T16:17:33.486Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/8e/4077b08b95a1f8302c694a8b399bd413815fbe89045c41e6e08cd7d9439a/kagglehub-0.3.13-py3-none-any.whl", hash = "sha256:e00dec8b81396cbad9c7b5eb62a33cf8ae27da26227abd196ed8f054c845ca00", size = 68257, upload-time = "2025-08-26T16:17:32.13Z" },
+]
+
+[[package]]
+name = "kagglesdk"
+version = "0.1.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/0e/51bf72a462e1e72fe3427b7c52b11c9c52cbcc63d7ce90f81a8f56d5a71b/kagglesdk-0.1.16.tar.gz", hash = "sha256:4a20da4ac6f4085e64b976a313ee136d4698737dc5be7c0f13009fadd41d5540", size = 121064, upload-time = "2026-02-27T19:32:34.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/6b/db30f17ad132391ac37a751fa45b32fd954a7ffa484fa3550eee9678334d/kagglesdk-0.1.16-py3-none-any.whl", hash = "sha256:a26ba7a754866f8eef1e327e78101f2960b6fe9b1b323183f2f61170abdb11ff", size = 160520, upload-time = "2026-02-27T19:32:32.721Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1870,26 +1870,6 @@ wheels = [
 ]
 
 [[package]]
-name = "kaggle"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "bleach" },
-    { name = "kagglesdk" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "python-dateutil" },
-    { name = "python-slugify" },
-    { name = "requests" },
-    { name = "tqdm" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/14/c7/4e9e7b742b637e32b6afe2b7723e17195627f0bc25c6fffdd7d09fdfe33b/kaggle-2.0.0.tar.gz", hash = "sha256:34cb700cec37273a39ca54f4b18bebc3b6609d08bd03351fc205f9178f79f9ca", size = 136535, upload-time = "2026-02-11T19:46:12.495Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/b0/868ff7b15389a35fbe49769b383a683ade21deb16565e84b7ad45af976d3/kaggle-2.0.0-py3-none-any.whl", hash = "sha256:91b3f717e529e57dd40c6c44513e25218674636fb1b143031370ad33c5f1a7e2", size = 75462, upload-time = "2026-02-11T19:46:11.488Z" },
-]
-
-[[package]]
 name = "kaggle-benchmarks"
 source = { editable = "." }
 dependencies = [
@@ -1912,7 +1892,8 @@ dependencies = [
 [package.optional-dependencies]
 kaggle-client = [
     { name = "jupytext" },
-    { name = "kaggle" },
+    { name = "kagglehub" },
+    { name = "kagglesdk" },
 ]
 
 [package.dev-dependencies]
@@ -1997,7 +1978,8 @@ requires-dist = [
     { name = "joblib" },
     { name = "jupyter" },
     { name = "jupytext", marker = "extra == 'kaggle-client'" },
-    { name = "kaggle", marker = "extra == 'kaggle-client'" },
+    { name = "kagglehub", marker = "extra == 'kaggle-client'", specifier = ">=0.3.10" },
+    { name = "kagglesdk", marker = "extra == 'kaggle-client'", specifier = ">=0.1.14,<1.0" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "openai", specifier = ">=1.66" },
     { name = "pandas" },
@@ -3830,18 +3812,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-slugify"
-version = "8.0.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "text-unidecode" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
-]
-
-[[package]]
 name = "pytokens"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4680,15 +4650,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", hash = "sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0", size = 14154, upload-time = "2024-03-12T14:34:36.569Z" },
-]
-
-[[package]]
-name = "text-unidecode"
-version = "1.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a `kaggle-bench` CLI entry point that wraps the `BenchmarkNotebookClient` 
SDK introduced in PR #90, allowing users to publish and retrieve benchmark 
notebooks directly from the terminal without writing Python boilerplate.

This addresses the open discussion in PR #90 / the broader request to integrate 
benchmark management into a CLI tool.

## New Commands

**Run a benchmark:**

**Fork an existing benchmark for local editing:**


## Changes

- `src/kaggle_benchmarks/kaggle_client/cli.py` — CLI entry point with `run` and `fork` subcommands
- `pyproject.toml` — registers `kaggle-bench` as an installable script
- `tests/kaggle_client/test_cli.py` — 5 unit tests covering argument parsing and correct delegation to `BenchmarkNotebookClient`

## Notes

- Depends on PR #90 (`BenchmarkNotebookClient`) being merged first
- All 273 existing offline tests still pass
- Follows the same import/auth patterns as `notebook_api.py`