### PR TITLE
test: reduce test reliance on LLMChat implementation

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@
 import pytest
 
 from kaggle_benchmarks import ExecutionMode, clients, config, contexts, events
+from tests.mocks import MockedChat
 
 
 @pytest.fixture(autouse=True)
@@ -35,3 +36,13 @@ def cfg():
     yield config
     config.__dict__.update(before)
     config.apply()
+
+
+@pytest.fixture()
+def duck():
+    yield MockedChat.from_contents(["quack"], name="Duck", cycle=True)
+
+
+@pytest.fixture()
+def goose():
+    yield MockedChat.from_contents(["honk"], name="Goose", cycle=True)

--- a/tests/kaggle/test_integration.py
+++ b/tests/kaggle/test_integration.py
@@ -18,14 +18,12 @@ import pytest
 
 from kaggle_benchmarks import (
     ExecutionMode,
-    actors,
     assertions,
     config,
     kaggle,
     task,
     utils,
 )
-from kaggle_benchmarks.actors.llms import LLMResponse
 
 
 @pytest.fixture
@@ -38,16 +36,6 @@ def client(monkeypatch):
         yield kaggle_client
 
         config.execution_mode = ExecutionMode.TESTING
-
-
-class Duck(actors.LLMChat):
-    def invoke(self, messages, system, **kwargs):
-        return LLMResponse(content="quack")
-
-
-@pytest.fixture
-def duck():
-    yield Duck()
 
 
 @task()

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+import json
+
+from kaggle_benchmarks import actors
+from kaggle_benchmarks.llm_messages import LLMMessage
+
+
+class MockedChat(actors.LLMChat):
+    def __init__(
+        self, responses: list[LLMMessage[str]], name="MockedChat", cycle=False, **kwargs
+    ):
+        super().__init__(name=name, **kwargs)
+        self.response = itertools.cycle(responses) if cycle else iter(responses)
+        self.invocations = []
+
+    @classmethod
+    def from_contents(cls, contents: list[str], cycle=False, **kwargs):
+        return cls(
+            responses=[
+                LLMMessage(sender=None, content=content) for content in contents
+            ],
+            cycle=cycle,
+            **kwargs,
+        )
+
+    @classmethod
+    def from_contents_data(cls, contents: list[dict], cycle=False, **kwargs):
+        return cls(
+            responses=[
+                LLMMessage(sender=None, content=json.dumps(content))
+                for content in contents
+            ],
+            cycle=cycle,
+            **kwargs,
+        )
+
+    def invoke(self, messages, **kwargs):
+        self.invocations.append((messages, kwargs))
+        try:
+            response = next(self.response)
+            response.sender = self
+            return response
+        except StopIteration:
+            assert False, "No more responses available"

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -17,8 +17,8 @@ import re
 
 import pytest
 
-from kaggle_benchmarks import actors, assertions, tasks
-from kaggle_benchmarks.actors.llms import LLMResponse
+from kaggle_benchmarks import assertions, tasks
+from tests.mocks import MockedChat
 
 
 def assert_assertion_result_matches(
@@ -156,16 +156,6 @@ def test_regex_assertions():
             "source_code": "r_not_contains_fail_custom = assertions.assert_not_contains_regex(",
         },
     )
-
-
-class Duck(actors.LLMChat):
-    def invoke(self, messages, system, **kwargs):
-        return LLMResponse(content="quack")
-
-
-@pytest.fixture
-def duck():
-    yield Duck()
 
 
 @assertions.assertion_handler()
@@ -349,14 +339,6 @@ def test_assert_fail():
 
 
 def test_assess_response_with_judge():
-    class MockJudge(actors.LLMChat):
-        def __init__(self, return_value):
-            super().__init__(name="MockJudge")
-            self.return_value = return_value
-
-        def prompt(self, message, schema=None, **kwargs):
-            return self.return_value
-
     # Judge returns dict result
     report_dict = {
         "results": [
@@ -368,7 +350,7 @@ def test_assess_response_with_judge():
             }
         ]
     }
