### PR TITLE
Make task name/description length limits env-var driven

### DIFF
--- a/quick_start.md
+++ b/quick_start.md
@@ -61,15 +61,9 @@ Here are some core concepts for using the library effectively:
   can optionally return a value. If no value is returned, the task is
   graded Pass/Fail based on its assertions. The first parameter must
   always be the LLM being tested; additional parameters are optional.
-  When running on Kaggle, the `name` and `description` arguments to
-  `@kbench.task(...)` must fit within the platform's storage limits;
-  the SDK reads those limits from the
-  `KAGGLE_BENCHMARK_MAX_NAME_LENGTH` and
-  `KAGGLE_BENCHMARK_MAX_DESCRIPTION_LENGTH` environment variables and
-  raises `ValueError` at decoration time if they are exceeded. If
-  `description` is omitted, the function's docstring is used and is
-  subject to the same limit. When the env vars are unset (or set to
-  `0`), no limit is enforced.
+  When running on Kaggle, `name` and `description` are subject to
+  platform length limits; the decorator raises `ValueError` immediately
+  if they are exceeded so you don't waste a run.
 - **`LLM`**: An object representing a large language model you can
   interact with. You can access available Kaggle models via
   `kbench.llms["vendor/model-name"]`.

--- a/quick_start.md
+++ b/quick_start.md
@@ -61,6 +61,15 @@ Here are some core concepts for using the library effectively:
   can optionally return a value. If no value is returned, the task is
   graded Pass/Fail based on its assertions. The first parameter must
   always be the LLM being tested; additional parameters are optional.
+  When running on Kaggle, the `name` and `description` arguments to
+  `@kbench.task(...)` must fit within the platform's storage limits;
+  the SDK reads those limits from the
+  `KAGGLE_BENCHMARK_MAX_NAME_LENGTH` and
+  `KAGGLE_BENCHMARK_MAX_DESCRIPTION_LENGTH` environment variables and
+  raises `ValueError` at decoration time if they are exceeded. If
+  `description` is omitted, the function's docstring is used and is
+  subject to the same limit. When the env vars are unset (or set to
+  `0`), no limit is enforced.
 - **`LLM`**: An object representing a large language model you can
   interact with. You can access available Kaggle models via
   `kbench.llms["vendor/model-name"]`.

--- a/src/kaggle_benchmarks/_config.py
+++ b/src/kaggle_benchmarks/_config.py
@@ -37,6 +37,19 @@ def string_to_bool(s: str) -> bool:
     return s.lower() in ("true", "1", "t", "y", "yes")
 
 
+def _parse_int_env(name: str, default: int = 0) -> int:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logging.getLogger(__name__).warning(
+            f"Ignoring non-integer value for {name}={raw!r}; using {default}."
+        )
+        return default
+
+
 class ExecutionMode(enum.Enum):
     NOTEBOOK = 0
     INTERACTIVE = 0
@@ -94,6 +107,19 @@ class Config:
     )
     render_subruns: bool = dataclasses.field(
         default_factory=lambda: string_to_bool(os.environ.get("RENDER_SUBRUNS", "True"))
+    )
+
+    # Maximum length the host platform allows for `@kbench.task(...)` `name`
+    # and `description` arguments. The Kaggle notebook runtime sets these to
+    # match its backend column widths so users get fast feedback before a
+    # wasted run; non-Kaggle users leave them unset (or `0`) for no limit.
+    task_name_max_length: int = dataclasses.field(
+        default_factory=lambda: _parse_int_env("KAGGLE_BENCHMARK_MAX_NAME_LENGTH")
+    )
+    task_description_max_length: int = dataclasses.field(
+        default_factory=lambda: _parse_int_env(
+            "KAGGLE_BENCHMARK_MAX_DESCRIPTION_LENGTH"
+        )
     )
 
     show_message_details: bool = False

--- a/src/kaggle_benchmarks/_config.py
+++ b/src/kaggle_benchmarks/_config.py
@@ -43,7 +43,7 @@ def _parse_int_env(name: str) -> int | None: ...
 def _parse_int_env(name: str, default: int) -> int: ...
 def _parse_int_env(name: str, default: int | None = None) -> int | None:
     raw = os.environ.get(name)
-    if not raw:
+    if raw is None:
         return default
     try:
         return int(raw)

