### PR TITLE
feat(tools): introduce agent and tool simulation

### DIFF
--- a/documentation/examples/use_calculator_tool.py
+++ b/documentation/examples/use_calculator_tool.py
@@ -14,17 +14,23 @@
 
 # %% [markdown]
 # ---
-# title: Manual Calculator Tool Calling
+# title: Simulated Calculator Tool Calling
 # ---
 # %%
-import json
 
-from kaggle_benchmarks import actors, assertions, llm, messages, task
+from kaggle_benchmarks import actors, assertions, llm, task, tools
 
 tool = actors.Actor(name="Tool", role="tool", avatar="🛠️")
 
 
 def run_simple_calculator(a: float, b: float, operator: str) -> float:
+    """Calculates the result of an arithmetic operation.
+
+    Args:
+        a: The first number.
+        b: The second number.
+        operator: The operator (+, -, *, /).
+    """
     if operator == "+":
         return a + b
     if operator == "-":
@@ -40,59 +46,26 @@ def run_simple_calculator(a: float, b: float, operator: str) -> float:
 def use_calculator(
     llm, problem: str, expected_answer: float, stream_mode: bool = False
 ) -> None:
-    calculator_tool = {
-        "type": "function",
-        "function": {
-            "name": "simple_calculator",
-            "description": "Calculates the result of an arithmetic operation.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "a": {"type": "number", "description": "The first number."},
-                    "b": {"type": "number", "description": "The second number."},
-                    "operator": {
-                        "type": "string",
-                        "description": "The operator (+, -, *, /).",
-                    },
-                },
-                "required": ["a", "b", "operator"],
-            },
-        },
-    }
     llm.stream_responses = stream_mode
 
     actors.user.send(problem)
 
-    tool_call_msg = llm.respond(tools=[calculator_tool])
-    tool_calls = tool_call_msg.tool_calls
+    response = tools.simulate_agent(
+        llm=llm,
+        tools=[run_simple_calculator],
+        output_schema=str,
+        max_iterations=3,
+    )
+
+    tool_calls = response.tool_calls
     assertions.assert_true(
         bool(tool_calls), "LLM was expected to call a tool, but it did not."
     )
 
-    tool_call = tool_calls[0]
-    function_args = json.loads(tool_call["function"]["arguments"])
-    # Removes 'signature' parameter in thinking mode.
-    function_args.pop("signature", None)
-    tool_result = ""
-    try:
-        tool_result = run_simple_calculator(**function_args)
-    except Exception as e:
-        tool_result = f"Error executing tool: {type(e).__name__} - {e}"
-
-    tool.send(
-        messages.Message(
-            sender=tool,
-            content=str(tool_result),
-            _meta={"tool_call_id": tool_call["id"]},
-        )
-    )
-
-    final_answer_msg = llm.respond()
-    final_answer = final_answer_msg.content
-
+    answer = response.content
     assertions.assert_true(
-        str(expected_answer) in final_answer,
-        f"Expected '{expected_answer}' to be in the final answer, but got '{final_answer}'.",
+        str(expected_answer) in answer,
+        f"Expected '{expected_answer}' to be in the final answer, but got '{answer}'.",
     )
 
 
@@ -100,9 +73,7 @@ problem = "What is 485 multiplied by 12?"
 expected = 485 * 12
 
 # %%
-use_calculator.run(llm, problem=problem, expected_answer=expected, stream_mode=True)
 
-# %%
-use_calculator.run(llm, problem=problem, expected_answer=expected, stream_mode=False)
+use_calculator.run(llm, problem=problem, expected_answer=expected)
 
 # %%

--- a/src/kaggle_benchmarks/messages.py
+++ b/src/kaggle_benchmarks/messages.py
@@ -56,6 +56,10 @@ class Message(Generic[T]):
     def tool_calls(self):
         return self._meta.get("tool_calls")
 
+    @tool_calls.setter
+    def tool_calls(self, value):
+        self._meta["tool_calls"] = value
+
     @property
     def usage(self):
         """Token usage and cost metadata for this message."""