-    judge_pass = MockJudge(report_dict)
+    judge_pass = MockedChat.from_contents_data([report_dict], name="MockJudge")
 
     report = assertions.assess_response_with_judge(
         criteria=["some expectation"],
@@ -393,7 +375,9 @@ def test_assess_response_with_judge():
             )
         ]
     )
-    judge_obj = MockJudge(report_obj)
+    judge_obj = MockedChat.from_contents(
+        [report_obj.model_dump_json()], name="MockJudge"
+    )
     report = assertions.assess_response_with_judge(
         criteria=["some expectation"],
         response_text="some response",

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -18,27 +18,12 @@ import pandas as pd
 import panel as pn
 import pytest
 
-from kaggle_benchmarks import actors, chats, config, runs, tasks, utils
-from kaggle_benchmarks.actors.llms import LLMResponse
-
-
-class Duck(actors.LLMChat):
-    def invoke(self, messages, **kwargs):
-        return LLMResponse(content="quack")
+from kaggle_benchmarks import chats, config, runs, tasks, utils
 
 
 @tasks.task()
 def task_that_errors():
     raise ValueError("This is an intentional error")
-
-
-class Goose(actors.LLMChat):
-    "quack"
-
-
-@pytest.fixture
-def duck():
-    yield Duck()
 
 
 @tasks.task()
@@ -192,7 +177,9 @@ def test_run_with_subrun_on_exception(monkeypatch, continue_with_exceptions):
 
 
 @pytest.mark.parametrize("continue_with_exceptions", [True, False])
-def test_run_evaluating_subrun_on_exception(monkeypatch, continue_with_exceptions):
+def test_run_evaluating_subrun_on_exception(
+    duck, monkeypatch, continue_with_exceptions
+):
     monkeypatch.setattr(config, "continue_with_exceptions", continue_with_exceptions)
 
     @tasks.task()
@@ -213,7 +200,7 @@ def test_run_evaluating_subrun_on_exception(monkeypatch, continue_with_exception
         )
 
     if continue_with_exceptions:
-        run = wrapper_task.run(llm=Duck())
+        run = wrapper_task.run(llm=duck)
         assert not run.passed
         assert run.status == utils.Status.FAILED
         assert (
@@ -222,7 +209,7 @@ def test_run_evaluating_subrun_on_exception(monkeypatch, continue_with_exception
         )
     else:
         with pytest.raises(ValueError, match="This is an intentional error"):
-            wrapper_task.run(llm=Duck())
+            wrapper_task.run(llm=duck)
 
 
 @pytest.mark.parametrize("continue_with_exceptions", [True, False])
@@ -319,10 +306,10 @@ def test_bind_dataframe():
 
 
 @pytest.mark.parametrize("mode", ["tabs", "columns"])
-def test_pivot(duck, mode):
+def test_pivot(duck, goose, mode):
     index = ["a", "b", "c"]
     runs = bench.evaluate(
-        grid={"llm": [duck, Duck(name="goose")]},
+        grid={"llm": [duck, goose]},
         evaluation_data=pd.DataFrame({"message": ["meow", "howl", "moo"]}, index=index),
     )
 

--- a/tests/test_llm_chats.py
+++ b/tests/test_llm_chats.py
@@ -19,7 +19,9 @@ import pytest
 from kaggle_benchmarks import actors, chats, contexts, prompting, utils
 from kaggle_benchmarks.actors.llms import LLMResponse
 from kaggle_benchmarks.content_types import images, videos
+from kaggle_benchmarks.llm_messages import LLMMessage
 from kaggle_benchmarks.prompting import handler
+from tests.mocks import MockedChat
 
 
 class Ferret(actors.LLMChat):
@@ -200,7 +202,10 @@ def test_video_message_payload():
 
     msg = messages.Message(sender=actors.user, content=video)
     assert msg.payload == [
-        {"type": "image_url", "image_url": {"url": "https://www.youtube.com/watch?v=abc123"}}
+        {
+            "type": "image_url",
+            "image_url": {"url": "https://www.youtube.com/watch?v=abc123"},
+        }
     ]
 
 
@@ -245,3 +250,17 @@ def test_chat_fork():
             assert len(of.history) == 2
 
         assert len(p.history) == 2
+
+
+def test_invoke_llmmessage():
+    mocked_chat = MockedChat.from_contents(["test response"])
+    messages = [LLMMessage(sender=actors.user, content="hello")]
+
+    response = mocked_chat.invoke(messages=messages, temperature=0.5)
+
+    assert isinstance(response, LLMMessage)
+    assert response.content == "test response"
+    assert response.sender is mocked_chat
+    assert len(mocked_chat.invocations) == 1
+    assert mocked_chat.invocations[0][0] == messages
+    assert mocked_chat.invocations[0][1] == {"temperature": 0.5}

--- a/tests/test_llm_chats.py
+++ b/tests/test_llm_chats.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import json
 
 import pytest
@@ -20,6 +21,7 @@ from kaggle_benchmarks import actors, chats, contexts, prompting, utils
 from kaggle_benchmarks.actors.llms import LLMResponse
 from kaggle_benchmarks.content_types import images, videos
 from kaggle_benchmarks.prompting import handler
+from tests.mocks import MockedChat
 
 
 class Ferret(actors.LLMChat):
@@ -51,13 +53,18 @@ class Ferret(actors.LLMChat):
 
 
 def test_prompt_without_context():
-    llm = Ferret()
+    llm = MockedChat.from_contents(["mocked"])
     r = llm.prompt("A")
-    assert {"messages": [["user", "A"]], "system": None} == json.loads(r)
+    assert r == "mocked"
+    messages, kwargs = llm.invocations[0]
+    assert len(messages) == 1
+    assert messages[0].sender is actors.user
+    assert messages[0].content == "A"
+    assert kwargs.get("system") is None
 
 
 def test_respond():
-    llm = Ferret()
+    llm = MockedChat.from_contents(["mocked"])
 
     with chats.new("Test") as t:
         actors.user.send("A")
@@ -65,37 +72,51 @@ def test_respond():
 
         r = llm.respond()
         assert len(t.messages) == 2
-        assert {"messages": [["user", "A"]], "system": None} == json.loads(r.text)
+        assert r.text == "mocked"
+
+        messages, kwargs = llm.invocations[0]
+        assert len(messages) == 1
+        assert messages[0].sender is actors.user
+        assert messages[0].content == "A"
+        assert kwargs.get("system") is None
 
 
 def test_chat_context():
-    llm = Ferret()
+    llm = MockedChat.from_contents(["r1", "r2", "r3"])
     llm.prompt("<should not be visible in the context>")
 
     with chats.new(system_instructions="S") as t:
         assert t.status == utils.Status.RUNNING
 
         r = llm.prompt("A")
-        assert {
-            "messages": [["system", "S"], ["user", "A"]],
-            "system": None,
-        } == json.loads(r)
+        assert r == "r2"
+        messages, kwargs = llm.invocations[1]
+        assert len(messages) == 2
+        assert messages[0].sender is actors.system
+        assert messages[0].content == "S"
+        assert messages[1].sender is actors.user
+        assert messages[1].content == "A"
+        assert kwargs.get("system") is None
 
         r = llm.prompt("B")
-        response = json.loads(r)
-
-        assert response["system"] is None
-        assert 4 == len(response["messages"])
-        assert ["system", "S"] == response["messages"][0]
-        assert ["user", "A"] == response["messages"][1]
-        assert llm.name.lower() == response["messages"][2][0]
-        assert ["user", "B"] == response["messages"][3]
+        assert r == "r3"
+        messages, kwargs = llm.invocations[2]
+        assert len(messages) == 4
+        assert messages[0].sender is actors.system
+        assert messages[0].content == "S"
+        assert messages[1].sender is actors.user
+        assert messages[1].content == "A"
+        assert messages[2].sender is llm
+        assert messages[2].content == "r2"
+        assert messages[1].sender is actors.user
+        assert messages[3].content == "B"
+        assert kwargs.get("system") is None
 
     assert t.status == utils.Status.SUCCESS
 
 
 def test_structured():
-    llm = Ferret()
+    llm = MockedChat.from_contents([""])
 
     class F:
         pass
@@ -118,6 +139,7 @@ def test_structured():
             error="Bad response", schema=cls, value=value
         )
 
+    llm = MockedChat.from_contents(["test_value"])
     with chats.new() as t:
         with pytest.raises(prompting.ResponseParsingError):
             llm.prompt("test_value", schema=F)
@@ -131,6 +153,7 @@ def test_structured():
         yield "nonsense"
         return F()
 
+    llm = MockedChat.from_contents(["", "nonsense"])
     with pytest.raises(prompting.SchemaError):
         llm.prompt("Test", schema=F)
 
@@ -148,12 +171,12 @@ def test_streaming_prompt():
         last_message = t.messages[-1]
         assert last_message.content == "streaming..."
         assert last_message.sender is llm
-        assert last_message._meta["input_tokens"] == 10
-        assert last_message._meta["output_tokens"] == 2
+        assert last_message.usage.input_tokens == 10
+        assert last_message.usage.output_tokens == 2
 
 
 def test_nested_chat_id():
-    llm = Ferret()
+    llm = MockedChat.from_contents(["mocked"])
     with chats.new("root") as root:
         sub = chats.Chat(name="sub")
         chats.get_current_chat().append(sub)
@@ -169,15 +192,22 @@ def test_nested_chat_id():
 
 def test_chat_usage_aggregation():
     """Test that chat usage properties aggregate token usage from all assistant messages."""
-    llm = Ferret()
-    llm.stream_responses = True
+    from kaggle_benchmarks.llm_messages import LLMMessage
+    from kaggle_benchmarks.usage import Usage
+
+    msg1 = LLMMessage(
+        sender=None, content="first", usage=Usage(input_tokens=10, output_tokens=2)
+    )
+    msg2 = LLMMessage(
+        sender=None, content="second", usage=Usage(input_tokens=10, output_tokens=2)
+    )
+
+    llm = MockedChat([msg1, msg2])
 
     with chats.new("Test Usage") as t:
         llm.prompt("first")
         llm.prompt("second")
 
-        # Each streaming response yields: input_tokens=10, output_tokens=2
-        # Two prompts = 2 * 10 = 20 input tokens, 2 * 2 = 4 output tokens
         assert t.usage.input_tokens == 20
         assert t.usage.output_tokens == 4
 
@@ -200,7 +230,10 @@ def test_video_message_payload():
 
     msg = messages.Message(sender=actors.user, content=video)
     assert msg.payload == [
-        {"type": "image_url", "image_url": {"url": "https://www.youtube.com/watch?v=abc123"}}
+        {
+            "type": "image_url",
+            "image_url": {"url": "https://www.youtube.com/watch?v=abc123"},
+        }
     ]
 
 
@@ -211,9 +244,6 @@ def test_prompt_with_image_and_video():
     video = videos.from_url("https://www.youtube.com/watch?v=abc123")
 
     with chats.new("image_and_video") as t:
-        # Manually send image and video, then prompt, to verify message ordering.
-        # We don't call llm.prompt() directly because Ferret's invoke() can't
-        # serialize image/video content to JSON.
         actors.user.send(img)
         actors.user.send(video)
         actors.user.send("Describe both")

--- a/tests/test_llm_chats.py
+++ b/tests/test_llm_chats.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import json
 
 import pytest
@@ -21,7 +20,6 @@ from kaggle_benchmarks import actors, chats, contexts, prompting, utils
 from kaggle_benchmarks.actors.llms import LLMResponse
 from kaggle_benchmarks.content_types import images, videos
 from kaggle_benchmarks.prompting import handler
-from tests.mocks import MockedChat
 
 
 class Ferret(actors.LLMChat):
@@ -53,18 +51,13 @@ class Ferret(actors.LLMChat):
 
 
 def test_prompt_without_context():
-    llm = MockedChat.from_contents(["mocked"])
+    llm = Ferret()
     r = llm.prompt("A")
-    assert r == "mocked"
-    messages, kwargs = llm.invocations[0]
-    assert len(messages) == 1
-    assert messages[0].sender is actors.user
-    assert messages[0].content == "A"
-    assert kwargs.get("system") is None
+    assert {"messages": [["user", "A"]], "system": None} == json.loads(r)
 
 
 def test_respond():
-    llm = MockedChat.from_contents(["mocked"])
+    llm = Ferret()
 
     with chats.new("Test") as t:
         actors.user.send("A")
@@ -72,51 +65,37 @@ def test_respond():
 
         r = llm.respond()
         assert len(t.messages) == 2
-        assert r.text == "mocked"
-
-        messages, kwargs = llm.invocations[0]
-        assert len(messages) == 1
-        assert messages[0].sender is actors.user
-        assert messages[0].content == "A"
-        assert kwargs.get("system") is None
+        assert {"messages": [["user", "A"]], "system": None} == json.loads(r.text)
 
 
 def test_chat_context():
-    llm = MockedChat.from_contents(["r1", "r2", "r3"])
+    llm = Ferret()
     llm.prompt("<should not be visible in the context>")
 
     with chats.new(system_instructions="S") as t:
         assert t.status == utils.Status.RUNNING
 
         r = llm.prompt("A")
-        assert r == "r2"
-        messages, kwargs = llm.invocations[1]
-        assert len(messages) == 2
-        assert messages[0].sender is actors.system
-        assert messages[0].content == "S"
-        assert messages[1].sender is actors.user
-        assert messages[1].content == "A"
-        assert kwargs.get("system") is None
+        assert {
+            "messages": [["system", "S"], ["user", "A"]],
+            "system": None,
+        } == json.loads(r)
 
         r = llm.prompt("B")
-        assert r == "r3"
-        messages, kwargs = llm.invocations[2]
-        assert len(messages) == 4
-        assert messages[0].sender is actors.system
-        assert messages[0].content == "S"
-        assert messages[1].sender is actors.user
-        assert messages[1].content == "A"
-        assert messages[2].sender is llm
-        assert messages[2].content == "r2"
-        assert messages[1].sender is actors.user
-        assert messages[3].content == "B"
-        assert kwargs.get("system") is None
+        response = json.loads(r)
+
+        assert response["system"] is None
+        assert 4 == len(response["messages"])
+        assert ["system", "S"] == response["messages"][0]
+        assert ["user", "A"] == response["messages"][1]
+        assert llm.name.lower() == response["messages"][2][0]
+        assert ["user", "B"] == response["messages"][3]
 
     assert t.status == utils.Status.SUCCESS
 
 
 def test_structured():
-    llm = MockedChat.from_contents([""])
+    llm = Ferret()
 
     class F:
         pass
@@ -139,7 +118,6 @@ def test_structured():
             error="Bad response", schema=cls, value=value
         )
 
