### PR TITLE
Add default .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+PYTHONPATH=src
+# Default model for benchmarks
+LLM_DEFAULT=google/gemini-3-flash-preview
+# Model used for evaluation/judging
+LLM_DEFAULT_EVAL=google/gemini-3-flash-preview
+# Comma-separated list of available models
+LLMS_AVAILABLE=google/gemini-3-flash-preview,google/gemini-3.1-flash-lite-preview

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
-PYTHONPATH=src
 # Default model for benchmarks
 LLM_DEFAULT=google/gemini-3-flash-preview
 # Model used for evaluation/judging


### PR DESCRIPTION
These correspond with the default token fetchable from the `kaggle-cli` command: `kaggle benchmarks auth`