--- a/src/kaggle_benchmarks/tools/__init__.py
+++ b/src/kaggle_benchmarks/tools/__init__.py
@@ -14,6 +14,7 @@
 
 from kaggle_benchmarks.tools import container, functions, python, search, web
 from kaggle_benchmarks.tools.base import (
+    UNKNOWN,
     ModelResponse,
     ToolCallModel,
     ToolInvocation,

--- a/src/kaggle_benchmarks/tools/base.py
+++ b/src/kaggle_benchmarks/tools/base.py
@@ -19,6 +19,8 @@ from typing import Any, Callable, Generic, TypeVar
 import pydantic
 
 T = TypeVar("T")
+F = TypeVar("F")
+Name = TypeVar("Name", bound=str)
 
 
 @dataclasses.dataclass
@@ -29,6 +31,13 @@ class ToolInvocation:
     arguments: dict[str, Any]
     call_id: str | None = None
 
+    # Allows serialization as content message
+    def get_payload(self):
+        return dataclasses.asdict(self)
+
+
+UNKNOWN = object()
+
 
 @dataclasses.dataclass
 class ToolInvocationResult:
@@ -37,24 +46,40 @@ class ToolInvocationResult:
     name: str
     arguments: dict[str, Any]
     call_id: str | None = None
-    output: Any = None
+    output: Any = UNKNOWN
+    error: str | None = None
 
     def describe(self):
+        if self.error:
+            return f"{self.name}({self.arguments}): Error: {self.error}"
         return f"{self.name}({self.arguments}) -> {self.output}"
 
+    def get_payload(self):
+        return dataclasses.asdict(self)
 
-class ToolCallModel(pydantic.BaseModel):
-    """Represents a tool call in a structured response."""
-
-    name: str
-    arguments: dict[str, Any]
+    @property
+    def text(self):
+        return str(self.output if self.output is not UNKNOWN else self.error)
 
 
-class ModelResponse(pydantic.BaseModel, Generic[T]):
-    """A structured response from the LLM that may contain tool calls or a message."""
+class ToolCallModel(pydantic.BaseModel, Generic[Name, T]):
+    # Represents a tool call in a structured response.
+    # Generic Name allows for overwriting str with Literal['tool_name']
+    name: Name
+    arguments: T
 
-    tools: list[ToolCallModel] | None = None
+
+class ModelResponse(pydantic.BaseModel, Generic[T, F]):
+    # A structured response from the LLM that may contain tool calls or a message.
+
+    tools: list[F] | None = None
     message: T | None = None
+
+    model_config = pydantic.ConfigDict(
+        title="Response",
+        extra="forbid",
+        arbitrary_types_allowed=False,
+    )
 
 
 def describe_tools(tools: list[Callable]) -> str:
@@ -107,7 +132,7 @@ def invoke_tool(call: ToolInvocation, tools: list[Callable]) -> ToolInvocationRe
             call_id=call.call_id,
         )
     try:
-        output = tool(**call.arguments)
+        output = tool(**(call.arguments or {}))
         return ToolInvocationResult(
             name=call.name,
             arguments=call.arguments,
@@ -121,6 +146,16 @@ def invoke_tool(call: ToolInvocation, tools: list[Callable]) -> ToolInvocationRe
         return ToolInvocationResult(
             name=call.name,
             arguments=call.arguments,
-            output=error_message,
+            error=error_message,
             call_id=call.call_id,
         )
+
+
+def iter_invocations(chat):
+    from kaggle_benchmarks import llm_messages
+
+    for item in chat.messages:
+        if isinstance(item.content, ToolInvocationResult):
+            yield item.content
+        elif isinstance(item, llm_messages.LLMMessage):
+            yield from item.tool_calls or []

--- a/src/kaggle_benchmarks/tools/functions.py
+++ b/src/kaggle_benchmarks/tools/functions.py
@@ -23,8 +23,8 @@ class ToolSchemaError(Exception):
     """Raised when a function schema cannot be generated."""
 
 
-def get_function_schema(func: Callable) -> dict:
-    """Generates a JSON schema for a function's parameters using Pydantic."""
+def _get_function_arguments(func: Callable) -> dict[str, tuple[type, Any]]:
+    """Generates a Pydantic model for a function's arguments."""
     sig = inspect.signature(func)
     fields = {}
 
@@ -36,12 +36,17 @@ def get_function_schema(func: Callable) -> dict:
 
         fields[name] = (annotation, default)
 
+    return fields
+
+
+def get_function_schema(func: Callable) -> dict:
+    """Generates a JSON schema for a function's parameters using Pydantic."""
     try:
-        DynamicModel = pydantic.create_model(f"{func.__name__}", **fields)
-        return DynamicModel.model_json_schema()
+        model = pydantic.create_model(func.__name__, **_get_function_arguments(func))
+        return model.model_json_schema()
     except pydantic.PydanticSchemaGenerationError as e:
         raise ToolSchemaError(
-            "Unable to generate json schema for function {func.__name__} arguments", e
+            f"Unable to generate json schema for function {func.__name__} arguments", e
         )
 
 

--- a/src/kaggle_benchmarks/tools/simulate.py
+++ b/src/kaggle_benchmarks/tools/simulate.py
@@ -1,0 +1,181 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable, Literal, TypeVar, Union
+
+import pydantic
+from typing_extensions import TypedDict
+
+from kaggle_benchmarks import actors, chats, usage
+from kaggle_benchmarks.llm_messages import LLMMessage
+from kaggle_benchmarks.tools import base, functions
+
+T = TypeVar("T")
+
+
+class ToolInvocationLimitExhausted(Exception):
+    pass
+
+
+def build_response_model(tools: list[Callable], output_schema: type):
+    """Creates a pydantic model that can be used as response format for LLM that provides option for llm to invoke tools."""
+    return base.ModelResponse[
+        output_schema,
+        Union[
+            *(
+                base.ToolCallModel[
+                    Literal[tool.__name__],
+                    TypedDict(
+                        tool.__name__,
+                        {
+                            field: annotation
+                            for field, (
+                                annotation,
+                                _,
+                            ) in functions._get_function_arguments(tool).items()
+                        },
+                    ),
+                ]
+                for tool in tools
+            )
+        ],
+    ]
+
+
+def simulate_respond_with_tools(
+    llm: actors.LLMChat,
+    tools: list[Callable],
+    output_schema: type[T],
+    system: str | None = None,
+    temperature: float | None = None,
+    seed: int | None = None,
+) -> LLMMessage[T]:
+    """Simulates tool calling for models that do not support it natively."""
+    if not tools:
+        return llm.respond(
+            system=system,
+            schema=output_schema,
+            temperature=temperature,
+            seed=seed,
+            tools=None,
+        )
+
+    chat = chats.get_current_chat()
+
+    previous_invocations = list(base.iter_invocations(chat))
+
+    if previous_invocations:
+        invocation_history = "\n".join(i.describe() for i in previous_invocations)
+
+        history_prompt = f"""You have already invocated the following tools:
+{invocation_history}"""
+    else:
+        history_prompt = ""
+
+    instructions = f"""You can invoke the following tools:
+{base.describe_tools(tools)}
+
+{history_prompt}
+
+If you decided to invoke a tool, fill the `tools` attribute with the invocation details, like `[{{"name": "function_name", "arguments": {{...}}}}]`.
+If you have enough information from previous tool calls or you decide not to use any tools, leave the `tools` field blank and fill the `message` field with your response.
+Only one of `tools` or `message`, should be filled with a value.
+"""
+
+    with chats.fork(orphan=True) as subchat:
+        actors.user.send(instructions)
+
+        try:
+            wrapped_schema = build_response_model(tools, output_schema)
+        except pydantic.PydanticSchemaGenerationError as e:
+            raise ValueError(
+                f"Unable to generate JSON schema for response format {output_schema}."
+            ) from e
+
+        response = llm.respond(
+            system=system,
+            schema=wrapped_schema,
+            temperature=temperature,
+            seed=seed,
+            tools=None,
+        )
+
+    value = response.content
+    if value.tools:
+        response.tool_calls = [
+            base.invoke_tool(
+                base.ToolInvocation(
+                    name=call.name,
+                    arguments=call.arguments,
+                    call_id=f"call_{call.name}",
+                ),
+                tools,
+            )
+            for call in value.tools
+        ]
+        response.content = value.message
+    elif value.message is not None:
+        response.content = value.message
+    else:
+        # some models will not produce anything
+        # so we ask them once more without tools
+        response = llm.respond(
+            system=system,
+            schema=output_schema,
+            temperature=temperature,
+            seed=seed,
+            tools=None,
+        )
+    response.chat = subchat
+    return response
+
+
+def simulate_agent(
+    llm: actors.LLMChat,
+    tools: list[Callable],
+    output_schema: type[T] = str,
+    max_iterations: int = 10,
+    system: str | None = None,
+    temperature: float | None = None,
+    seed: int | None = None,
+) -> LLMMessage[T | None]:
+    """Simulates an agent using tools over multiple iterations."""
+    final_response = LLMMessage(
+        sender=llm, content=None, usage=usage.Usage(0, 0), tool_calls=[]
+    )
+
+    for _ in range(max_iterations):
+        response = simulate_respond_with_tools(
+            llm,
+            tools,
+            output_schema=output_schema,
+            system=system,
+            temperature=temperature,
+            seed=seed,
+        )
+
+        final_response.content = response.content
+        final_response.usage += response.usage
+
+        if tools and response.tool_calls:
+            for call in response.tool_calls:
+                result = base.invoke_tool(call=call, tools=tools)
+                final_response.tool_calls.append(result)
+                actors.Tool(name=call.name).send(result)
+        else:
+            break
+    else:
+        raise ToolInvocationLimitExhausted()
+
+    return final_response

--- a/tests/tools/test_base.py
+++ b/tests/tools/test_base.py
@@ -51,10 +51,12 @@ def test_invoke_tool_success():
 def test_invoke_tool_not_found():
     call = ToolInvocation(name="non_existent_tool", arguments={})
     result = invoke_tool(call, [simple_tool])
-    assert "Error: Tool 'non_existent_tool' not found." in result.output
+    assert "Error: Tool 'non_existent_tool' not found." in result.describe()
 
 
 def test_invoke_tool_exception():
     call = ToolInvocation(name="tool_that_raises", arguments={})
     result = invoke_tool(call, [tool_that_raises])
-    assert "Error invoking tool 'tool_that_raises': This tool failed." in result.output
+    assert (
+        "Error invoking tool 'tool_that_raises': This tool failed." in result.describe()
+    )

--- a/tests/tools/test_simulate.py
+++ b/tests/tools/test_simulate.py
@@ -1,0 +1,219 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pydantic
+import pytest
+
+from kaggle_benchmarks import chats
+from kaggle_benchmarks.tools import simulate
+from tests.mocks import MockedChat
+
+
+def dummy_tool(x: int, y: str = "default") -> str:
+    """A dummy tool."""
+    return f"{x}-{y}"
+
+
+def dummy_tool_2(z: float) -> float:
+    return z
+
+
+def tool_no_arguments():
+    pass
+
+
+def error_tool() -> str:
+    raise ValueError("Simulated tool failure")
+
+
+def test_build_response_model():
+    """Tests the creation of a Pydantic response model for tool invocation."""
+    model = simulate.build_response_model(
+        [dummy_tool, dummy_tool_2, tool_no_arguments], str
+    )
+    assert issubclass(model, pydantic.BaseModel)
+
+
+@pytest.mark.parametrize(
+    "tools_payload",
+    [
+        [{"name": "dummy_tool", "arguments": {"x": 1, "y": "test"}}],
+        [{"name": "dummy_tool_2", "arguments": {"z": 3.14}}],
+        [
+            {
+                "name": "dummy_tool",
+                "arguments": {"x": 1, "y": "test", "extra_arg": "ignored"},
+            }
+        ],
+    ],
+)
+def test_build_response_model_valid(tools_payload):
+    """Tests the creation of a Pydantic response model for tool invocation."""
+    model = simulate.build_response_model([dummy_tool, dummy_tool_2], str)
+    assert issubclass(model, pydantic.BaseModel)
+
+    instance = model(tools=tools_payload, message=None)
+    assert instance.tools is not None
+    assert len(instance.tools) == 1
+    assert instance.tools[0].name == tools_payload[0]["name"]
+    for k, v in instance.tools[0].arguments.items():
+        assert v == tools_payload[0]["arguments"][k]
+
+
+@pytest.mark.parametrize(
+    "tools_payload,expected_error",
+    [
+        (
+            [{"name": "non_existent_tool", "arguments": {"x": 1, "y": "test"}}],
+            "Input should be",
+        ),
+        (
+            [{"name": "dummy_tool", "arguments": {"x": "not-an-int", "y": "test"}}],
+            "Input should be a valid integer",
+        ),
+        (
+            [{"name": "dummy_tool", "arguments": {}}],
+            "Field required",
+        ),
+    ],
+)
+def test_build_response_model_invalid(tools_payload, expected_error):
+    """Tests that the response model rejects invalid tool calls."""
+    model = simulate.build_response_model([dummy_tool, dummy_tool_2], str)
+
+    with pytest.raises(pydantic.ValidationError) as exc_info:
+        model(tools=tools_payload, message=None)
+
+    assert expected_error in str(exc_info.value)
+
+
+def test_simulate_tool_calling_with_tools():
+    llm = MockedChat.from_contents_data(
+        [
+            dict(
+                tools=[
+                    {
+                        "name": "dummy_tool",
+                        "arguments": {"x": 42, "y": "default"},
+                    }
+                ],
+                message=None,
+            )
+        ]
+    )
+
+    response = simulate.simulate_respond_with_tools(
+        llm=llm, tools=[dummy_tool, dummy_tool_2], output_schema=str
+    )
+
+    tool_calls = response.tool_calls or []
+    assert len(tool_calls) == 1
+    assert tool_calls[0].name == "dummy_tool"
+    assert tool_calls[0].arguments == {"x": 42, "y": "default"}
+    assert response.content is None
+
+
+def test_simulate_tool_calling_with_message():
+    llm = MockedChat.from_contents_data(
+        [{"tools": None, "message": "Here is the final answer."}]
+    )
+
+    response = simulate.simulate_respond_with_tools(
+        llm=llm, tools=[dummy_tool, dummy_tool_2], output_schema=str
+    )
+    tool_calls = response.tool_calls or []
+    assert not tool_calls
+    assert response.content == "Here is the final answer."
+
+
+def test_simulate_agent_success():
+    llm = MockedChat.from_contents_data(
+        [
+            {
+                "tools": [
+                    {
+                        "name": "dummy_tool",
+                        "arguments": {"x": 10, "y": "test"},
+                    }
+                ],
+                "message": None,
+            },
+            {"tools": None, "message": "Done!"},
+        ]
+    )
+
+    response = simulate.simulate_agent(
+        llm=llm, tools=[dummy_tool, dummy_tool_2], output_schema=str
+    )
+
+    assert response.content == "Done!"
+    assert len(response.tool_calls) == 1
+    assert response.tool_calls[0].name == "dummy_tool"
+    assert response.tool_calls[0].output == "10-test"
+
+
+def test_simulate_agent_limit_exhausted():
+    llm = MockedChat.from_contents_data(
+        [
+            {
+                "tools": [
+                    {
+                        "name": "dummy_tool",
+                        "arguments": {"x": i, "y": "test"},
+                    }
+                ],
+                "message": None,
+            }
+            for i in range(5)
+        ]
+    )
+
+    with pytest.raises(simulate.ToolInvocationLimitExhausted):
+        simulate.simulate_agent(
+            llm=llm, tools=[dummy_tool], output_schema=str, max_iterations=2
+        )
+
+
+def test_simulate_agent_without_tools():
+    llm = MockedChat.from_contents(["No tools used!"])
+    with chats.new("test_chat"):
+        response = simulate.simulate_agent(llm=llm, tools=[], output_schema=str)
+        assert response.content == "No tools used!"
+        assert not response.tool_calls
+
+
+def test_simulate_agent_tool_error_recovery():
+    # 1st turn: calls the tool that will fail
+    # 2nd turn: acknowledges the error and provides a final answer
+    llm = MockedChat.from_contents_data(
+        [
+            {
+                "tools": [{"name": "error_tool", "arguments": {}}],
+                "message": None,
+            },
+            {"tools": None, "message": "I recovered from the error!"},
+        ]
+    )
+
+    with chats.new("test_chat"):
+        response = simulate.simulate_agent(
+            llm=llm, tools=[error_tool], output_schema=str
+        )
+
+        assert response.content == "I recovered from the error!"
+        assert len(response.tool_calls) == 1
+        assert response.tool_calls[0].name == "error_tool"
+        assert response.tool_calls[0].error is not None
+        assert "Simulated tool failure" in response.tool_calls[0].error


### PR DESCRIPTION
This commit introduces a new simulation capability for models that do not natively support tool/function calling, allowing them to act as tool-using agents through structured prompting.

- `simulate_agent`: An iterative agent loop that automatically prompts the LLM with available tools, parses its requested tool calls, executes them locally, and feeds the results back until a final answer is reached (or `max_iterations` is hit).
- `simulate_respond_with_tools`: A single-turn simulation that wraps the LLM call with instructions and a structured output schema built dynamically from the provided Python functions.