### PR TITLE
fix(assertions): add flags param to assert_not_contains_regex

### DIFF
--- a/src/kaggle_benchmarks/assertions.py
+++ b/src/kaggle_benchmarks/assertions.py
@@ -356,6 +356,7 @@ def assert_contains_regex(
         pattern: The regex pattern to search for.
         text: The string to search within.
         expectation: An optional message summarizing the assertion.
+        flags: Optional regex flags to pass to `re.search`.
     """
     passed = re.search(pattern, text, flags=flags) is not None
 

--- a/src/kaggle_benchmarks/assertions.py
+++ b/src/kaggle_benchmarks/assertions.py
@@ -370,6 +370,8 @@ def assert_not_contains_regex(
     pattern: str | re.Pattern[str],
     text: str,
     expectation: str | None = None,
+    *,
+    flags=re.RegexFlag.NOFLAG,
 ) -> AssertionResult:
     """Asserts that the given regex pattern is not found anywhere in the text.
 
@@ -377,8 +379,9 @@ def assert_not_contains_regex(
         pattern: The regex pattern to search for.
         text: The string to search within.
         expectation: An optional message summarizing the assertion.
+        flags: Optional regex flags to pass to `re.search`.
     """
-    passed = re.search(pattern, text) is None
+    passed = re.search(pattern, text, flags=flags) is None
 
     return AssertionResult(
         passed=passed,

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -157,6 +157,21 @@ def test_regex_assertions():
         },
     )
 
+    # Case 4: flags kwarg honored — IGNORECASE makes the match succeed,
+    # so the not_contains assertion should fail.
+    r_not_contains_flags = assertions.assert_not_contains_regex(
+        r"HELLO", "hello world", flags=re.IGNORECASE
+    )
+    assert_assertion_result_matches(
+        r_not_contains_flags,
+        expected_passed=False,
+        expected_expectation="Expected pattern 'HELLO' not found in 'hello world'",
+        expected_details_content={
+            "assertion_type": "assert_not_contains_regex",
+            "source_code": "r_not_contains_flags = assertions.assert_not_contains_regex(",
+        },
+    )
+
 
 @assertions.assertion_handler()
 def assert_duck_always_quacks(response, expectation) -> assertions.AssertionResult:


### PR DESCRIPTION
## Summary

Reopens the minimal change from #99 (which was closed because it bundled unrelated work). This PR contains *only* the `assert_not_contains_regex` fix.

Adds the `flags` keyword-only argument to `assert_not_contains_regex`, matching the same change made to `assert_contains_regex` in #82.

## Changes

- Added `*, flags=re.RegexFlag.NOFLAG` parameter to `assert_not_contains_regex`
- Passed `flags=flags` into the `re.search()` call
- Updated docstring to document the new `flags` argument

## Related

Addresses reviewer feedback from #82 where `dolaameng` noted: "We should change `assert_not_contains_regex` too."