### PR TITLE
Add orphan argument and tests to chats.fork

### DIFF
--- a/src/kaggle_benchmarks/chats.py
+++ b/src/kaggle_benchmarks/chats.py
@@ -149,9 +149,17 @@ def new(
 
 
 @contextlib.contextmanager
-def fork(name: str = "Fork"):
-    parent = get_current_chat()
+def fork(name: str = "Fork", orphan: bool = False):
+    """
+    Creates and enters a new chat with the same history as the current one.
 
-    with new(name) as chat:
-        chat.history.extend(parent.messages)
+    Args:
+        name: The name of the new chat thread.
+        orphan: Controls whether the new chat will appear in the parent chat's history.
+    """
+    parent = get_current_chat()
+    messages = parent.messages
+
+    with new(name, orphan=orphan) as chat:
+        chat.history.extend(messages)
         yield chat

--- a/tests/test_llm_chats.py
+++ b/tests/test_llm_chats.py
@@ -222,3 +222,26 @@ def test_prompt_with_image_and_video():
         assert isinstance(t.messages[0].content, images.ImageBase64)
         assert isinstance(t.messages[1].content, videos.VideoURL)
         assert t.messages[2].content == "Describe both"
+
+
+def test_chat_fork():
+    with chats.new("Parent") as p:
+        actors.user.send("Hello")
+
+        with chats.fork("Forked") as f:
+            assert f.name == "Forked"
+            assert len(f.history) == 1
+            assert f.history[0].content == "Hello"
+            actors.user.send("World")
+            assert len(f.history) == 2
+
+        assert len(p.history) == 2
+        assert p.history[1] is f
+
+        with chats.fork("Orphaned", orphan=True) as of:
+            assert of.name == "Orphaned"
+            assert len(of.history) == 1  # Only messages are copied to the fork
+            actors.user.send("Bye")
+            assert len(of.history) == 2
+
+        assert len(p.history) == 2


### PR DESCRIPTION
Adds the orphan parameter to the chats.fork context manager to control whether the newly forked chat appears in the parent chat's history. It also adds a docstring and unit tests to verify the behavior.