-    llm = MockedChat.from_contents(["test_value"])
     with chats.new() as t:
         with pytest.raises(prompting.ResponseParsingError):
             llm.prompt("test_value", schema=F)
@@ -153,7 +131,6 @@ def test_structured():
         yield "nonsense"
         return F()
 
-    llm = MockedChat.from_contents(["", "nonsense"])
     with pytest.raises(prompting.SchemaError):
         llm.prompt("Test", schema=F)
 
@@ -171,12 +148,12 @@ def test_streaming_prompt():
         last_message = t.messages[-1]
         assert last_message.content == "streaming..."
         assert last_message.sender is llm
-        assert last_message.usage.input_tokens == 10
-        assert last_message.usage.output_tokens == 2
+        assert last_message._meta["input_tokens"] == 10
+        assert last_message._meta["output_tokens"] == 2
 
 
 def test_nested_chat_id():
-    llm = MockedChat.from_contents(["mocked"])
+    llm = Ferret()
     with chats.new("root") as root:
         sub = chats.Chat(name="sub")
         chats.get_current_chat().append(sub)
@@ -192,22 +169,15 @@ def test_nested_chat_id():
 
 def test_chat_usage_aggregation():
     """Test that chat usage properties aggregate token usage from all assistant messages."""
-    from kaggle_benchmarks.llm_messages import LLMMessage
-    from kaggle_benchmarks.usage import Usage
-
-    msg1 = LLMMessage(
-        sender=None, content="first", usage=Usage(input_tokens=10, output_tokens=2)
-    )
-    msg2 = LLMMessage(
-        sender=None, content="second", usage=Usage(input_tokens=10, output_tokens=2)
-    )
-
-    llm = MockedChat([msg1, msg2])
+    llm = Ferret()
+    llm.stream_responses = True
 
     with chats.new("Test Usage") as t:
         llm.prompt("first")
         llm.prompt("second")
 
