### PR TITLE
Update bug report template to clarify asset sharing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -156,7 +156,11 @@ body:
   - type: markdown
     attributes:
       value: |
-        **Important:** To help us troubleshoot your issue, please share any associated Kaggle assets (notebooks, tasks, benchmarks, models, datasets) with **kaggle-ai-resources-support@google.com** as a **Viewer**.
+        **Important:** To troubleshoot your issue, we need access to your Kaggle assets (notebooks, tasks, benchmarks, models, datasets). Please share them with **kaggle-ai-resources-support@google.com** as a **Viewer**.
+
+        **Privacy note:** This is a restricted Google Group used only by the Kaggle support team. Your code and data will not be shared publicly or with anyone outside the team. Access is used solely for debugging your issue.
+
+        **Without access to your assets, we may not be able to diagnose or resolve your issue.**
 
         To do this:
         1. Go to your asset on Kaggle (notebook, dataset, model, etc.)
@@ -175,7 +179,7 @@ body:
         - https://www.kaggle.com/code/yourusername/your-notebook
         - https://www.kaggle.com/datasets/yourusername/your-dataset
     validations:
-      required: false
+      required: true
 
   # ── Additional Context ────────────────────────────────────────
 
@@ -201,3 +205,5 @@ body:
           required: true
         - label: I am using the latest version of kaggle-benchmarks (or have noted my version above).
           required: false
+        - label: I have shared my relevant Kaggle assets (notebooks, datasets, etc.) with kaggle-ai-resources-support@google.com as a Viewer, or I have explained in the issue why I cannot.
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -158,7 +158,7 @@ body:
       value: |
         **Important:** To troubleshoot your issue, we need access to your Kaggle assets (notebooks, tasks, benchmarks, models, datasets). Please share them with **kaggle-ai-resources-support@google.com** as a **Viewer**.
 
-        **Privacy note:** This is a restricted Google Group used only by the Kaggle support team. Your code and data will not be shared publicly or with anyone outside the team. Access is used solely for debugging your issue.
+        **Privacy note:** This is a restricted group used only by the Kaggle support team. Your code and data will not be shared publicly or with anyone outside the team. Access is used solely for debugging your issue.
 
         **Without access to your assets, we may not be able to diagnose or resolve your issue.**
 


### PR DESCRIPTION
Users are hesitant to share private notebooks with the support group.
Add privacy note explaining it's a restricted Google Group used only
by the support team. Make the shared asset links field required and
add a checklist item so users confirm they've shared assets or
explained why they cannot.

Co-authored-by: kaggle-agent <kaggle-agent@users.noreply.github.com>

---

Task: [limagoog-20260408223339-db80b8c8](https://agents.dev.kaggle.net/tasks/limagoog-20260408223339-db80b8c8)
Context: https://chat.kaggle.net/kaggle/pl/4jeisfbuk7n5dkkzezfqjwi59c

