### PR TITLE
Add ModelProxy thinking trace access

### DIFF
--- a/documentation/examples/reasoning_with_thoughts.py
+++ b/documentation/examples/reasoning_with_thoughts.py
@@ -1,0 +1,61 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# %% [markdown]
+# ---
+# title: Reasoning with Thoughts
+# ---
+# This example demonstrates how to use the `reasoning_level` and
+# `include_thoughts` parameters when loading a model via Model Proxy.
+#
+# - `reasoning_level` maps to the OpenAI `reasoning_effort` parameter
+#   and controls how much reasoning the model performs. Options: "low",
+#   "medium", "high".
+# - `include_thoughts` sends the `google.thinking_config` extra body
+#   so the proxy returns inline thinking traces wrapped in `<think>` tags.
+# %%
+from kaggle_benchmarks import assertions, task
+from kaggle_benchmarks.kaggle import load_model
+
+question = "How many r's are in 'strawberry'?"
+
+
+@task("Reasoning with thoughts")
+def reasoning_with_thoughts(llm, question: str):
+    """Evaluates reasoning with thinking traces enabled."""
+    answer = llm.prompt(question)
+    assertions.assert_not_empty(answer, "LLM should return a non-empty answer.")
+
+
+# %% [markdown]
+# ### 1. reasoning_level only
+# %%
+llm_reasoning = load_model("google/gemini-2.5-pro", reasoning_level="high")
+reasoning_with_thoughts.run(llm_reasoning, question)
+
+# %% [markdown]
+# ### 2. reasoning_level + include_thoughts
+# %%
+llm_both = load_model(
+    "google/gemini-2.5-pro", reasoning_level="high", include_thoughts=True
+)
+reasoning_with_thoughts.run(llm_both, question)
+
+# %% [markdown]
+# ### 3. include_thoughts only
+# %%
+llm_thoughts = load_model("google/gemini-2.5-pro", include_thoughts=True)
+reasoning_with_thoughts.run(llm_thoughts, question)
+
+# %%

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -279,11 +279,20 @@ class LLMChat(actors.Actor):
 
 
 class OpenAI(LLMChat):
-    def __init__(self, client: openai.OpenAI, model: str, **kwargs):
+    def __init__(
+        self,
+        client: openai.OpenAI,
+        model: str,
+        reasoning_level: str | None = None,
+        include_thoughts: bool | None = None,
+        **kwargs,
+    ):
         kwargs.setdefault("name", model)
         super().__init__(**kwargs)
         self.model = model
         self.client = client
+        self.reasoning_level = reasoning_level
+        self.include_thoughts = include_thoughts
         self.serializer = openai_serializer.ModelProxyOpenAISerializer(
             roles_mapping={"tool": "system"}
         )
@@ -366,6 +375,19 @@ class OpenAI(LLMChat):
                 kwargs["stream"] = True
 
             method = self.client.chat.completions.create
+
+        if self.reasoning_level:
+            kwargs.setdefault("reasoning_effort", self.reasoning_level)
+        if self.include_thoughts:
+            # The Model Proxy expects a literal "extra_body" key in the
+            # request body.  The OpenAI SDK's extra_body parameter merges
+            # its dict into the top level, so we nest one level deeper.
+            kwargs.setdefault("extra_body", {})
+            kwargs["extra_body"].setdefault("extra_body", {})
+            kwargs["extra_body"]["extra_body"].setdefault("google", {})
+            kwargs["extra_body"]["extra_body"]["google"].setdefault(
+                "thinking_config", {"include_thoughts": True}
+            )
 
         response = method(
             model=self.model,

--- a/src/kaggle_benchmarks/kaggle/model_proxy.py
+++ b/src/kaggle_benchmarks/kaggle/model_proxy.py
@@ -30,6 +30,8 @@ class ModelProxy:
         api: str = "openai",
         api_key: str | None = None,
         base_url: str | None = None,
+        reasoning_level: str | None = None,
+        include_thoughts: bool | None = None,
         **kwargs,
     ) -> LLMChat:
         resolved_api_key = api_key or os.getenv("MODEL_PROXY_API_KEY")
@@ -65,7 +67,13 @@ class ModelProxy:
 
             # TODO (b/439876083): Disable temperature parameter till this is resolved.
             kwargs.setdefault("support_temperature", False)
-            llm_instance = OpenAI(client, model, **kwargs)
+            llm_instance = OpenAI(
+                client,
+                model,
+                reasoning_level=reasoning_level,
+                include_thoughts=include_thoughts,
+                **kwargs,
+            )
 
         else:
             raise ValueError(f"Unsupported API: '{api}'. Must be 'openai' or 'genai'.")

--- a/src/kaggle_benchmarks/kaggle/models.py
+++ b/src/kaggle_benchmarks/kaggle/models.py
@@ -49,7 +49,12 @@ def load_available_models() -> dict[str, LLMChat]:
     }
 
 
-def load_model(model_name: str, api: str = "openai") -> LLMChat:
+def load_model(
+    model_name: str,
+    api: str = "openai",
+    reasoning_level: str | None = None,
+    include_thoughts: bool | None = None,
+) -> LLMChat:
     if "MODEL_PROXY_API_KEY" not in os.environ:
         raise RuntimeError(
             "The MODEL_PROXY_API_KEY environment variable should be provided"
@@ -63,4 +68,6 @@ def load_model(model_name: str, api: str = "openai") -> LLMChat:
         api_key=os.environ["MODEL_PROXY_API_KEY"],
         base_url=os.environ["MODEL_PROXY_URL"],
         api=api,
+        reasoning_level=reasoning_level,
+        include_thoughts=include_thoughts,
     )


### PR DESCRIPTION
Add particular arguments to model instantiation to support access thinking traces in from the Kaggle ModelProxy backed ChatCompletions FE.