+        # Each streaming response yields: input_tokens=10, output_tokens=2
+        # Two prompts = 2 * 10 = 20 input tokens, 2 * 2 = 4 output tokens
         assert t.usage.input_tokens == 20
         assert t.usage.output_tokens == 4
 
@@ -230,10 +200,7 @@ def test_video_message_payload():
 
     msg = messages.Message(sender=actors.user, content=video)
     assert msg.payload == [
-        {
-            "type": "image_url",
-            "image_url": {"url": "https://www.youtube.com/watch?v=abc123"},
-        }
+        {"type": "image_url", "image_url": {"url": "https://www.youtube.com/watch?v=abc123"}}
     ]
 
 
@@ -244,6 +211,9 @@ def test_prompt_with_image_and_video():
     video = videos.from_url("https://www.youtube.com/watch?v=abc123")
 
     with chats.new("image_and_video") as t:
+        # Manually send image and video, then prompt, to verify message ordering.
+        # We don't call llm.prompt() directly because Ferret's invoke() can't
+        # serialize image/video content to JSON.
         actors.user.send(img)
         actors.user.send(video)
         actors.user.send("Describe both")

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -18,28 +18,18 @@ from dataclasses import dataclass
 import pydantic
 import pytest
 
-from kaggle_benchmarks import actors, chats, messages, user
+from kaggle_benchmarks import chats, messages, user
 from kaggle_benchmarks.actors.llms import LLMResponse
