### PR TITLE
Add reasoning and include_thoughts as explicit prompt() params

### DIFF
--- a/cookbook.md
+++ b/cookbook.md
@@ -530,6 +530,24 @@ response = llm.prompt("Transcribe this audio.", audio=audio_content)
 
 ------------------------------------------------------------------------
 
+### Recipe: Controlling Reasoning
+
+Control how much reasoning the model performs:
+
+```python
+response = llm.prompt("Solve this math problem.", reasoning="high")
+```
+
+Valid values: `"low"`, `"medium"`, `"high"`.
+
+Include the model's internal reasoning in the response:
+
+```python
+response = llm.prompt("How many r's in strawberry?", reasoning="high", include_thoughts=True)
+```
+
+---
+
 ## Advanced Patterns
 
 ### Recipe: Implementing an Interactive Game Loop

--- a/cookbook.md
+++ b/cookbook.md
@@ -538,7 +538,7 @@ Control how much reasoning the model performs:
 response = llm.prompt("Solve this math problem.", reasoning="high")
 ```
 
-Valid values: `"low"`, `"medium"`, `"high"`.
+Valid values: `"none"`, `"low"`, `"medium"`, `"high"`.
 
 > **Note:** Not all models support reasoning. Models that don't support
 > it will return an error.

--- a/cookbook.md
+++ b/cookbook.md
@@ -540,10 +540,15 @@ response = llm.prompt("Solve this math problem.", reasoning="high")
 
 Valid values: `"low"`, `"medium"`, `"high"`.
 
-Include the model's internal reasoning in the response:
+> **Note:** Not all models support reasoning. Models that don't support
+> it will return an error.
+
+Since `prompt()` returns a plain string, use `kbench.last_reasoning_traces()`
+to access the model's reasoning traces from the most recent response:
 
 ```python