--- a/src/kaggle_benchmarks/_config.py
+++ b/src/kaggle_benchmarks/_config.py
@@ -17,7 +17,7 @@ import enum
 import logging
 import os
 from pathlib import Path
-from typing import Any, Self
+from typing import Any, Self, overload
 
 import dotenv
 import panel as pn
@@ -37,7 +37,11 @@ def string_to_bool(s: str) -> bool:
     return s.lower() in ("true", "1", "t", "y", "yes")
 
 
-def _parse_int_env(name: str, default: int = 0) -> int:
+@overload
+def _parse_int_env(name: str) -> int | None: ...
+@overload
+def _parse_int_env(name: str, default: int) -> int: ...
+def _parse_int_env(name: str, default: int | None = None) -> int | None:
     raw = os.environ.get(name)
     if not raw:
         return default
@@ -79,8 +83,8 @@ class Config:
     )
 
     cache_timeout_seconds: int = dataclasses.field(
-        default_factory=lambda: int(
-            os.environ.get("CACHE_TIMEOUT_SECONDS", str(7 * 24 * 60 * 60))
+        default_factory=lambda: _parse_int_env(
+            "CACHE_TIMEOUT_SECONDS", 7 * 24 * 60 * 60
         )
     )
 
@@ -112,11 +116,11 @@ class Config:
     # Maximum length the host platform allows for `@kbench.task(...)` `name`
     # and `description` arguments. The Kaggle notebook runtime sets these to
     # match its backend column widths so users get fast feedback before a
-    # wasted run; non-Kaggle users leave them unset (or `0`) for no limit.
-    task_name_max_length: int = dataclasses.field(
+    # wasted run; non-Kaggle users leave them unset (`None`) for no limit.
+    task_name_max_length: int | None = dataclasses.field(
         default_factory=lambda: _parse_int_env("KAGGLE_BENCHMARK_MAX_NAME_LENGTH")
     )
-    task_description_max_length: int = dataclasses.field(
+    task_description_max_length: int | None = dataclasses.field(
         default_factory=lambda: _parse_int_env(
             "KAGGLE_BENCHMARK_MAX_DESCRIPTION_LENGTH"
         )

--- a/src/kaggle_benchmarks/_config.py
+++ b/src/kaggle_benchmarks/_config.py
@@ -31,6 +31,8 @@ if _dotenv_path := dotenv.find_dotenv():
 else:
     _logger.info("No .env file found; skipping dotenv load")
 
+logger = logging.getLogger(__name__)
+
 
 def string_to_bool(s: str) -> bool:
     """Converts a string to a boolean, handling various truthy values."""
@@ -48,7 +50,7 @@ def _parse_int_env(name: str, default: int | None = None) -> int | None:
     try:
         return int(raw)
     except ValueError:
-        logging.getLogger(__name__).warning(
+        logger.warning(
             f"Ignoring non-integer value for {name}={raw!r}; using {default}."
         )
         return default

--- a/src/kaggle_benchmarks/tasks.py
+++ b/src/kaggle_benchmarks/tasks.py
@@ -52,25 +52,20 @@ class Task(Generic[T]):
         from kaggle_benchmarks import client
         from kaggle_benchmarks._config import config
 
-        if (
-            config.task_name_max_length > 0
-            and len(self.name) > config.task_name_max_length
-        ):
+        name_limit = config.task_name_max_length
+        if name_limit and len(self.name) > name_limit:
             raise ValueError(
                 f"Task name is {len(self.name)} characters; the maximum "
-                f"allowed is {config.task_name_max_length}. Please shorten "
-                f"the 'name' argument to @kbench.task(...)."
+                f"allowed is {name_limit}. Please shorten the 'name' "
+                f"argument to @kbench.task(...)."
             )
 
-        if (
-            config.task_description_max_length > 0
-            and len(self.description) > config.task_description_max_length
-        ):
+        description_limit = config.task_description_max_length
+        if description_limit and len(self.description) > description_limit:
             raise ValueError(
                 f"Task description is {len(self.description)} characters; "
-                f"the maximum allowed is {config.task_description_max_length}. "
-                f"Please shorten the 'description' argument to "
-                f"@kbench.task(...)."
+                f"the maximum allowed is {description_limit}. Please shorten "
+                f"the 'description' argument to @kbench.task(...)."
             )
 
         client.register_task(self)

--- a/src/kaggle_benchmarks/tasks.py
+++ b/src/kaggle_benchmarks/tasks.py
@@ -17,7 +17,6 @@ import datetime  # For Run start_time and end_time
 import functools
 import inspect
 import logging
-import os
 import time
 from typing import TYPE_CHECKING, Any, Callable, Generic, Iterable, Self, TypeVar
 
@@ -31,27 +30,6 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
-
-# Env vars the host platform (e.g. Kaggle) can set to enforce its own
-# column-width limits on task name and description without baking those
-# limits into the SDK itself. Unset or 0 means "no limit", so non-Kaggle
-# users of the SDK are unaffected.
-TASK_NAME_MAX_LENGTH_ENV = "KAGGLE_BENCHMARK_MAX_NAME_LENGTH"
-TASK_DESCRIPTION_MAX_LENGTH_ENV = "KAGGLE_BENCHMARK_MAX_DESCRIPTION_LENGTH"
-
-
-def _max_length_from_env(env_var: str) -> int | None:
-    raw = os.environ.get(env_var)
-    if not raw:
-        return None
-    try:
-        value = int(raw)
-    except ValueError:
-        logger.warning(
-            f"Ignoring non-integer value for {env_var}={raw!r}; treating as no limit."
-        )
-        return None
-    return value if value > 0 else None
 
 
 class NonRecoverableError(Exception):
@@ -72,23 +50,27 @@ class Task(Generic[T]):
 
     def __post_init__(self):
         from kaggle_benchmarks import client
+        from kaggle_benchmarks._config import config
 
-        name_limit = _max_length_from_env(TASK_NAME_MAX_LENGTH_ENV)
-        if name_limit is not None and len(self.name) > name_limit:
+        if (
+            config.task_name_max_length > 0
+            and len(self.name) > config.task_name_max_length
+        ):
             raise ValueError(
                 f"Task name is {len(self.name)} characters; the maximum "
-                f"allowed is {name_limit} (set via "
-                f"{TASK_NAME_MAX_LENGTH_ENV}). Please shorten the 'name' "
-                f"argument to @kbench.task(...)."
+                f"allowed is {config.task_name_max_length}. Please shorten "
+                f"the 'name' argument to @kbench.task(...)."
             )
 
-        description_limit = _max_length_from_env(TASK_DESCRIPTION_MAX_LENGTH_ENV)
-        if description_limit is not None and len(self.description) > description_limit:
+        if (
+            config.task_description_max_length > 0
+            and len(self.description) > config.task_description_max_length
+        ):
             raise ValueError(
                 f"Task description is {len(self.description)} characters; "
-                f"the maximum allowed is {description_limit} (set via "
-                f"{TASK_DESCRIPTION_MAX_LENGTH_ENV}). Please shorten the "
-                f"'description' argument to @kbench.task(...)."
+                f"the maximum allowed is {config.task_description_max_length}. "
+                f"Please shorten the 'description' argument to "
+                f"@kbench.task(...)."
             )
 
         client.register_task(self)

--- a/src/kaggle_benchmarks/tasks.py
+++ b/src/kaggle_benchmarks/tasks.py
@@ -17,6 +17,7 @@ import datetime  # For Run start_time and end_time
 import functools
 import inspect
 import logging
+import os
 import time
 from typing import TYPE_CHECKING, Any, Callable, Generic, Iterable, Self, TypeVar
 
@@ -30,6 +31,27 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
+
+# Env vars the host platform (e.g. Kaggle) can set to enforce its own
+# column-width limits on task name and description without baking those
+# limits into the SDK itself. Unset or 0 means "no limit", so non-Kaggle
+# users of the SDK are unaffected.
+TASK_NAME_MAX_LENGTH_ENV = "KAGGLE_BENCHMARK_MAX_NAME_LENGTH"
+TASK_DESCRIPTION_MAX_LENGTH_ENV = "KAGGLE_BENCHMARK_MAX_DESCRIPTION_LENGTH"
+
+
+def _max_length_from_env(env_var: str) -> int | None:
+    raw = os.environ.get(env_var)
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            f"Ignoring non-integer value for {env_var}={raw!r}; treating as no limit."
+        )
+        return None
+    return value if value > 0 else None
 
 
 class NonRecoverableError(Exception):
@@ -50,6 +72,24 @@ class Task(Generic[T]):
 
     def __post_init__(self):
         from kaggle_benchmarks import client
+
+        name_limit = _max_length_from_env(TASK_NAME_MAX_LENGTH_ENV)
+        if name_limit is not None and len(self.name) > name_limit:
+            raise ValueError(
+                f"Task name is {len(self.name)} characters; the maximum "
+                f"allowed is {name_limit} (set via "
+                f"{TASK_NAME_MAX_LENGTH_ENV}). Please shorten the 'name' "
+                f"argument to @kbench.task(...)."
+            )
+
+        description_limit = _max_length_from_env(TASK_DESCRIPTION_MAX_LENGTH_ENV)
+        if description_limit is not None and len(self.description) > description_limit:
+            raise ValueError(
+                f"Task description is {len(self.description)} characters; "
+                f"the maximum allowed is {description_limit} (set via "
+                f"{TASK_DESCRIPTION_MAX_LENGTH_ENV}). Please shorten the "
+                f"'description' argument to @kbench.task(...)."
+            )
 
         client.register_task(self)
         events.manager.dispatch("new_task", self)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -356,71 +356,30 @@ def test_partial():
     assert partial.run(x=1, y=2).result == 3
 
 
-@pytest.mark.parametrize("limit", [0, -1])
-def test_task_name_unbounded_when_limit_unset_or_zero(monkeypatch, limit):
-    monkeypatch.setattr(config, "task_name_max_length", limit)
-    monkeypatch.setattr(config, "task_description_max_length", limit)
+def test_task_length_limits_enforced(monkeypatch):
+    monkeypatch.setattr(config, "task_name_max_length", 5)
+    monkeypatch.setattr(config, "task_description_max_length", 5)
 
-    long_name = "x" * 10_000
-    long_description = "y" * 10_000
-
-    @tasks.task(name=long_name, description=long_description)
-    def long_values():
+    @tasks.task(name="ok", description="short")
+    def within_limit():
         pass
 
-    assert long_values.name == long_name
-    assert long_values.description == long_description
+    with pytest.raises(ValueError, match=r"Task name is 6 characters"):
+        tasks.task(name="x" * 6)(lambda: None)
+
+    with pytest.raises(ValueError, match=r"Task description is 6 characters"):
+        tasks.task(name="ok", description="y" * 6)(lambda: None)
 
 
-def test_task_name_too_long_raises(monkeypatch):
-    monkeypatch.setattr(config, "task_name_max_length", 255)
-    long_name = "x" * 256
-    with pytest.raises(
-        ValueError,
-        match=r"Task name is 256 characters; the maximum allowed is 255",
-    ):
+def test_task_length_limits_disabled_when_none(monkeypatch):
+    monkeypatch.setattr(config, "task_name_max_length", None)
+    monkeypatch.setattr(config, "task_description_max_length", None)
 
-        @tasks.task(name=long_name)
-        def too_long_name():
-            pass
-
-
-def test_task_description_too_long_raises(monkeypatch):
-    monkeypatch.setattr(config, "task_description_max_length", 255)
-    long_description = "y" * 256
-    with pytest.raises(
-        ValueError,
-        match=r"Task description is 256 characters; the maximum allowed is 255",
-    ):
-
-        @tasks.task(description=long_description)
-        def too_long_description():
-            pass
-
-
-def test_task_name_and_description_at_limit_accepted(monkeypatch):
-    monkeypatch.setattr(config, "task_name_max_length", 255)
-    monkeypatch.setattr(config, "task_description_max_length", 255)
-    name_at_limit = "n" * 255
-    description_at_limit = "d" * 255
-
-    @tasks.task(name=name_at_limit, description=description_at_limit)
-    def at_limit():
+    @tasks.task(name="x" * 1000, description="y" * 1000)
+    def unbounded():
         pass
 
-    assert at_limit.name == name_at_limit
-    assert at_limit.description == description_at_limit
-
-
-def test_task_invalid_env_value_treated_as_no_limit(monkeypatch):
-    from kaggle_benchmarks import _config
-
-    monkeypatch.setenv("KAGGLE_BENCHMARK_MAX_NAME_LENGTH", "not-an-int")
-    monkeypatch.setenv("KAGGLE_BENCHMARK_MAX_DESCRIPTION_LENGTH", "not-an-int")
-
-    fresh_config = _config.Config()
-    assert fresh_config.task_name_max_length == 0
-    assert fresh_config.task_description_max_length == 0
+    assert len(unbounded.name) == 1000
 
 
 def test_nested_task_evaluate_with_retries_coerces_to_one(duck, caplog):

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -356,14 +356,10 @@ def test_partial():
     assert partial.run(x=1, y=2).result == 3
 
 
-@pytest.mark.parametrize("env_value", [None, "0"])
-def test_task_name_unbounded_when_env_unset_or_zero(monkeypatch, env_value):
-    if env_value is None:
-        monkeypatch.delenv(tasks.TASK_NAME_MAX_LENGTH_ENV, raising=False)
-        monkeypatch.delenv(tasks.TASK_DESCRIPTION_MAX_LENGTH_ENV, raising=False)
-    else:
-        monkeypatch.setenv(tasks.TASK_NAME_MAX_LENGTH_ENV, env_value)
-        monkeypatch.setenv(tasks.TASK_DESCRIPTION_MAX_LENGTH_ENV, env_value)
+@pytest.mark.parametrize("limit", [0, -1])
+def test_task_name_unbounded_when_limit_unset_or_zero(monkeypatch, limit):
+    monkeypatch.setattr(config, "task_name_max_length", limit)
+    monkeypatch.setattr(config, "task_description_max_length", limit)
 
     long_name = "x" * 10_000
     long_description = "y" * 10_000
@@ -377,7 +373,7 @@ def test_task_name_unbounded_when_env_unset_or_zero(monkeypatch, env_value):
 
 
 def test_task_name_too_long_raises(monkeypatch):
-    monkeypatch.setenv(tasks.TASK_NAME_MAX_LENGTH_ENV, "255")
+    monkeypatch.setattr(config, "task_name_max_length", 255)
     long_name = "x" * 256
     with pytest.raises(
         ValueError,
@@ -390,7 +386,7 @@ def test_task_name_too_long_raises(monkeypatch):
 
 
 def test_task_description_too_long_raises(monkeypatch):
-    monkeypatch.setenv(tasks.TASK_DESCRIPTION_MAX_LENGTH_ENV, "255")
+    monkeypatch.setattr(config, "task_description_max_length", 255)
     long_description = "y" * 256
     with pytest.raises(
         ValueError,
@@ -403,8 +399,8 @@ def test_task_description_too_long_raises(monkeypatch):
 
 
 def test_task_name_and_description_at_limit_accepted(monkeypatch):
-    monkeypatch.setenv(tasks.TASK_NAME_MAX_LENGTH_ENV, "255")
-    monkeypatch.setenv(tasks.TASK_DESCRIPTION_MAX_LENGTH_ENV, "255")
+    monkeypatch.setattr(config, "task_name_max_length", 255)
+    monkeypatch.setattr(config, "task_description_max_length", 255)
     name_at_limit = "n" * 255
     description_at_limit = "d" * 255
 
@@ -417,14 +413,14 @@ def test_task_name_and_description_at_limit_accepted(monkeypatch):
 
 
 def test_task_invalid_env_value_treated_as_no_limit(monkeypatch):
-    monkeypatch.setenv(tasks.TASK_NAME_MAX_LENGTH_ENV, "not-an-int")
-    monkeypatch.setenv(tasks.TASK_DESCRIPTION_MAX_LENGTH_ENV, "not-an-int")
+    from kaggle_benchmarks import _config
 
-    @tasks.task(name="n" * 1000, description="d" * 1000)
-    def malformed_env():
-        pass
+    monkeypatch.setenv("KAGGLE_BENCHMARK_MAX_NAME_LENGTH", "not-an-int")
+    monkeypatch.setenv("KAGGLE_BENCHMARK_MAX_DESCRIPTION_LENGTH", "not-an-int")
 
-    assert len(malformed_env.name) == 1000
+    fresh_config = _config.Config()
+    assert fresh_config.task_name_max_length == 0
+    assert fresh_config.task_description_max_length == 0
 
 
 def test_nested_task_evaluate_with_retries_coerces_to_one(duck, caplog):

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -356,6 +356,77 @@ def test_partial():
     assert partial.run(x=1, y=2).result == 3
 
 
+@pytest.mark.parametrize("env_value", [None, "0"])
+def test_task_name_unbounded_when_env_unset_or_zero(monkeypatch, env_value):
+    if env_value is None:
+        monkeypatch.delenv(tasks.TASK_NAME_MAX_LENGTH_ENV, raising=False)
+        monkeypatch.delenv(tasks.TASK_DESCRIPTION_MAX_LENGTH_ENV, raising=False)
+    else:
+        monkeypatch.setenv(tasks.TASK_NAME_MAX_LENGTH_ENV, env_value)
+        monkeypatch.setenv(tasks.TASK_DESCRIPTION_MAX_LENGTH_ENV, env_value)
+
+    long_name = "x" * 10_000
+    long_description = "y" * 10_000
+
+    @tasks.task(name=long_name, description=long_description)
+    def long_values():
+        pass
+
+    assert long_values.name == long_name
+    assert long_values.description == long_description
+
+
+def test_task_name_too_long_raises(monkeypatch):
+    monkeypatch.setenv(tasks.TASK_NAME_MAX_LENGTH_ENV, "255")
+    long_name = "x" * 256
+    with pytest.raises(
+        ValueError,
+        match=r"Task name is 256 characters; the maximum allowed is 255",
+    ):
+
+        @tasks.task(name=long_name)
+        def too_long_name():
+            pass
+
+
+def test_task_description_too_long_raises(monkeypatch):
+    monkeypatch.setenv(tasks.TASK_DESCRIPTION_MAX_LENGTH_ENV, "255")
+    long_description = "y" * 256
+    with pytest.raises(
+        ValueError,
+        match=r"Task description is 256 characters; the maximum allowed is 255",
+    ):
+
+        @tasks.task(description=long_description)
+        def too_long_description():
+            pass
+
+
+def test_task_name_and_description_at_limit_accepted(monkeypatch):
+    monkeypatch.setenv(tasks.TASK_NAME_MAX_LENGTH_ENV, "255")
+    monkeypatch.setenv(tasks.TASK_DESCRIPTION_MAX_LENGTH_ENV, "255")
+    name_at_limit = "n" * 255
+    description_at_limit = "d" * 255
+
+    @tasks.task(name=name_at_limit, description=description_at_limit)
+    def at_limit():
+        pass
+
+    assert at_limit.name == name_at_limit
+    assert at_limit.description == description_at_limit
+
+
+def test_task_invalid_env_value_treated_as_no_limit(monkeypatch):
+    monkeypatch.setenv(tasks.TASK_NAME_MAX_LENGTH_ENV, "not-an-int")
+    monkeypatch.setenv(tasks.TASK_DESCRIPTION_MAX_LENGTH_ENV, "not-an-int")
+
+    @tasks.task(name="n" * 1000, description="d" * 1000)
+    def malformed_env():
+        pass
+
+    assert len(malformed_env.name) == 1000
+
+
 def test_nested_task_evaluate_with_retries_coerces_to_one(duck, caplog):
     @tasks.task()
     def single_task(llm, x):

--- a/user_guide.md
+++ b/user_guide.md
@@ -48,6 +48,10 @@ def my_task(llm):
     pass
 ```
 
+When running on Kaggle, the `name` and `description` arguments are
+subject to platform length limits; the decorator raises `ValueError`
+immediately if they are exceeded so you don't waste a run.
+
 ### Task Function Parameters
 
 A task function always accepts an `LLM` object as its first argument.


### PR DESCRIPTION
The Kaggle backend's nvarchar(255) columns are a platform detail, not
something the SDK should hardcode — `kaggle-benchmarks` is also used
outside Kaggle. Read the limits from `KAGGLE_BENCHMARK_MAX_NAME_LENGTH`
and `KAGGLE_BENCHMARK_MAX_DESCRIPTION_LENGTH` so the Kaggle notebook
runtime can inject its own bounds, while non-Kaggle users (env unset
or `0`) see no limit at all.

Co-authored-by: kaggle-agent <kaggle-agent@users.noreply.github.com>

---

Task: [nanliao-20260421203919-4e678454](https://agents.dev.kaggle.net/tasks/nanliao-20260421203919-4e678454)
Context: https://chat.kaggle.net/kaggle/pl/6hrbew73m7yjijco33ytgq48ao