-
-
-class Parrot(actors.LLMChat):
-    """Repeats last user message."""
-
-    def invoke(self, messages, **kwargs):
-        return next(
-            LLMResponse(content=m.payload)
-            for m in reversed(messages)
-            if m.sender == user
-        )
+from tests.mocks import MockedChat
 
 
 def test_raw_payload():
-    p = Parrot()
+    float_response = '{"value": 0.01}'
+    p = MockedChat.from_contents([float_response, '{"value": true}'])
     with chats.new() as chat:
-        raw_response = '{"value": 0.01}'
-        m = p.prompt(raw_response, schema=float)
+        m = p.prompt(float_response, schema=float)
         assert m == 0.01
-        assert chat.messages[-1].payload == raw_response
+        assert chat.messages[-1].payload == float_response
 
     r = p.prompt('{"value": true}', schema=bool)
     assert r

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -19,9 +19,9 @@ from dataclasses import dataclass
 import pydantic
 import pytest
 
-from kaggle_benchmarks import actors, chats, messages, prompting
-from kaggle_benchmarks.actors.llms import LLMResponse
+from kaggle_benchmarks import chats, prompting
 from kaggle_benchmarks.prompting import ResponseParsingError
+from tests.mocks import MockedChat
 
 
 def test_str():
@@ -81,19 +81,17 @@ def test_llm():
         test_field: str = "default"
         another_field: int = 1
 