-response = llm.prompt("How many r's in strawberry?", reasoning="high", include_thoughts=True)
+response = llm.prompt("How many r's in strawberry?", reasoning="high")
+traces = kbench.last_reasoning_traces()  # model's internal reasoning
 ```
 
 ---

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -624,9 +624,9 @@ def test_reasoning_param(llm):
 
 
 # %%
-# --- Test Case: Include thoughts ---
-# Tests that thinking traces are returned when include_thoughts=True is passed.
-# Both backends wrap thoughts in <think> tags.
+# --- Test Case: Reasoning with thinking traces ---
+# Tests that thinking traces are automatically captured on the message
+# when reasoning is enabled, accessible via message.reasoning_traces.
 
 @benchmark_test(
     include={
@@ -635,18 +635,20 @@ def test_reasoning_param(llm):
     },
 )
 @kbench.task()
-def test_include_thoughts(llm):
-    """Tests that include_thoughts returns thinking traces."""
+def test_reasoning_captures_thinking(llm):
+    """Tests that reasoning captures thinking traces on the message."""
     response = llm.prompt(
         "How many r's are in the word 'strawberry'? Think step by step.",
         reasoning="high",
-        include_thoughts=True,
     )
 
-    kbench.assertions.assert_contains_regex(
-        r"(?i)<think>",
-        response,
-        expectation="Response should contain thinking traces in <think> tags.",
+    chat = kbench.chats.get_current_chat()
+    last_message = chat.messages[-1]
+    assert last_message.reasoning_traces is not None, (
+        "Reasoning traces should be accessible via message.reasoning_traces"
+    )
+    assert len(last_message.reasoning_traces) > 0, (
+        "Reasoning traces should not be empty"
     )
 
 

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -592,7 +592,7 @@ def test_audio_url(llm):
 
 # %%
 # --- Test Case: Reasoning parameter ---
-# Sverifies that `reasoning=` doesn't error across providers.
+# Verifies that `reasoning=` doesn't error across providers.
 # Actual wiring (thinking_config, reasoning_effort) is covered by unit tests;
 # trace capture is verified in test_reasoning_captures_traces for models that
 # support it (not all models return traces).

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -647,6 +647,7 @@ def test_reasoning_captures_traces(llm):
         "Reasoning traces should not be empty"
     )
 
+
 # %%
 # --- Test Case: Tool Use ---
 # This doesn't work with "genai" API for now

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -647,7 +647,6 @@ def test_reasoning_captures_traces(llm):
         "Reasoning traces should not be empty"
     )
 
-
 # %%
 # --- Test Case: Tool Use ---
 # This doesn't work with "genai" API for now

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -598,14 +598,8 @@ def test_audio_url(llm):
 
 @benchmark_test(
     exclude={
-        "google/gemma-3-12b",
         "google/gemini-2.0-flash",
-        "deepseek-ai/deepseek-r1-0528",
-        "deepseek-ai/deepseek-v3.2",
-        "qwen/qwen3-235b-a22b-instruct-2507",
-        "qwen/qwen3-next-80b-a3b-instruct",
-        "zai/glm-5",
-        "google/gemini-3.1-flash-lite-preview",
+        "google/gemma-3-12b",
     },
 )
 @kbench.task()
@@ -624,8 +618,8 @@ def test_reasoning_param(llm):
 
 
 # %%
-# --- Test Case: Reasoning with thinking traces ---
-# Tests that thinking traces are automatically captured on the message
+# --- Test Case: Reasoning traces ---
+# Tests that reasoning traces are automatically captured on the message
 # when reasoning is enabled, accessible via message.reasoning_traces.
 
 
@@ -633,12 +627,13 @@ def test_reasoning_param(llm):
     include={
         "google/gemini-2.5-flash",
         "google/gemini-2.5-pro",
+        "anthropic/claude-sonnet-4-5@20250929",
     },
 )
 @kbench.task()
-def test_reasoning_captures_thinking(llm):
-    """Tests that reasoning captures thinking traces on the message."""
-    response = llm.prompt(
+def test_reasoning_captures_traces(llm):
+    """Tests that reasoning captures reasoning traces on the message."""
+    llm.prompt(
         "How many r's are in the word 'strawberry'? Think step by step.",
         reasoning="high",
     )

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -628,6 +628,7 @@ def test_reasoning_param(llm):
 # Tests that thinking traces are automatically captured on the message
 # when reasoning is enabled, accessible via message.reasoning_traces.
 
+
 @benchmark_test(
     include={
         "google/gemini-2.5-flash",

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -592,8 +592,10 @@ def test_audio_url(llm):
 
 # %%
 # --- Test Case: Reasoning parameter ---
-# The SDK maps the unified `reasoning` parameter to provider-specific params:
-# OpenAI → reasoning_effort, GenAI → thinking_config.
+# Sverifies that `reasoning=` doesn't error across providers.
+# Actual wiring (thinking_config, reasoning_effort) is covered by unit tests;
+# trace capture is verified in test_reasoning_captures_traces for models that
+# support it (not all models return traces).
 
 
 @benchmark_test(

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -591,6 +591,66 @@ def test_audio_url(llm):
 
 
 # %%
+# --- Test Case: Reasoning parameter ---
+# The SDK maps the unified `reasoning` parameter to provider-specific params:
+# OpenAI → reasoning_effort, GenAI → thinking_config.
+
+
+@benchmark_test(
+    exclude={
+        "google/gemma-3-12b",
+        "google/gemini-2.0-flash",
+        "deepseek-ai/deepseek-r1-0528",
+        "deepseek-ai/deepseek-v3.2",
+        "qwen/qwen3-235b-a22b-instruct-2507",
+        "qwen/qwen3-next-80b-a3b-instruct",
+        "zai/glm-5",
+        "google/gemini-3.1-flash-lite-preview",
+    },
+)
+@kbench.task()
+def test_reasoning_param(llm):
+    """Tests that the unified reasoning parameter works across providers."""
+    response = llm.prompt(
+        "What is 2 + 2? Reply with just the number.",
+        reasoning="low",
+    )
+
+    kbench.assertions.assert_contains_regex(
+        r"4",
+        response,
+        expectation="Model should answer 4.",
+    )
+
+
+# %%
+# --- Test Case: Include thoughts ---
+# Tests that thinking traces are returned when include_thoughts=True is passed.
+# Both backends wrap thoughts in <think> tags.
+
+@benchmark_test(
+    include={
+        "google/gemini-2.5-flash",
+        "google/gemini-2.5-pro",
+    },
+)
+@kbench.task()
+def test_include_thoughts(llm):
+    """Tests that include_thoughts returns thinking traces."""
+    response = llm.prompt(
+        "How many r's are in the word 'strawberry'? Think step by step.",
+        reasoning="high",
+        include_thoughts=True,
+    )
+
+    kbench.assertions.assert_contains_regex(
+        r"(?i)<think>",
+        response,
+        expectation="Response should contain thinking traces in <think> tags.",
+    )
+
+
+# %%
 # --- Test Case: Tool Use ---
 # This doesn't work with "genai" API for now
 # So test it with `-k "openai"` only.

--- a/src/kaggle_benchmarks/__init__.py
+++ b/src/kaggle_benchmarks/__init__.py
@@ -29,9 +29,9 @@ from kaggle_benchmarks import (
 )
 from kaggle_benchmarks._config import ExecutionMode, config
 from kaggle_benchmarks.actors import Actor, LLMChat, system, user
+from kaggle_benchmarks.chats import last_reasoning_traces
 from kaggle_benchmarks.kaggle.model_proxy import validate_model_proxy_config
 from kaggle_benchmarks.runs import Run, Runs
-from kaggle_benchmarks.chats import last_reasoning_traces
 from kaggle_benchmarks.tasks import benchmark, task
 from kaggle_benchmarks.usage import Usage
 

--- a/src/kaggle_benchmarks/__init__.py
+++ b/src/kaggle_benchmarks/__init__.py
@@ -31,6 +31,7 @@ from kaggle_benchmarks._config import ExecutionMode, config
 from kaggle_benchmarks.actors import Actor, LLMChat, system, user
 from kaggle_benchmarks.kaggle.model_proxy import validate_model_proxy_config
 from kaggle_benchmarks.runs import Run, Runs
+from kaggle_benchmarks.chats import last_reasoning_traces
 from kaggle_benchmarks.tasks import benchmark, task
 from kaggle_benchmarks.usage import Usage
 

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -137,6 +137,7 @@ def _validate_reasoning(reasoning: str | None) -> None:
 @dataclasses.dataclass(frozen=True)
 class LLMResponse:
     content: str
+    thinking: str | None = None
     tool_calls: list[Any] | None = None
     meta: dict[str, Any] = dataclasses.field(default_factory=dict)
 
@@ -266,6 +267,7 @@ class LLMChat(actors.Actor):
             response.content = invoke_response.content or ""
             response._meta["tool_calls"] = invoke_response.tool_calls
             response._meta.update(invoke_response.meta)
+            response._meta["thinking"] = invoke_response.thinking
         elif isinstance(invoke_response, Iterator):
             response.stream(invoke_response)
         elif isinstance(invoke_response, llm_messages.LLMMessage):
@@ -426,6 +428,7 @@ class OpenAI(LLMChat):
             tool_calls = message.tool_calls
             return LLMResponse(
                 content=message.content or "",
+                thinking=getattr(message, "reasoning_content", None),
                 tool_calls=[t.model_dump() for t in tool_calls] if tool_calls else None,
                 meta=self._get_usage_meta(response.usage),
             )
@@ -458,7 +461,7 @@ class GoogleGenAI(LLMChat):
 
     @staticmethod
     def _extract_text(response: types.GenerateContentResponse) -> str:
-        """Extracts text from a response, wrapping thought parts in <think> tags."""
+        """Extracts non-thought text content from a response."""
         if not response.candidates or not response.candidates[0].content:
             return ""
         parts = response.candidates[0].content.parts or []
@@ -467,10 +470,23 @@ class GoogleGenAI(LLMChat):
             if not part.text:
                 continue
             if getattr(part, "thought", False):
-                segments.append(f"<think>\n{part.text}\n</think>")
-            else:
-                segments.append(part.text)
+                continue
+            segments.append(part.text)
         return "".join(segments) if segments else ""
+
+    @staticmethod
+    def _extract_thinking(response: types.GenerateContentResponse) -> str | None:
+        """Extracts thinking text from thought parts of a response."""
+        if not response.candidates or not response.candidates[0].content:
+            return None
+        parts = response.candidates[0].content.parts or []
+        segments = []
+        for part in parts:
+            if not part.text:
+                continue
+            if getattr(part, "thought", False):
+                segments.append(part.text)
+        return "".join(segments) if segments else None
 
     def _get_stream_response(
         self, response_stream: Iterator[types.GenerateContentResponse]
@@ -547,5 +563,6 @@ class GoogleGenAI(LLMChat):
 
             return LLMResponse(
                 content=self._extract_text(response),
+                thinking=self._extract_thinking(response),
                 meta=self._get_usage_meta(response.usage_metadata),
             )

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -105,7 +105,8 @@ if TYPE_CHECKING:
     from kaggle_benchmarks import llm_messages
 
 T = TypeVar("T")
-ReasoningLevel = Literal["low", "medium", "high", None]
+# TODO: Add "none" once Model Proxy supports reasoning_effort="none".
+ReasoningLevel = Literal["low", "medium", "high"]
 
 
 # TODO: Figure out a more robust way to handle extra fields.

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -89,7 +89,7 @@ import dataclasses
 import enum
 import json
 import typing
-from typing import TYPE_CHECKING, Any, Iterator, TypeVar
+from typing import TYPE_CHECKING, Any, Iterator, Literal, TypeVar
 
 import openai
 from google import genai
@@ -118,6 +118,21 @@ def _extract_extra_usage_metadata(usage: Any) -> dict[str, Any]:
     }
 
 
+def _validate_reasoning(reasoning: str | None) -> None:
+    """Raises if reasoning is not a valid level.
+
+    Note: GenAI validates these values automatically via ThinkingConfig,
+    but OpenAI does not, so we validate here for both backends.
+    """
+    # TODO: Add "disabled" once Model Proxy supports reasoning_effort="none".
+    valid = {"low", "medium", "high"}
+    if reasoning is not None and reasoning not in valid:
+        raise ValueError(
+            f"Invalid reasoning level: {reasoning!r}. "
+            f"Must be one of: {sorted(valid)}"
+        )
+
+
 @dataclasses.dataclass(frozen=True)
 class LLMResponse:
     content: str
@@ -143,7 +158,12 @@ class LLMChat(actors.Actor):
         self.stream_responses = config.interactive_mode
 
     def invoke(
-        self, messages: list[messages.Message], system: str | None, **kwargs
+        self,
+        messages: list[messages.Message],
+        system: str | None,
+        reasoning: Literal["low", "medium", "high"] | None = None,
+        include_thoughts: bool = False,
+        **kwargs,
     ) -> LLMResponse | Iterator[LLMResponse] | "llm_messages.LLMMessage[str]":
         """Invokes the LLM with the given messages and system instructions."""
         raise NotImplementedError
@@ -158,7 +178,10 @@ class LLMChat(actors.Actor):
         image: images.ImageContent | None = None,
         video: videos.VideoContent | None = None,
         audio: audios.AudioContent | None = None,
+        reasoning: Literal["low", "medium", "high"] | None = None,
+        include_thoughts: bool = False,
     ) -> T:
+        _validate_reasoning(reasoning)
         if image is not None:
             match image:
                 case images.ImageURL():
@@ -186,6 +209,8 @@ class LLMChat(actors.Actor):
             seed=seed,
             temperature=temperature if self.support_temperature else None,
             tools=tools if tools is not None else [],
+            reasoning=reasoning,
+            include_thoughts=include_thoughts,
         ).content
 
     @chats.emits_message
@@ -305,7 +330,12 @@ class OpenAI(LLMChat):
         return any(self.model.startswith(prefix) for prefix in unsupported_prefixes)
 
     def invoke(
-        self, messages: list[messages.Message], system: str | None, **kwargs
+        self,
+        messages: list[messages.Message],
+        system: str | None,
+        reasoning: Literal["low", "medium", "high"] | None = None,
+        include_thoughts: bool = False,
+        **kwargs,
     ) -> LLMResponse | Iterator[LLMResponse]:
         if system:
             from kaggle_benchmarks.messages import Message
@@ -318,6 +348,17 @@ class OpenAI(LLMChat):
             # TODO(b/430112500): Remove once model proxy supports it for AIS backends.
             # Temporarily do not send "seed" parameter for models not supporting it in Model Proxy.
             kwargs.pop("seed", None)
+
+        if reasoning is not None:
+            kwargs["reasoning_effort"] = reasoning
+
+        if include_thoughts:
+            kwargs.setdefault("extra_body", {})
+            kwargs["extra_body"].setdefault("extra_body", {})
+            kwargs["extra_body"]["extra_body"].setdefault("google", {})
+            kwargs["extra_body"]["extra_body"]["google"].setdefault(
+                "thinking_config", {"include_thoughts": True}
+            )
 
         return self._call_api(raw_messages, **kwargs)
 
@@ -404,24 +445,64 @@ class GoogleGenAI(LLMChat):
             **_extract_extra_usage_metadata(usage),
         }
 
+    _REASONING_LEVEL_MAP = {
+        "low": "LOW",
+        "medium": "MEDIUM",
+        "high": "HIGH",
+    }
+
+    @staticmethod
+    def _extract_text(response: types.GenerateContentResponse) -> str:
+        """Extracts text from a response, wrapping thought parts in <think> tags."""
+        if not response.candidates or not response.candidates[0].content:
+            return ""
+        parts = response.candidates[0].content.parts or []
+        segments = []
+        for part in parts:
+            if not part.text:
+                continue
+            if getattr(part, "thought", False):
+                segments.append(f"<think>\n{part.text}\n</think>")
+            else:
+                segments.append(part.text)
+        return "\n".join(segments) if segments else ""
+
     def _get_stream_response(
         self, response_stream: Iterator[types.GenerateContentResponse]
     ) -> Iterator[LLMResponse]:
         # We currently only support text outputs
         for chunk in response_stream:
             yield LLMResponse(
-                content=chunk.text or "",
+                content=self._extract_text(chunk) if chunk.candidates else (chunk.text or ""),
                 meta=self._get_usage_meta(chunk.usage_metadata),
             )
 
     def invoke(
-        self, messages: list[messages.Message], system: str | None, **kwargs
+        self,
+        messages: list[messages.Message],
+        system: str | None,
+        reasoning: Literal["low", "medium", "high"] | None = None,
+        include_thoughts: bool = False,
+        **kwargs,
     ) -> LLMResponse | Iterator[LLMResponse]:
         raw_messages = list(self.serializer.dump_messages(messages))
 
         config_params = {}
         if system:
             config_params["system_instruction"] = system
+
+        if reasoning is not None:
+            # reasoning is already validated by _validate_reasoning in prompt().
+            level = self._REASONING_LEVEL_MAP[reasoning]
+            config_params["thinking_config"] = types.ThinkingConfig(
+                thinking_level=level,
+                include_thoughts=include_thoughts or None,
+            )
+        elif include_thoughts:
+            config_params["thinking_config"] = types.ThinkingConfig(
+                include_thoughts=True,
+            )
+
         if "response_format" in kwargs:
             schema = kwargs.pop("response_format")
             config_params["response_schema"] = schema
@@ -460,6 +541,6 @@ class GoogleGenAI(LLMChat):
                 )
 
             return LLMResponse(
-                content=response.text,
+                content=self._extract_text(response),
                 meta=self._get_usage_meta(response.usage_metadata),
             )

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -120,7 +120,6 @@ def _extract_extra_usage_metadata(usage: Any) -> dict[str, Any]:
     }
 
 
-
 @dataclasses.dataclass(frozen=True)
 class LLMResponse:
     content: str

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -108,6 +108,23 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 ReasoningLevel = Literal["none", "low", "medium", "high"]
 
+_THINK_TAG_PATTERN = re.compile(r"<think>\n?(.*?)\n?</think>\n*", re.DOTALL)
+
+
+def _parse_think_tags(content: str) -> tuple[str, str | None]:
+    """Extracts all <think>...</think> blocks from content.
+
+    Model Proxy wraps reasoning traces in <think> tags inside content
+    because the chat completions spec doesn't have a dedicated field
+    for reasoning traces.
+    """
+    segments = _THINK_TAG_PATTERN.findall(content)
+    if not segments:
+        return content, None
+    remaining = _THINK_TAG_PATTERN.sub("", content).strip()
+    thinking = "\n\n".join(s.strip() for s in segments if s.strip())
+    return remaining, thinking or None
+
 
 # TODO: Figure out a more robust way to handle extra fields.
 def _extract_extra_usage_metadata(usage: Any) -> dict[str, Any]:
@@ -310,22 +327,6 @@ class OpenAI(LLMChat):
             **_extract_extra_usage_metadata(usage),
         }
 
-    @staticmethod
-    def _parse_think_tags(content: str) -> tuple[str, str | None]:
-        """Extracts all <think>...</think> blocks from content.
-
-        Model Proxy wraps reasoning traces in <think> tags inside content
-        because the chat completions spec doesn't have a dedicated field
-        for reasoning traces.
-        """
-        pattern = re.compile(r"<think>\n?(.*?)\n?</think>\n*", re.DOTALL)
-        segments = pattern.findall(content)
-        if not segments:
-            return content, None
-        remaining = pattern.sub("", content).strip()
-        thinking = "\n\n".join(s.strip() for s in segments if s.strip())
-        return remaining, thinking or None
-
     def _should_remove_seed(self) -> bool:
         unsupported_prefixes = ("google/", "openai/gpt-5.4-pro")
         return any(self.model.startswith(prefix) for prefix in unsupported_prefixes)
@@ -370,6 +371,9 @@ class OpenAI(LLMChat):
         self, response_stream: openai.Stream
     ) -> Iterator[LLMResponse]:
         """Yields LLMResponse objects from a streaming response."""
+        # TODO: Streaming does not capture reasoning_traces. Think tags in
+        # streamed chunks are not parsed, so last_reasoning_traces() will
+        # return None when streaming is enabled.
         for chunk in response_stream:
             if not chunk.choices:
                 continue
@@ -429,8 +433,8 @@ class OpenAI(LLMChat):
             # in content using <think> tags.  Only parse when reasoning was
             # requested to avoid stripping literal <think> tags from content.
             reasoning = getattr(message, "reasoning_content", None)
-            if reasoning is None and "reasoning_effort" in kwargs:
-                content, reasoning = self._parse_think_tags(content)
+            if reasoning is None and kwargs.get("reasoning_effort") not in (None, "none"):
+                content, reasoning = _parse_think_tags(content)
             return LLMResponse(
                 content=content,
                 reasoning_traces=reasoning,
@@ -494,6 +498,9 @@ class GoogleGenAI(LLMChat):
     def _get_stream_response(
         self, response_stream: Iterator[types.GenerateContentResponse]
     ) -> Iterator[LLMResponse]:
+        # TODO: Streaming does not capture reasoning_traces. Thought parts
+        # are filtered out by _extract_text, so last_reasoning_traces() will
+        # return None when streaming is enabled.
         # We currently only support text outputs
         for chunk in response_stream:
             yield LLMResponse(

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -470,7 +470,9 @@ class GoogleGenAI(LLMChat):
         # We currently only support text outputs
         for chunk in response_stream:
             yield LLMResponse(
-                content=self._extract_text(chunk) if chunk.candidates else (chunk.text or ""),
+                content=self._extract_text(chunk)
+                if chunk.candidates
+                else (chunk.text or ""),
                 meta=self._get_usage_meta(chunk.usage_metadata),
             )
 

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -88,6 +88,7 @@ print(outer_t)
 import dataclasses
 import enum
 import json
+import re
 import typing
 from typing import TYPE_CHECKING, Any, Iterator, Literal, TypeVar
 
@@ -105,8 +106,7 @@ if TYPE_CHECKING:
     from kaggle_benchmarks import llm_messages
 
 T = TypeVar("T")
-# TODO: Add "none" once Model Proxy supports reasoning_effort="none".
-ReasoningLevel = Literal["low", "medium", "high"]
+ReasoningLevel = Literal["none", "low", "medium", "high"]
 
 
 # TODO: Figure out a more robust way to handle extra fields.
@@ -149,7 +149,7 @@ class LLMChat(actors.Actor):
         self,
         messages: list[messages.Message],
         system: str | None,
-        reasoning: ReasoningLevel = None,
+        reasoning: ReasoningLevel | None = None,
         **kwargs,
     ) -> LLMResponse | Iterator[LLMResponse] | "llm_messages.LLMMessage[str]":
         """Invokes the LLM with the given messages and system instructions."""
@@ -165,7 +165,7 @@ class LLMChat(actors.Actor):
         image: images.ImageContent | None = None,
         video: videos.VideoContent | None = None,
         audio: audios.AudioContent | None = None,
-        reasoning: ReasoningLevel = None,
+        reasoning: ReasoningLevel | None = None,
     ) -> T:
         if image is not None:
             match image:
@@ -310,6 +310,22 @@ class OpenAI(LLMChat):
             **_extract_extra_usage_metadata(usage),
         }
 
+    @staticmethod
+    def _parse_think_tags(content: str) -> tuple[str, str | None]:
+        """Extracts all <think>...</think> blocks from content.
+
+        Model Proxy wraps reasoning traces in <think> tags inside content
+        because the chat completions spec doesn't have a dedicated field
+        for reasoning traces.
+        """
+        pattern = re.compile(r"<think>\n?(.*?)\n?</think>\n*", re.DOTALL)
+        segments = pattern.findall(content)
+        if not segments:
+            return content, None
+        remaining = pattern.sub("", content).strip()
+        thinking = "\n\n".join(s.strip() for s in segments if s.strip())
+        return remaining, thinking or None
+
     def _should_remove_seed(self) -> bool:
         unsupported_prefixes = ("google/", "openai/gpt-5.4-pro")
         return any(self.model.startswith(prefix) for prefix in unsupported_prefixes)
@@ -318,7 +334,7 @@ class OpenAI(LLMChat):
         self,
         messages: list[messages.Message],
         system: str | None,
-        reasoning: ReasoningLevel = None,
+        reasoning: ReasoningLevel | None = None,
         **kwargs,
     ) -> LLMResponse | Iterator[LLMResponse]:
         if system:
@@ -335,16 +351,18 @@ class OpenAI(LLMChat):
 
         if reasoning is not None:
             kwargs["reasoning_effort"] = reasoning
-            # Model Proxy expects provider-specific params inside a nested
-            # extra_body: the outer extra_body is consumed by the OpenAI SDK,
-            # and the inner extra_body is forwarded to Model Proxy which reads
-            # the google.thinking_config field.
-            kwargs.setdefault("extra_body", {})
-            kwargs["extra_body"].setdefault("extra_body", {})
-            kwargs["extra_body"]["extra_body"].setdefault("google", {})
-            kwargs["extra_body"]["extra_body"]["google"].setdefault(
-                "thinking_config", {"include_thoughts": True}
-            )
+            # The double-nested extra_body is intentional: the outer one is
+            # consumed by the OpenAI SDK (merged into the request body), the
+            # inner one arrives at Model Proxy as a top-level field where it
+            # reads google.thinking_config.  Without include_thoughts, the
+            # frontend drops thinking traces from the response.
+            if reasoning != "none":
+                kwargs.setdefault("extra_body", {})
+                kwargs["extra_body"].setdefault("extra_body", {})
+                kwargs["extra_body"]["extra_body"].setdefault("google", {})
+                kwargs["extra_body"]["extra_body"]["google"].setdefault(
+                    "thinking_config", {"include_thoughts": True}
+                )
 
         return self._call_api(raw_messages, **kwargs)
 
@@ -405,9 +423,17 @@ class OpenAI(LLMChat):
         else:
             message = response.choices[0].message
             tool_calls = message.tool_calls
+            content = message.content or ""
+            # The OpenAI chat completions spec doesn't support a dedicated
+            # reasoning_content field, so Model Proxy embeds thinking traces
+            # in content using <think> tags.  Only parse when reasoning was
+            # requested to avoid stripping literal <think> tags from content.
+            reasoning = getattr(message, "reasoning_content", None)
+            if reasoning is None and "reasoning_effort" in kwargs:
+                content, reasoning = self._parse_think_tags(content)
             return LLMResponse(
-                content=message.content or "",
-                reasoning_traces=getattr(message, "reasoning_content", None),
+                content=content,
+                reasoning_traces=reasoning,
                 tool_calls=[t.model_dump() for t in tool_calls] if tool_calls else None,
                 meta=self._get_usage_meta(response.usage),
             )
@@ -433,6 +459,7 @@ class GoogleGenAI(LLMChat):
         }
 
     _REASONING_LEVEL_MAP = {
+        "none": None,
         "low": "LOW",
         "medium": "MEDIUM",
         "high": "HIGH",
@@ -480,7 +507,7 @@ class GoogleGenAI(LLMChat):
         self,
         messages: list[messages.Message],
         system: str | None,
-        reasoning: ReasoningLevel = None,
+        reasoning: ReasoningLevel | None = None,
         **kwargs,
     ) -> LLMResponse | Iterator[LLMResponse]:
         raw_messages = list(self.serializer.dump_messages(messages))
@@ -491,10 +518,15 @@ class GoogleGenAI(LLMChat):
 
         if reasoning is not None:
             level = self._REASONING_LEVEL_MAP[reasoning]
-            config_params["thinking_config"] = types.ThinkingConfig(
-                thinking_level=level,
-                include_thoughts=True,
-            )
+            if level is None:
+                config_params["thinking_config"] = types.ThinkingConfig(
+                    thinking_budget=0,
+                )
+            else:
+                config_params["thinking_config"] = types.ThinkingConfig(
+                    thinking_level=level,
+                    include_thoughts=True,
+                )
 
         if "response_format" in kwargs:
             schema = kwargs.pop("response_format")

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -105,6 +105,7 @@ if TYPE_CHECKING:
     from kaggle_benchmarks import llm_messages
 
 T = TypeVar("T")
+ReasoningLevel = Literal["low", "medium", "high"]
 
 
 # TODO: Figure out a more robust way to handle extra fields.
@@ -125,7 +126,7 @@ def _validate_reasoning(reasoning: str | None) -> None:
     but OpenAI does not, so we validate here for both backends.
     """
     # TODO: Add "disabled" once Model Proxy supports reasoning_effort="none".
-    valid = {"low", "medium", "high"}
+    valid = set(typing.get_args(ReasoningLevel))
     if reasoning is not None and reasoning not in valid:
         raise ValueError(
             f"Invalid reasoning level: {reasoning!r}. "
@@ -161,7 +162,7 @@ class LLMChat(actors.Actor):
         self,
         messages: list[messages.Message],
         system: str | None,
-        reasoning: Literal["low", "medium", "high"] | None = None,
+        reasoning: ReasoningLevel | None = None,
         include_thoughts: bool = False,
         **kwargs,
     ) -> LLMResponse | Iterator[LLMResponse] | "llm_messages.LLMMessage[str]":
@@ -178,7 +179,7 @@ class LLMChat(actors.Actor):
         image: images.ImageContent | None = None,
         video: videos.VideoContent | None = None,
         audio: audios.AudioContent | None = None,
-        reasoning: Literal["low", "medium", "high"] | None = None,
+        reasoning: ReasoningLevel | None = None,
         include_thoughts: bool = False,
     ) -> T:
         _validate_reasoning(reasoning)
@@ -333,7 +334,7 @@ class OpenAI(LLMChat):
         self,
         messages: list[messages.Message],
         system: str | None,
-        reasoning: Literal["low", "medium", "high"] | None = None,
+        reasoning: ReasoningLevel | None = None,
         include_thoughts: bool = False,
         **kwargs,
     ) -> LLMResponse | Iterator[LLMResponse]:
@@ -353,6 +354,10 @@ class OpenAI(LLMChat):
             kwargs["reasoning_effort"] = reasoning
 
         if include_thoughts:
+            # Model Proxy expects provider-specific params inside a nested
+            # extra_body: the outer extra_body is consumed by the OpenAI SDK,
+            # and the inner extra_body is forwarded to Model Proxy which reads
+            # the google.thinking_config field.
             kwargs.setdefault("extra_body", {})
             kwargs["extra_body"].setdefault("extra_body", {})
             kwargs["extra_body"]["extra_body"].setdefault("google", {})
@@ -465,7 +470,7 @@ class GoogleGenAI(LLMChat):
                 segments.append(f"<think>\n{part.text}\n</think>")
             else:
                 segments.append(part.text)
-        return "\n".join(segments) if segments else ""
+        return "".join(segments) if segments else ""
 
     def _get_stream_response(
         self, response_stream: Iterator[types.GenerateContentResponse]
@@ -481,7 +486,7 @@ class GoogleGenAI(LLMChat):
         self,
         messages: list[messages.Message],
         system: str | None,
-        reasoning: Literal["low", "medium", "high"] | None = None,
+        reasoning: ReasoningLevel | None = None,
         include_thoughts: bool = False,
         **kwargs,
     ) -> LLMResponse | Iterator[LLMResponse]:

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -105,7 +105,7 @@ if TYPE_CHECKING:
     from kaggle_benchmarks import llm_messages
 
 T = TypeVar("T")
-ReasoningLevel = Literal["low", "medium", "high"]
+ReasoningLevel = Literal["low", "medium", "high", None]
 
 
 # TODO: Figure out a more robust way to handle extra fields.
@@ -119,25 +119,11 @@ def _extract_extra_usage_metadata(usage: Any) -> dict[str, Any]:
     }
 
 
-def _validate_reasoning(reasoning: str | None) -> None:
-    """Raises if reasoning is not a valid level.
-
-    Note: GenAI validates these values automatically via ThinkingConfig,
-    but OpenAI does not, so we validate here for both backends.
-    """
-    # TODO: Add "disabled" once Model Proxy supports reasoning_effort="none".
-    valid = set(typing.get_args(ReasoningLevel))
-    if reasoning is not None and reasoning not in valid:
-        raise ValueError(
-            f"Invalid reasoning level: {reasoning!r}. "
-            f"Must be one of: {sorted(valid)}"
-        )
-
 
 @dataclasses.dataclass(frozen=True)
 class LLMResponse:
     content: str
-    thinking: str | None = None
+    reasoning_traces: str | None = None
     tool_calls: list[Any] | None = None
     meta: dict[str, Any] = dataclasses.field(default_factory=dict)
 
@@ -163,8 +149,7 @@ class LLMChat(actors.Actor):
         self,
         messages: list[messages.Message],
         system: str | None,
-        reasoning: ReasoningLevel | None = None,
-        include_thoughts: bool = False,
+        reasoning: ReasoningLevel = None,
         **kwargs,
     ) -> LLMResponse | Iterator[LLMResponse] | "llm_messages.LLMMessage[str]":
         """Invokes the LLM with the given messages and system instructions."""
@@ -180,10 +165,8 @@ class LLMChat(actors.Actor):
         image: images.ImageContent | None = None,
         video: videos.VideoContent | None = None,
         audio: audios.AudioContent | None = None,
-        reasoning: ReasoningLevel | None = None,
-        include_thoughts: bool = False,
+        reasoning: ReasoningLevel = None,
     ) -> T:
-        _validate_reasoning(reasoning)
         if image is not None:
             match image:
                 case images.ImageURL():
@@ -212,7 +195,6 @@ class LLMChat(actors.Actor):
             temperature=temperature if self.support_temperature else None,
             tools=tools if tools is not None else [],
             reasoning=reasoning,
-            include_thoughts=include_thoughts,
         ).content
 
     @chats.emits_message
@@ -267,7 +249,7 @@ class LLMChat(actors.Actor):
             response.content = invoke_response.content or ""
             response._meta["tool_calls"] = invoke_response.tool_calls
             response._meta.update(invoke_response.meta)
-            response._meta["thinking"] = invoke_response.thinking
+            response._meta["reasoning_traces"] = invoke_response.reasoning_traces
         elif isinstance(invoke_response, Iterator):
             response.stream(invoke_response)
         elif isinstance(invoke_response, llm_messages.LLMMessage):
@@ -336,8 +318,7 @@ class OpenAI(LLMChat):
         self,
         messages: list[messages.Message],
         system: str | None,
-        reasoning: ReasoningLevel | None = None,
-        include_thoughts: bool = False,
+        reasoning: ReasoningLevel = None,
         **kwargs,
     ) -> LLMResponse | Iterator[LLMResponse]:
         if system:
@@ -354,8 +335,6 @@ class OpenAI(LLMChat):
 
         if reasoning is not None:
             kwargs["reasoning_effort"] = reasoning
-
-        if include_thoughts:
             # Model Proxy expects provider-specific params inside a nested
             # extra_body: the outer extra_body is consumed by the OpenAI SDK,
             # and the inner extra_body is forwarded to Model Proxy which reads
@@ -428,7 +407,7 @@ class OpenAI(LLMChat):
             tool_calls = message.tool_calls
             return LLMResponse(
                 content=message.content or "",
-                thinking=getattr(message, "reasoning_content", None),
+                reasoning_traces=getattr(message, "reasoning_content", None),
                 tool_calls=[t.model_dump() for t in tool_calls] if tool_calls else None,
                 meta=self._get_usage_meta(response.usage),
             )
@@ -459,34 +438,31 @@ class GoogleGenAI(LLMChat):
         "high": "HIGH",
     }
 
-    @staticmethod
-    def _extract_text(response: types.GenerateContentResponse) -> str:
-        """Extracts non-thought text content from a response."""
+    def _split_response(
+        self,
+        response: types.GenerateContentResponse,
+    ) -> tuple[str, str | None]:
+        """Splits a response into content text and thinking text."""
         if not response.candidates or not response.candidates[0].content:
-            return ""
+            return "", None
         parts = response.candidates[0].content.parts or []
-        segments = []
+        content_segments = []
+        thinking_segments = []
         for part in parts:
             if not part.text:
                 continue
             if getattr(part, "thought", False):
-                continue
-            segments.append(part.text)
-        return "".join(segments) if segments else ""
+                thinking_segments.append(part.text)
+            else:
+                content_segments.append(part.text)
+        content = "".join(content_segments) if content_segments else ""
+        thinking = "".join(thinking_segments) if thinking_segments else None
+        return content, thinking
 
-    @staticmethod
-    def _extract_thinking(response: types.GenerateContentResponse) -> str | None:
-        """Extracts thinking text from thought parts of a response."""
-        if not response.candidates or not response.candidates[0].content:
-            return None
-        parts = response.candidates[0].content.parts or []
-        segments = []
-        for part in parts:
-            if not part.text:
-                continue
-            if getattr(part, "thought", False):
-                segments.append(part.text)
-        return "".join(segments) if segments else None
+    def _extract_text(self, response: types.GenerateContentResponse) -> str:
+        """Extracts non-thought text content from a response."""
+        content, _ = self._split_response(response)
+        return content
 
     def _get_stream_response(
         self, response_stream: Iterator[types.GenerateContentResponse]
@@ -502,8 +478,7 @@ class GoogleGenAI(LLMChat):
         self,
         messages: list[messages.Message],
         system: str | None,
-        reasoning: ReasoningLevel | None = None,
-        include_thoughts: bool = False,
+        reasoning: ReasoningLevel = None,
         **kwargs,
     ) -> LLMResponse | Iterator[LLMResponse]:
         raw_messages = list(self.serializer.dump_messages(messages))
@@ -513,14 +488,9 @@ class GoogleGenAI(LLMChat):
             config_params["system_instruction"] = system
 
         if reasoning is not None:
-            # reasoning is already validated by _validate_reasoning in prompt().
             level = self._REASONING_LEVEL_MAP[reasoning]
             config_params["thinking_config"] = types.ThinkingConfig(
                 thinking_level=level,
-                include_thoughts=include_thoughts or None,
-            )
-        elif include_thoughts:
-            config_params["thinking_config"] = types.ThinkingConfig(
                 include_thoughts=True,
             )
 
@@ -561,8 +531,9 @@ class GoogleGenAI(LLMChat):
                     meta=self._get_usage_meta(response.usage_metadata),
                 )
 
+            content, thinking = self._split_response(response)
             return LLMResponse(
-                content=self._extract_text(response),
-                thinking=self._extract_thinking(response),
+                content=content,
+                reasoning_traces=thinking,
                 meta=self._get_usage_meta(response.usage_metadata),
             )

--- a/src/kaggle_benchmarks/chats.py
+++ b/src/kaggle_benchmarks/chats.py
@@ -105,6 +105,12 @@ def get_current_chat():
     return contexts.get_current().chat
 
 
+def last_reasoning_traces() -> str | None:
+    """Returns the reasoning traces from the last message in the current chat."""
+    messages = get_current_chat().messages
+    return messages[-1].reasoning_traces if messages else None
+
+
 def send(message: Message | Chat) -> Message | Chat:
     """A shortcut to send a message to the current chat."""
     return get_current_chat().append(message)

--- a/src/kaggle_benchmarks/llm_messages.py
+++ b/src/kaggle_benchmarks/llm_messages.py
@@ -27,7 +27,7 @@ class LLMMessage(messages.Message[T]):
 
     content: T
     _status: utils.Status = utils.Status.RUNNING
-    thinking: str | None = None
+    reasoning: str | None = None
     tool_calls: (
         list[tool_utils.ToolInvocation | tool_utils.ToolInvocationResult] | None
     ) = None

--- a/src/kaggle_benchmarks/llm_messages.py
+++ b/src/kaggle_benchmarks/llm_messages.py
@@ -27,7 +27,7 @@ class LLMMessage(messages.Message[T]):
 
     content: T
     _status: utils.Status = utils.Status.RUNNING
-    reasoning: str | None = None
+    reasoning_traces: str | None = None
     tool_calls: (
         list[tool_utils.ToolInvocation | tool_utils.ToolInvocationResult] | None
     ) = None

--- a/src/kaggle_benchmarks/messages.py
+++ b/src/kaggle_benchmarks/messages.py
@@ -53,8 +53,8 @@ class Message(Generic[T]):
         return str(self.content)
 
     @property
-    def thinking(self):
-        return self._meta.get("thinking")
+    def reasoning_traces(self):
+        return self._meta.get("reasoning_traces")
 
     @property
     def tool_calls(self):

--- a/src/kaggle_benchmarks/messages.py
+++ b/src/kaggle_benchmarks/messages.py
@@ -53,6 +53,10 @@ class Message(Generic[T]):
         return str(self.content)
 
     @property
+    def thinking(self):
+        return self._meta.get("thinking")
+
+    @property
     def tool_calls(self):
         return self._meta.get("tool_calls")
 

--- a/src/kaggle_benchmarks/messages.py
+++ b/src/kaggle_benchmarks/messages.py
@@ -54,6 +54,8 @@ class Message(Generic[T]):
 
     @property
     def reasoning_traces(self):
+        # TODO: Remove this _meta workaround once respond() creates LLMMessage
+        # instead of Message. LLMMessage.reasoning_traces will be the canonical field.
         return self._meta.get("reasoning_traces")
 
     @property

--- a/src/kaggle_benchmarks/ui/panel.py
+++ b/src/kaggle_benchmarks/ui/panel.py
@@ -129,7 +129,7 @@ def render_llm_message(message, **kwargs) -> pn.chat.ChatMessage:
         footer_objects=[
             pn.Column(*(render_tool_call(call) for call in message.tool_calls or [])),
             render_usage(message.usage),
-            render_thinking(message.thinking or ""),
+            render_thinking(message.reasoning_traces or ""),
         ]
         + history,
         **kwargs,

--- a/tests/test_genai_client.py
+++ b/tests/test_genai_client.py
@@ -89,6 +89,83 @@ def test_invoke_with_config_params():
     assert llm.config.temperature == 0.9
 
 
+def test_prompt_reasoning_maps_to_thinking_config():
+    """Tests that reasoning='low' maps to thinking_level='LOW'."""
+    llm = MockedGoogleGenAI()
+    llm.prompt("Think hard", reasoning="low")
+
+    assert llm.config.thinking_config.thinking_level == "LOW"
+
+
+def test_prompt_reasoning_high():
+    """Tests that reasoning='high' maps to thinking_level='HIGH'."""
+    llm = MockedGoogleGenAI()
+    llm.prompt("Think hard", reasoning="high")
+
+    assert llm.config.thinking_config.thinking_level == "HIGH"
+
+
+def test_prompt_include_thoughts():
+    """Tests that include_thoughts is passed into thinking_config."""
+    llm = MockedGoogleGenAI()
+    llm.prompt("Think hard", include_thoughts=True)
+
+    assert llm.config.thinking_config.include_thoughts is True
+
+
+def test_prompt_reasoning_with_include_thoughts():
+    """Tests that reasoning and include_thoughts are merged into one thinking_config."""
+    llm = MockedGoogleGenAI()
+    llm.prompt("Think hard", reasoning="high", include_thoughts=True)
+
+    assert llm.config.thinking_config.thinking_level == "HIGH"
+    assert llm.config.thinking_config.include_thoughts is True
+
+
+def test_extract_text_wraps_thought_parts():
+    """Tests that _extract_text wraps thought parts in <think> tags."""
+    response = types.GenerateContentResponse(
+        candidates=[
+            types.Candidate(
+                content=types.Content(
+                    parts=[
+                        types.Part(text="I need to count...", thought=True),
+                        types.Part(text="There are 3 r's."),
+                    ]
+                )
+            )
+        ]
+    )
+    text = GoogleGenAI._extract_text(response)
+    assert "<think>" in text
+    assert "I need to count..." in text
+    assert "</think>" in text
+    assert "There are 3 r's." in text
+
+
+def test_extract_text_no_thought_parts():
+    """Tests that _extract_text returns plain text when no thought parts."""
+    response = types.GenerateContentResponse(
+        candidates=[
+            types.Candidate(
+                content=types.Content(
+                    parts=[types.Part(text="Hello world")]
+                )
+            )
+        ]
+    )
+    text = GoogleGenAI._extract_text(response)
+    assert text == "Hello world"
+    assert "<think>" not in text
+
+
+def test_prompt_rejects_invalid_reasoning():
+    """Tests that an invalid reasoning level raises ValueError."""
+    llm = MockedGoogleGenAI()
+    with pytest.raises(ValueError, match="Invalid reasoning level"):
+        llm.prompt("Think hard", reasoning="hgih")
+
+
 @pytest.mark.parametrize("streaming", [True, False])
 def test_streaming_and_non_streaming_responses(streaming):
     """Tests both streaming and non-streaming modes and checks metadata."""

--- a/tests/test_genai_client.py
+++ b/tests/test_genai_client.py
@@ -185,7 +185,7 @@ def test_streaming_thought_output_matches_non_streaming():
 
 
 def test_thinking_captured_in_response(mocker):
-    """Tests that thought parts from GenAI response reach the message as thinking."""
+    """Tests that thought parts from GenAI response are captured as reasoning traces."""
     mock_client = mocker.MagicMock()
     mock_response = types.GenerateContentResponse(
         candidates=[

--- a/tests/test_genai_client.py
+++ b/tests/test_genai_client.py
@@ -133,9 +133,7 @@ def test_split_response_returns_none_thinking_without_thoughts():
     response = types.GenerateContentResponse(
         candidates=[
             types.Candidate(
-                content=types.Content(
-                    parts=[types.Part(text="Hello world")]
-                )
+                content=types.Content(parts=[types.Part(text="Hello world")])
             )
         ]
     )
@@ -170,18 +168,14 @@ def test_streaming_thought_output_matches_non_streaming():
 
     # Non-streaming: all parts in one response
     full_response = types.GenerateContentResponse(
-        candidates=[
-            types.Candidate(content=types.Content(parts=parts))
-        ]
+        candidates=[types.Candidate(content=types.Content(parts=parts))]
     )
     non_streaming_text = llm._extract_text(full_response)
 
     # Streaming: one part per chunk
     chunks = [
         types.GenerateContentResponse(
-            candidates=[
-                types.Candidate(content=types.Content(parts=[p]))
-            ]
+            candidates=[types.Candidate(content=types.Content(parts=[p]))]
         )
         for p in parts
     ]

--- a/tests/test_genai_client.py
+++ b/tests/test_genai_client.py
@@ -159,6 +159,50 @@ def test_extract_text_no_thought_parts():
     assert "<think>" not in text
 
 
+def test_extract_text_multi_part_matches_response_text():
+    """_extract_text should match response.text for non-thought multi-part responses."""
+    response = types.GenerateContentResponse(
+        candidates=[
+            types.Candidate(
+                content=types.Content(
+                    parts=[types.Part(text="Hello"), types.Part(text=" world")]
+                )
+            )
+        ]
+    )
+    assert GoogleGenAI._extract_text(response) == response.text
+
+
+def test_streaming_thought_output_matches_non_streaming():
+    """Streaming and non-streaming should produce the same text for identical content."""
+    parts = [
+        types.Part(text="step 1", thought=True),
+        types.Part(text="step 2", thought=True),
+        types.Part(text="Final answer"),
+    ]
+
+    # Non-streaming: all parts in one response
+    full_response = types.GenerateContentResponse(
+        candidates=[
+            types.Candidate(content=types.Content(parts=parts))
+        ]
+    )
+    non_streaming_text = GoogleGenAI._extract_text(full_response)
+
+    # Streaming: one part per chunk
+    chunks = [
+        types.GenerateContentResponse(
+            candidates=[
+                types.Candidate(content=types.Content(parts=[p]))
+            ]
+        )
+        for p in parts
+    ]
+    streaming_text = "".join(GoogleGenAI._extract_text(c) for c in chunks)
+
+    assert streaming_text == non_streaming_text
+
+
 def test_prompt_rejects_invalid_reasoning():
     """Tests that an invalid reasoning level raises ValueError."""
     llm = MockedGoogleGenAI()

--- a/tests/test_genai_client.py
+++ b/tests/test_genai_client.py
@@ -252,6 +252,39 @@ def test_streaming_thought_output_matches_non_streaming():
     assert streaming_text == non_streaming_text
 
 
+def test_thinking_captured_in_response():
+    """Tests that thought parts from GenAI response reach the message as thinking."""
+    from unittest.mock import MagicMock
+
+    mock_client = MagicMock()
+    mock_response = types.GenerateContentResponse(
+        candidates=[
+            types.Candidate(
+                content=types.Content(
+                    parts=[
+                        types.Part(text="Let me count the letters...", thought=True),
+                        types.Part(text="There are 3 r's."),
+                    ]
+                )
+            )
+        ],
+        usage_metadata=types.UsageMetadata(
+            prompt_token_count=10, response_token_count=5
+        ),
+    )
+    mock_client.models.generate_content.return_value = mock_response
+
+    llm = GoogleGenAI(client=mock_client, model="test-gemini")
+    llm.stream_responses = False
+
+    with chats.new("Test GenAI thinking") as t:
+        response = llm.prompt("How many r's in strawberry?")
+
+    assert response == "There are 3 r's."
+    last_message = t.messages[-1]
+    assert last_message.thinking == "Let me count the letters..."
+
+
 def test_prompt_rejects_invalid_reasoning():
     """Tests that an invalid reasoning level raises ValueError."""
     llm = MockedGoogleGenAI()

--- a/tests/test_genai_client.py
+++ b/tests/test_genai_client.py
@@ -221,7 +221,6 @@ def test_thinking_captured_in_response(mocker):
     assert last_message.reasoning_traces == "Let me count the letters..."
 
 
-
 @pytest.mark.parametrize("streaming", [True, False])
 def test_streaming_and_non_streaming_responses(streaming):
     """Tests both streaming and non-streaming modes and checks metadata."""

--- a/tests/test_genai_client.py
+++ b/tests/test_genai_client.py
@@ -89,41 +89,27 @@ def test_invoke_with_config_params():
     assert llm.config.temperature == 0.9
 
 
-def test_prompt_reasoning_maps_to_thinking_config():
-    """Tests that reasoning='low' maps to thinking_level='LOW'."""
+@pytest.mark.parametrize(
+    "reasoning, expected_level",
+    [
+        ("low", "LOW"),
+        ("medium", "MEDIUM"),
+        ("high", "HIGH"),
+    ],
+)
+def test_prompt_thinking_config(reasoning, expected_level):
+    """Tests that reasoning maps to the correct ThinkingConfig with thoughts enabled."""
     llm = MockedGoogleGenAI()
-    llm.prompt("Think hard", reasoning="low")
+    llm.prompt("Think hard", reasoning=reasoning)
 
-    assert llm.config.thinking_config.thinking_level == "LOW"
+    tc = llm.config.thinking_config
+    assert tc.thinking_level == expected_level
+    assert tc.include_thoughts is True
 
 
-def test_prompt_reasoning_high():
-    """Tests that reasoning='high' maps to thinking_level='HIGH'."""
+def test_split_response_separates_content_and_thinking():
+    """Tests that _split_response separates content from thought parts."""
     llm = MockedGoogleGenAI()
-    llm.prompt("Think hard", reasoning="high")
-
-    assert llm.config.thinking_config.thinking_level == "HIGH"
-
-
-def test_prompt_include_thoughts():
-    """Tests that include_thoughts is passed into thinking_config."""
-    llm = MockedGoogleGenAI()
-    llm.prompt("Think hard", include_thoughts=True)
-
-    assert llm.config.thinking_config.include_thoughts is True
-
-
-def test_prompt_reasoning_with_include_thoughts():
-    """Tests that reasoning and include_thoughts are merged into one thinking_config."""
-    llm = MockedGoogleGenAI()
-    llm.prompt("Think hard", reasoning="high", include_thoughts=True)
-
-    assert llm.config.thinking_config.thinking_level == "HIGH"
-    assert llm.config.thinking_config.include_thoughts is True
-
-
-def test_extract_text_excludes_thought_parts():
-    """Tests that _extract_text excludes thought parts from content."""
     response = types.GenerateContentResponse(
         candidates=[
             types.Candidate(
@@ -136,32 +122,14 @@ def test_extract_text_excludes_thought_parts():
             )
         ]
     )
-    text = GoogleGenAI._extract_text(response)
-    assert text == "There are 3 r's."
-    assert "I need to count..." not in text
-    assert "<think>" not in text
-
-
-def test_extract_thinking_returns_thought_text():
-    """Tests that _extract_thinking extracts thought parts separately."""
-    response = types.GenerateContentResponse(
-        candidates=[
-            types.Candidate(
-                content=types.Content(
-                    parts=[
-                        types.Part(text="I need to count...", thought=True),
-                        types.Part(text="There are 3 r's."),
-                    ]
-                )
-            )
-        ]
-    )
-    thinking = GoogleGenAI._extract_thinking(response)
+    content, thinking = llm._split_response(response)
+    assert content == "There are 3 r's."
     assert thinking == "I need to count..."
 
 
-def test_extract_thinking_returns_none_without_thoughts():
-    """Tests that _extract_thinking returns None when no thought parts exist."""
+def test_split_response_returns_none_thinking_without_thoughts():
+    """Tests that _split_response returns None thinking when no thought parts exist."""
+    llm = MockedGoogleGenAI()
     response = types.GenerateContentResponse(
         candidates=[
             types.Candidate(
@@ -171,45 +139,14 @@ def test_extract_thinking_returns_none_without_thoughts():
             )
         ]
     )
-    assert GoogleGenAI._extract_thinking(response) is None
-
-
-def test_extract_text_excludes_thoughts_from_structured_content():
-    """Thought parts should not corrupt structured output."""
-    response = types.GenerateContentResponse(
-        candidates=[
-            types.Candidate(
-                content=types.Content(
-                    parts=[
-                        types.Part(text="Let me think...", thought=True),
-                        types.Part(text='{"answer": 42}'),
-                    ]
-                )
-            )
-        ]
-    )
-    text = GoogleGenAI._extract_text(response)
-    assert text == '{"answer": 42}'
-
-
-def test_extract_text_no_thought_parts():
-    """Tests that _extract_text returns plain text when no thought parts."""
-    response = types.GenerateContentResponse(
-        candidates=[
-            types.Candidate(
-                content=types.Content(
-                    parts=[types.Part(text="Hello world")]
-                )
-            )
-        ]
-    )
-    text = GoogleGenAI._extract_text(response)
-    assert text == "Hello world"
-    assert "<think>" not in text
+    content, thinking = llm._split_response(response)
+    assert content == "Hello world"
+    assert thinking is None
 
 
 def test_extract_text_multi_part_matches_response_text():
     """_extract_text should match response.text for non-thought multi-part responses."""
+    llm = MockedGoogleGenAI()
     response = types.GenerateContentResponse(
         candidates=[
             types.Candidate(
@@ -219,11 +156,12 @@ def test_extract_text_multi_part_matches_response_text():
             )
         ]
     )
-    assert GoogleGenAI._extract_text(response) == response.text
+    assert llm._extract_text(response) == response.text
 
 
 def test_streaming_thought_output_matches_non_streaming():
-    """Streaming and non-streaming should produce the same text for identical content."""
+    """Streaming and non-streaming should produce the same content for identical input."""
+    llm = MockedGoogleGenAI()
     parts = [
         types.Part(text="step 1", thought=True),
         types.Part(text="step 2", thought=True),
@@ -236,7 +174,7 @@ def test_streaming_thought_output_matches_non_streaming():
             types.Candidate(content=types.Content(parts=parts))
         ]
     )
-    non_streaming_text = GoogleGenAI._extract_text(full_response)
+    non_streaming_text = llm._extract_text(full_response)
 
     # Streaming: one part per chunk
     chunks = [
@@ -247,16 +185,14 @@ def test_streaming_thought_output_matches_non_streaming():
         )
         for p in parts
     ]
-    streaming_text = "".join(GoogleGenAI._extract_text(c) for c in chunks)
+    streaming_text = "".join(llm._extract_text(c) for c in chunks)
 
     assert streaming_text == non_streaming_text
 
 
-def test_thinking_captured_in_response():
+def test_thinking_captured_in_response(mocker):
     """Tests that thought parts from GenAI response reach the message as thinking."""
-    from unittest.mock import MagicMock
-
-    mock_client = MagicMock()
+    mock_client = mocker.MagicMock()
     mock_response = types.GenerateContentResponse(
         candidates=[
             types.Candidate(
@@ -282,14 +218,8 @@ def test_thinking_captured_in_response():
 
     assert response == "There are 3 r's."
     last_message = t.messages[-1]
-    assert last_message.thinking == "Let me count the letters..."
+    assert last_message.reasoning_traces == "Let me count the letters..."
 
-
-def test_prompt_rejects_invalid_reasoning():
-    """Tests that an invalid reasoning level raises ValueError."""
-    llm = MockedGoogleGenAI()
-    with pytest.raises(ValueError, match="Invalid reasoning level"):
-        llm.prompt("Think hard", reasoning="hgih")
 
 
 @pytest.mark.parametrize("streaming", [True, False])

--- a/tests/test_genai_client.py
+++ b/tests/test_genai_client.py
@@ -122,8 +122,8 @@ def test_prompt_reasoning_with_include_thoughts():
     assert llm.config.thinking_config.include_thoughts is True
 
 
-def test_extract_text_wraps_thought_parts():
-    """Tests that _extract_text wraps thought parts in <think> tags."""
+def test_extract_text_excludes_thought_parts():
+    """Tests that _extract_text excludes thought parts from content."""
     response = types.GenerateContentResponse(
         candidates=[
             types.Candidate(
@@ -137,10 +137,59 @@ def test_extract_text_wraps_thought_parts():
         ]
     )
     text = GoogleGenAI._extract_text(response)
-    assert "<think>" in text
-    assert "I need to count..." in text
-    assert "</think>" in text
-    assert "There are 3 r's." in text
+    assert text == "There are 3 r's."
+    assert "I need to count..." not in text
+    assert "<think>" not in text
+
+
+def test_extract_thinking_returns_thought_text():
+    """Tests that _extract_thinking extracts thought parts separately."""
+    response = types.GenerateContentResponse(
+        candidates=[
+            types.Candidate(
+                content=types.Content(
+                    parts=[
+                        types.Part(text="I need to count...", thought=True),
+                        types.Part(text="There are 3 r's."),
+                    ]
+                )
+            )
+        ]
+    )
+    thinking = GoogleGenAI._extract_thinking(response)
+    assert thinking == "I need to count..."
+
+
+def test_extract_thinking_returns_none_without_thoughts():
+    """Tests that _extract_thinking returns None when no thought parts exist."""
+    response = types.GenerateContentResponse(
+        candidates=[
+            types.Candidate(
+                content=types.Content(
+                    parts=[types.Part(text="Hello world")]
+                )
+            )
+        ]
+    )
+    assert GoogleGenAI._extract_thinking(response) is None
+
+
+def test_extract_text_excludes_thoughts_from_structured_content():
+    """Thought parts should not corrupt structured output."""
+    response = types.GenerateContentResponse(
+        candidates=[
+            types.Candidate(
+                content=types.Content(
+                    parts=[
+                        types.Part(text="Let me think...", thought=True),
+                        types.Part(text='{"answer": 42}'),
+                    ]
+                )
+            )
+        ]
+    )
+    text = GoogleGenAI._extract_text(response)
+    assert text == '{"answer": 42}'
 
 
 def test_extract_text_no_thought_parts():

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -295,7 +295,6 @@ def test_last_reasoning_traces_returns_none_without_reasoning():
         assert chats.last_reasoning_traces() is None
 
 
-
 def test_invoke_prompt():
     llm = MockedOpenAI(model="test-model")
     llm.support_structured_outputs = False

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -19,7 +19,7 @@ import pytest
 from pydantic import BaseModel
 
 from kaggle_benchmarks import actors, chats
-from kaggle_benchmarks.actors.llms import LLMResponse, OpenAI
+from kaggle_benchmarks.actors.llms import LLMResponse, OpenAI, _parse_think_tags
 from kaggle_benchmarks.prompting import handler
 
 
@@ -309,7 +309,7 @@ def test_last_reasoning_traces_returns_none_without_reasoning():
 def test_parse_think_tags_extracts_traces():
     """Tests that <think> tags in content are parsed into reasoning_traces."""
     content = "<think>\nLet me think step by step.\n</think>\n\nThe answer is 42."
-    remaining, thinking = OpenAI._parse_think_tags(content)
+    remaining, thinking = _parse_think_tags(content)
     assert remaining == "The answer is 42."
     assert thinking == "Let me think step by step."
 
@@ -317,7 +317,7 @@ def test_parse_think_tags_extracts_traces():
 def test_parse_think_tags_returns_none_without_tags():
     """Tests that content without <think> tags returns None for thinking."""
     content = "The answer is 42."
-    remaining, thinking = OpenAI._parse_think_tags(content)
+    remaining, thinking = _parse_think_tags(content)
     assert remaining == "The answer is 42."
     assert thinking is None
 
@@ -330,9 +330,17 @@ def test_parse_think_tags_extracts_multiple_blocks():
         "<think>\nSecond thought.\n</think>\n\n"
         "The answer is 42."
     )
-    remaining, thinking = OpenAI._parse_think_tags(content)
+    remaining, thinking = _parse_think_tags(content)
     assert remaining == "Middle content.\n\nThe answer is 42."
     assert thinking == "First thought.\n\nSecond thought."
+
+
+def test_parse_think_tags_empty_block():
+    """Tests that malformed empty <think></think> returns None for thinking."""
+    content = "<think></think>\n\nThe answer is 42."
+    remaining, thinking = _parse_think_tags(content)
+    assert remaining == "The answer is 42."
+    assert thinking is None
 
 
 def test_think_tags_captured_in_response(mocker):

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -208,10 +208,14 @@ def test_prompt_reasoning_sets_effort_and_thoughts():
 
 
 def test_reasoning_content_captured_in_response(mocker):
-    """Tests that reasoning_content from OpenAI response is not silently dropped."""
+    """Tests that reasoning_content is captured as reasoning_traces.
+
+    When reasoning_content is set, <think> tags in content should remain
+    untouched since reasoning_content takes priority.
+    """
     mock_client = mocker.MagicMock()
     mock_message = mocker.MagicMock()
-    mock_message.content = "There are 3 r's."
+    mock_message.content = "<think>\nstale\n</think>\n\nThere are 3 r's."
     mock_message.reasoning_content = (
         "Let me count: s-t-r-a-w-b-e-r-r-y. r appears at positions 3, 8, 9."
     )
@@ -236,7 +240,8 @@ def test_reasoning_content_captured_in_response(mocker):
     with chats.new("Test reasoning") as t:
         response = llm.prompt("How many r's in strawberry?")
 
-    assert response == "There are 3 r's."
+    # Content should preserve <think> tags since reasoning_content takes priority.
+    assert response == "<think>\nstale\n</think>\n\nThere are 3 r's."
     last_message = t.messages[-1]
     assert last_message.reasoning_traces == (
         "Let me count: s-t-r-a-w-b-e-r-r-y. r appears at positions 3, 8, 9."
@@ -295,6 +300,69 @@ def test_last_reasoning_traces_returns_none_without_reasoning():
     with chats.new("Test no reasoning"):
         llm.prompt("Hi")
         assert chats.last_reasoning_traces() is None
+
+
+def test_parse_think_tags_extracts_traces():
+    """Tests that <think> tags in content are parsed into reasoning_traces."""
+    content = "<think>\nLet me think step by step.\n</think>\n\nThe answer is 42."
+    remaining, thinking = OpenAI._parse_think_tags(content)
+    assert remaining == "The answer is 42."
+    assert thinking == "Let me think step by step."
+
+
+def test_parse_think_tags_returns_none_without_tags():
+    """Tests that content without <think> tags returns None for thinking."""
+    content = "The answer is 42."
+    remaining, thinking = OpenAI._parse_think_tags(content)
+    assert remaining == "The answer is 42."
+    assert thinking is None
+
+
+def test_parse_think_tags_extracts_multiple_blocks():
+    """Tests that multiple <think> blocks are all extracted and joined."""
+    content = (
+        "<think>\nFirst thought.\n</think>\n\n"
+        "Middle content.\n\n"
+        "<think>\nSecond thought.\n</think>\n\n"
+        "The answer is 42."
+    )
+    remaining, thinking = OpenAI._parse_think_tags(content)
+    assert remaining == "Middle content.\n\nThe answer is 42."
+    assert thinking == "First thought.\n\nSecond thought."
+
+
+def test_think_tags_captured_in_response(mocker):
+    """Tests that Model Proxy <think> tags are parsed into reasoning_traces."""
+    mock_client = mocker.MagicMock()
+    mock_message = mocker.MagicMock()
+    mock_message.content = (
+        "<think>\nCounting the letters...\n</think>\n\nThere are 3 r's."
+    )
+    mock_message.reasoning_content = None
+    mock_message.tool_calls = None
+
+    mock_usage = mocker.MagicMock()
+    mock_usage.prompt_tokens = 10
+    mock_usage.completion_tokens = 5
+
+    mock_choice = mocker.MagicMock()
+    mock_choice.message = mock_message
+
+    mock_response = mocker.MagicMock()
+    mock_response.choices = [mock_choice]
+    mock_response.usage = mock_usage
+
+    mock_client.chat.completions.create.return_value = mock_response
+
+    llm = OpenAI(client=mock_client, model="google/gemini-2.5-flash")
+    llm.stream_responses = False
+
+    with chats.new("Test think tags") as t:
+        response = llm.prompt("How many r's in strawberry?", reasoning="high")
+
+    assert response == "There are 3 r's."
+    last_message = t.messages[-1]
+    assert last_message.reasoning_traces == "Counting the letters..."
 
 
 def test_invoke_prompt():

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -197,6 +197,40 @@ def test_invoke():
     assert llm.kwargs.get("response_format") is None
 
 
+def test_prompt_reasoning_maps_to_reasoning_effort():
+    """Tests that reasoning='high' maps to reasoning_effort='high'."""
+    llm = MockedOpenAI(model="test-model")
+    llm.prompt("Think hard", reasoning="high")
+
+    assert llm.kwargs["reasoning_effort"] == "high"
+
+
+def test_prompt_include_thoughts():
+    """Tests that include_thoughts constructs the correct extra_body."""
+    llm = MockedOpenAI(model="test-model")
+    llm.prompt("Think hard", include_thoughts=True)
+
+    extra = llm.kwargs["extra_body"]["extra_body"]["google"]["thinking_config"]
+    assert extra["include_thoughts"] is True
+
+
+def test_prompt_include_thoughts_with_reasoning():
+    """Tests that include_thoughts and reasoning work together."""
+    llm = MockedOpenAI(model="test-model")
+    llm.prompt("Think hard", reasoning="high", include_thoughts=True)
+
+    assert llm.kwargs["reasoning_effort"] == "high"
+    extra = llm.kwargs["extra_body"]["extra_body"]["google"]["thinking_config"]
+    assert extra["include_thoughts"] is True
+
+
+def test_prompt_rejects_invalid_reasoning():
+    """Tests that an invalid reasoning level raises ValueError."""
+    llm = MockedOpenAI(model="test-model")
+    with pytest.raises(ValueError, match="Invalid reasoning level"):
+        llm.prompt("Hi", reasoning="hgih")
+
+
 def test_invoke_prompt():
     llm = MockedOpenAI(model="test-model")
     llm.support_structured_outputs = False

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -283,7 +283,9 @@ def test_last_reasoning_traces_accessor():
 
     with chats.new("Test last_reasoning_traces"):
         llm.prompt("What is the answer?")
-        assert chats.last_reasoning_traces() == "I need to think about this carefully..."
+        assert (
+            chats.last_reasoning_traces() == "I need to think about this carefully..."
+        )
 
 
 def test_last_reasoning_traces_returns_none_without_reasoning():

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -197,53 +197,34 @@ def test_invoke():
     assert llm.kwargs.get("response_format") is None
 
 
-def test_prompt_reasoning_maps_to_reasoning_effort():
-    """Tests that reasoning='high' maps to reasoning_effort='high'."""
+def test_prompt_reasoning_sets_effort_and_thoughts():
+    """Tests that reasoning='high' sets reasoning_effort and enables thinking."""
     llm = MockedOpenAI(model="test-model")
     llm.prompt("Think hard", reasoning="high")
 
     assert llm.kwargs["reasoning_effort"] == "high"
-
-
-def test_prompt_include_thoughts():
-    """Tests that include_thoughts constructs the correct extra_body."""
-    llm = MockedOpenAI(model="test-model")
-    llm.prompt("Think hard", include_thoughts=True)
-
     extra = llm.kwargs["extra_body"]["extra_body"]["google"]["thinking_config"]
     assert extra["include_thoughts"] is True
 
 
-def test_prompt_include_thoughts_with_reasoning():
-    """Tests that include_thoughts and reasoning work together."""
-    llm = MockedOpenAI(model="test-model")
-    llm.prompt("Think hard", reasoning="high", include_thoughts=True)
-
-    assert llm.kwargs["reasoning_effort"] == "high"
-    extra = llm.kwargs["extra_body"]["extra_body"]["google"]["thinking_config"]
-    assert extra["include_thoughts"] is True
-
-
-def test_reasoning_content_captured_in_response():
+def test_reasoning_content_captured_in_response(mocker):
     """Tests that reasoning_content from OpenAI response is not silently dropped."""
-    from unittest.mock import MagicMock
-
-    mock_client = MagicMock()
-    mock_message = MagicMock()
+    mock_client = mocker.MagicMock()
+    mock_message = mocker.MagicMock()
     mock_message.content = "There are 3 r's."
     mock_message.reasoning_content = (
         "Let me count: s-t-r-a-w-b-e-r-r-y. r appears at positions 3, 8, 9."
     )
     mock_message.tool_calls = None
 
-    mock_usage = MagicMock()
+    mock_usage = mocker.MagicMock()
     mock_usage.prompt_tokens = 10
     mock_usage.completion_tokens = 5
 
-    mock_choice = MagicMock()
+    mock_choice = mocker.MagicMock()
     mock_choice.message = mock_message
 
-    mock_response = MagicMock()
+    mock_response = mocker.MagicMock()
     mock_response.choices = [mock_choice]
     mock_response.usage = mock_usage
 
@@ -257,39 +238,62 @@ def test_reasoning_content_captured_in_response():
 
     assert response == "There are 3 r's."
     last_message = t.messages[-1]
-    assert last_message.thinking == (
+    assert last_message.reasoning_traces == (
         "Let me count: s-t-r-a-w-b-e-r-r-y. r appears at positions 3, 8, 9."
     )
 
 
-def test_thinking_plumbed_through_respond():
-    """Tests that LLMResponse.thinking is plumbed through respond() to the message."""
+def test_reasoning_plumbed_through_respond():
+    """Tests that LLMResponse.reasoning_traces is plumbed through respond() to the message."""
 
-    class MockedOpenAIWithThinking(OpenAI):
+    class MockedOpenAIWithReasoning(OpenAI):
         def __init__(self):
-            super().__init__(client=None, model="mock-thinking")
+            super().__init__(client=None, model="mock-reasoning")
 
         def _call_api(self, messages, **kwargs):
             return LLMResponse(
                 content="The answer is 42.",
-                thinking="I need to think about this carefully...",
+                reasoning_traces="I need to think about this carefully...",
             )
 
-    llm = MockedOpenAIWithThinking()
+    llm = MockedOpenAIWithReasoning()
 
-    with chats.new("Test thinking plumbing") as t:
+    with chats.new("Test reasoning plumbing") as t:
         response = llm.prompt("What is the answer?")
 
     assert response == "The answer is 42."
     last_message = t.messages[-1]
-    assert last_message.thinking == "I need to think about this carefully..."
+    assert last_message.reasoning_traces == "I need to think about this carefully..."
 
 
-def test_prompt_rejects_invalid_reasoning():
-    """Tests that an invalid reasoning level raises ValueError."""
+def test_last_reasoning_traces_accessor():
+    """Tests that kbench.last_reasoning_traces() returns reasoning from the last message."""
+
+    class MockedOpenAIWithReasoning(OpenAI):
+        def __init__(self):
+            super().__init__(client=None, model="mock-reasoning")
+
+        def _call_api(self, messages, **kwargs):
+            return LLMResponse(
+                content="The answer is 42.",
+                reasoning_traces="I need to think about this carefully...",
+            )
+
+    llm = MockedOpenAIWithReasoning()
+
+    with chats.new("Test last_reasoning_traces"):
+        llm.prompt("What is the answer?")
+        assert chats.last_reasoning_traces() == "I need to think about this carefully..."
+
+
+def test_last_reasoning_traces_returns_none_without_reasoning():
+    """Tests that kbench.last_reasoning_traces() returns None when no reasoning traces exist."""
     llm = MockedOpenAI(model="test-model")
-    with pytest.raises(ValueError, match="Invalid reasoning level"):
-        llm.prompt("Hi", reasoning="hgih")
+
+    with chats.new("Test no reasoning"):
+        llm.prompt("Hi")
+        assert chats.last_reasoning_traces() is None
+
 
 
 def test_invoke_prompt():

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -224,6 +224,67 @@ def test_prompt_include_thoughts_with_reasoning():
     assert extra["include_thoughts"] is True
 
 
+def test_reasoning_content_captured_in_response():
+    """Tests that reasoning_content from OpenAI response is not silently dropped."""
+    from unittest.mock import MagicMock
+
+    mock_client = MagicMock()
+    mock_message = MagicMock()
+    mock_message.content = "There are 3 r's."
+    mock_message.reasoning_content = (
+        "Let me count: s-t-r-a-w-b-e-r-r-y. r appears at positions 3, 8, 9."
+    )
+    mock_message.tool_calls = None
+
+    mock_usage = MagicMock()
+    mock_usage.prompt_tokens = 10
+    mock_usage.completion_tokens = 5
+
+    mock_choice = MagicMock()
+    mock_choice.message = mock_message
+
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    mock_response.usage = mock_usage
+
+    mock_client.chat.completions.create.return_value = mock_response
+
+    llm = OpenAI(client=mock_client, model="test-model")
+    llm.stream_responses = False
+
+    with chats.new("Test reasoning") as t:
+        response = llm.prompt("How many r's in strawberry?")
+
+    assert response == "There are 3 r's."
+    last_message = t.messages[-1]
+    assert last_message.thinking == (
+        "Let me count: s-t-r-a-w-b-e-r-r-y. r appears at positions 3, 8, 9."
+    )
+
+
+def test_thinking_plumbed_through_respond():
+    """Tests that LLMResponse.thinking is plumbed through respond() to the message."""
+
+    class MockedOpenAIWithThinking(OpenAI):
+        def __init__(self):
+            super().__init__(client=None, model="mock-thinking")
+
+        def _call_api(self, messages, **kwargs):
+            return LLMResponse(
+                content="The answer is 42.",
+                thinking="I need to think about this carefully...",
+            )
+
+    llm = MockedOpenAIWithThinking()
+
+    with chats.new("Test thinking plumbing") as t:
+        response = llm.prompt("What is the answer?")
+
+    assert response == "The answer is 42."
+    last_message = t.messages[-1]
+    assert last_message.thinking == "I need to think about this carefully..."
+
+
 def test_prompt_rejects_invalid_reasoning():
     """Tests that an invalid reasoning level raises ValueError."""
     llm = MockedOpenAI(model="test-model")

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -197,9 +197,13 @@ def test_invoke():
     assert llm.kwargs.get("response_format") is None
 
 
-def test_prompt_reasoning_sets_effort_and_thoughts():
-    """Tests that reasoning='high' sets reasoning_effort and enables thinking."""
-    llm = MockedOpenAI(model="test-model")
+@pytest.mark.parametrize(
+    "model",
+    ["google/gemini-2.5-flash", "anthropic/claude-sonnet", "openai/gpt-5.4"],
+)
+def test_prompt_reasoning_sets_effort_and_thinking_config(model):
+    """Tests that reasoning sets reasoning_effort and include_thoughts for all models."""
+    llm = MockedOpenAI(model=model)
     llm.prompt("Think hard", reasoning="high")
 
     assert llm.kwargs["reasoning_effort"] == "high"

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -70,7 +70,7 @@ COMPLEX_USAGE = llm_messages.Usage(input_tokens=100, output_tokens=50)
             llm_messages.LLMMessage(
                 sender=LLM_ACTOR,
                 content="Thinking about something...",
-                thinking="hmmm...",
+                reasoning_traces="hmmm...",
             ),
             id="with_thinking",
         ),
@@ -104,7 +104,7 @@ COMPLEX_USAGE = llm_messages.Usage(input_tokens=100, output_tokens=50)
             llm_messages.LLMMessage(
                 sender=LLM_ACTOR,
                 content="Complex message",
-                thinking="Thinking hard...",
+                reasoning_traces="Thinking hard...",
                 usage=COMPLEX_USAGE,
                 tool_calls=[TOOL_INVOCATION],
                 chat=QUESTION_HISTORY,

--- a/user_guide.md
+++ b/user_guide.md
@@ -242,7 +242,7 @@ GenAI).
 response = llm.prompt("Solve this math problem.", reasoning="high")
 ```
 
