### PR TITLE
Clarify asset sharing privacy in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -156,9 +156,13 @@ body:
   - type: markdown
     attributes:
       value: |
-        **Important:** To help us troubleshoot your issue, please share any associated Kaggle assets (notebooks, tasks, benchmarks, models, datasets) with **kaggle-ai-resources-support@google.com** as a **Viewer**.
+        ### 🔒 Share Your Kaggle Assets (Required for Debugging)
 
-        To do this:
+        **We need access to your notebooks/assets to investigate your issue.** Without them, we cannot reproduce or debug the problem and your issue may be closed.
+
+        Sharing with `kaggle-ai-resources-support@google.com` grants **Viewer** access **only to the Kaggle support team**. Your code and data remain **private and confidential** — they will not be shared publicly, leaked, or used for any purpose other than troubleshooting your issue.
+
+        **Steps to share:**
         1. Go to your asset on Kaggle (notebook, dataset, model, etc.)
         2. Click the **Share** button
         3. Search for `kaggle-ai-resources-support@google.com`
@@ -171,11 +175,12 @@ body:
       label: Shared Asset Links
       description: |
         Paste links to any Kaggle assets you've shared with kaggle-ai-resources-support@google.com.
+        Sharing is required for us to debug your issue. Your assets will only be visible to the Kaggle support team and will remain fully confidential.
       placeholder: |
         - https://www.kaggle.com/code/yourusername/your-notebook
         - https://www.kaggle.com/datasets/yourusername/your-dataset
     validations:
-      required: false
+      required: true
 
   # ── Additional Context ────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Reworded the "Share Your Assets" section in the bug report issue template to clearly communicate that sharing notebooks/assets with `kaggle-ai-resources-support@google.com` is **confidential** — only the Kaggle support team can view them, and they will not be shared publicly or used for anything other than troubleshooting.
- Made it clear that **without sharing assets, the team cannot debug the issue** and it may be closed.
- Changed the "Shared Asset Links" field from optional to **required** to ensure users provide the necessary information for debugging.

## Context
Addresses feedback from [#122](https://github.com/Kaggle/kaggle-benchmarks/issues/122) where a user was hesitant to share their notebooks. The previous template wording didn't explicitly reassure users about confidentiality or explain that sharing is essential for the support team to help.

## Changes
**`.github/ISSUE_TEMPLATE/bug_report.yml`**:
- Added a heading with a lock icon: "Share Your Kaggle Assets (Required for Debugging)"
- Added explicit privacy/confidentiality reassurance
- Added clear statement that issues without shared assets cannot be debugged and may be closed
- Changed the field description to reiterate confidentiality
- Changed `required: false` → `required: true` for the shared asset links field

## Test plan
- [ ] Verify the updated template renders correctly by navigating to "New Issue" on the repo
- [ ] Confirm the "Shared Asset Links" field is now required
- [ ] Confirm the privacy language is clear and visible