-    class LLM(actors.LLMChat):
-        def invoke(
-            self, messages: list[messages.Message], system: str | None, **kwargs
-        ) -> LLMResponse:
-            texts = "\n".join(m.text for m in messages) + str(system)
-            assert "test_field" in texts
-            assert "another_field" in texts
-            return LLMResponse(content='{"test_field": "a", "another_field": 2}')
-
+    llm = MockedChat.from_contents(['{"test_field": "a", "another_field": 2}'])
     with chats.new("test"):
-        response = LLM().prompt(message="?", schema=A)
+        response = llm.prompt(message="?", schema=A)
         assert isinstance(response, A)
         assert response == A("a", 2)
+
+        assert len(llm.invocations) == 1
+        invoked_messages, _ = llm.invocations[0]
+        instructions = invoked_messages[-1].content
+        assert "test_field" in instructions
+        assert "another_field" in instructions
 
 
 def test_pydantic_error():

--- a/tests/test_protobuf.py
+++ b/tests/test_protobuf.py
@@ -16,10 +16,10 @@ import pytest
 from google.protobuf import json_format
 from pydantic import BaseModel
 
-from kaggle_benchmarks import actors, assertions, chats, config, user
-from kaggle_benchmarks.actors.llms import LLMResponse
+from kaggle_benchmarks import assertions, chats, config, user
 from kaggle_benchmarks.kaggle import serialization
 from kaggle_benchmarks.tasks import task
