### PR TITLE
Add uv exclude-newer for supply chain hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ dev/
 _site/
 site_libs/
 docs/
+.kagent-context/**
+.claude/settings.local.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ description = ""
 readme = "README.md"
 authors = []
 requires-python = ">=3.11"
+# NOTE: Before upgrading dependencies, bump [tool.uv] exclude-newer date below.
 dependencies = [
   "openai>=1.66",
   "pandas",
@@ -104,7 +105,8 @@ dev = [
 ]
 
 [tool.uv]
-# Supply chain hardening: exclude packages published after this date.
+# Supply chain hardening: refuse to install any package published after this date.
+# To upgrade packages: bump this date to ~2 days before today, then run `uv lock --upgrade`.
 # This is a fixed date (not a rolling window) and must be bumped periodically.
 # See: https://docs.astral.sh/uv/reference/settings/#exclude-newer
 exclude-newer = "2026-03-24T00:00:00Z"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,12 @@ dev = [
   "mypy-protobuf>=3.6.0",
 ]
 
+[tool.uv]
+# Supply chain hardening: exclude packages published after this date.
+# This is a fixed date (not a rolling window) and must be bumped periodically.
+# See: https://docs.astral.sh/uv/reference/settings/#exclude-newer
+exclude-newer = "2026-03-24T00:00:00Z"
+
 [tool.mypy]
 warn_unused_configs = true
 

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
+[options]
+exclude-newer = "2026-03-24T00:00:00Z"
+
 [[package]]
 name = "aiofiles"
 version = "22.1.0"


### PR DESCRIPTION
Set exclude-newer to 2026-03-24 (7 days ago) to prevent uv from
installing package versions published after that date. This is a
defense-in-depth measure against supply chain attacks like the
axios@1.14.1 compromise.

Also add .kagent-context/** and .claude/settings.local.json to
.gitignore.

Co-authored-by: kaggle-agent <kaggle-agent@users.noreply.github.com>

---

Task: [erdalsivri-20260331150706-ca58d74f](https://agents.dev.kaggle.net/tasks/erdalsivri-20260331150706-ca58d74f)
Context: https://chat.kaggle.net/kaggle/pl/o3rrqgcf5fy3jjsjkbuhdp7ifh