-Valid values: `"low"`, `"medium"`, `"high"`.
+Valid values: `"none"`, `"low"`, `"medium"`, `"high"`.
 
 > **Note:** Not all models support reasoning. Models that don't support
 > it will return an error.

--- a/user_guide.md
+++ b/user_guide.md
@@ -244,17 +244,15 @@ response = llm.prompt("Solve this math problem.", reasoning="high")
 
 Valid values: `"low"`, `"medium"`, `"high"`.
 
-### Thinking Traces
+> **Note:** Not all models support reasoning. Models that don't support
+> it will return an error.
 
-Set `include_thoughts=True` to receive the model's internal reasoning
-traces in the response:
+Since `prompt()` returns a plain string, use `kbench.last_reasoning_traces()`
+to access the model's reasoning traces from the most recent response:
 
 ```python
-response = llm.prompt(
-    "How many r's are in 'strawberry'?",
-    reasoning="high",
-    include_thoughts=True,
-)
+response = llm.prompt("How many r's are in 'strawberry'?", reasoning="high")
+traces = kbench.last_reasoning_traces()  # model's internal reasoning
 ```
 
 ### `llm.prompt()` with Tool Calling

--- a/user_guide.md
+++ b/user_guide.md
@@ -231,6 +231,32 @@ response = kbench.llm.prompt(
 > models support audio inputs. Models that don't support audio will
 > return an error.
 
+### Reasoning
+
+The `reasoning` parameter controls how much reasoning the model
+performs. The SDK maps this to the correct provider-specific parameter
+automatically (`reasoning_effort` for OpenAI, `thinking_config` for
+GenAI).
+
+```python
+response = llm.prompt("Solve this math problem.", reasoning="high")
+```
+
+Valid values: `"low"`, `"medium"`, `"high"`.
+
+### Thinking Traces
+
+Set `include_thoughts=True` to receive the model's internal reasoning
+traces in the response:
+
+```python
+response = llm.prompt(
+    "How many r's are in 'strawberry'?",
+    reasoning="high",
+    include_thoughts=True,
+)
+```
+
 ### `llm.prompt()` with Tool Calling
 
 You can allow the LLM to use Python functions as tools by passing them


### PR DESCRIPTION
Maps reasoning to reasoning_effort (OpenAI) and ThinkingConfig (GenAI). Adds _extract_text for GenAI to wrap thought parts in <think> tags. 

[design doc](https://docs.google.com/document/d/16LU76WK-xngCzWj8L4uySMG45SHSHil_Pz_iERayw5U/edit?resourcekey=0-t0INHEgqdLzANbNliEoKMw&tab=t.0#heading=h.1sf05llk29fe)
BUG=b/505746972