+from tests.mocks import MockedChat
 
 
 @task(name="test", version=2, description="Test")
@@ -57,15 +57,6 @@ def task_with_docstring():
     pass
 
 
-class MockScoringLLM(actors.LLMChat):
-    def __init__(self, score_to_return: int, name="MockScoringLLM"):
-        super().__init__(name=name)
-        self.score_to_return = score_to_return
-
-    def invoke(self, messages, **kwargs):
-        return LLMResponse(content=f'{{"score": {self.score_to_return}}}')
-
-
 class BeautyScore(BaseModel):
     score: int
 
@@ -73,7 +64,9 @@ class BeautyScore(BaseModel):
 @task()
 def scoring_task(score_to_return: int, raises_exception: bool = False) -> int:
     """A task that returns a score and has an assertion."""
-    llm = MockScoringLLM(score_to_return)
+    llm = MockedChat.from_contents_data(
+        [{"score": score_to_return}], name="MockScoringLLM"
+    )
     eval_response = llm.prompt("Rate this", schema=BeautyScore)
     score = eval_response.score
     assertions.assert_true(score >= 4, f"Score {score} is less than 4.")
@@ -83,22 +76,10 @@ def scoring_task(score_to_return: int, raises_exception: bool = False) -> int:
     return score
 
 
-class MockLLM(actors.LLMChat):
-    def __init__(self, name="MockLLM"):
-        super().__init__(name=name)
-
-    def invoke(self, messages, **kwargs):
-        last_user_message = next(
-            (m.content for m in reversed(messages) if m.sender.role == "user"),
-            "No user message.",
-        )
-        return LLMResponse(content=f"I heard you say: {last_user_message}")
-
-
 @task()
-def chatty_task():
+def chatty_task(responses):
     """A task with a conversation."""
-    llm = MockLLM()
+    llm = MockedChat.from_contents(responses, name="MockLLM")
     user.send("Hello")
     llm.respond()
     user.send("How are you?")
@@ -110,7 +91,9 @@ def chatty_task():
 @task()
 def task_with_subchat():
     """A task with a sub-chat."""
-    llm = MockLLM()
+    llm = MockedChat.from_contents(
+        ["Outer hello", "Inner hello", "Outer goodbye"], name="MockLLM"
+    )
     user.send("Outer hello")
     llm.respond()
 
@@ -224,7 +207,7 @@ def test_combined_run_serialization():
 
 
 def test_chat_serialization():
-    run = chatty_task.run()
+    run = chatty_task.run(["one", "two"])
     message = serialization.dump_run(run)
     result = json_format.MessageToDict(message)
 
@@ -241,7 +224,7 @@ def test_chat_serialization():
     assert request1["contents"][0]["parts"][0]["text"] == "Hello"
     assert request1["contents"][0]["senderName"] == "User"
     assert request1["contents"][1]["role"] == "CONTENT_ROLE_ASSISTANT"
-    assert "I heard you say: Hello" in request1["contents"][1]["parts"][0]["text"]
+    assert request1["contents"][1]["parts"][0]["text"] == "one"
     assert request1["contents"][1]["senderName"] == "MockLLM"
 
     # Check second request
@@ -251,9 +234,7 @@ def test_chat_serialization():
     assert request2["contents"][0]["parts"][0]["text"] == "How are you?"
     assert request2["contents"][0]["senderName"] == "User"
     assert request2["contents"][1]["role"] == "CONTENT_ROLE_ASSISTANT"
-    assert (
-        "I heard you say: How are you?" in request2["contents"][1]["parts"][0]["text"]
-    )
+    assert request2["contents"][1]["parts"][0]["text"] == "two"
     assert request2["contents"][1]["senderName"] == "MockLLM"
 
     # Check assertion mapping


### PR DESCRIPTION

Provides MockedChat with predefined responses to decouple tests from the LLMChat implementation.
