### PR TITLE
Log effective .env path in _config

### DIFF
--- a/src/kaggle_benchmarks/_config.py
+++ b/src/kaggle_benchmarks/_config.py
@@ -25,8 +25,7 @@ import panel as pn
 base_dir = Path(__file__).parent.parent.parent
 
 _logger = logging.getLogger(__name__)
-_dotenv_path = dotenv.find_dotenv(usecwd=True)
-if _dotenv_path:
+if _dotenv_path := dotenv.find_dotenv():
     _logger.info("Loading environment variables from %s", _dotenv_path)
     dotenv.load_dotenv(_dotenv_path, override=True)
 else:

--- a/src/kaggle_benchmarks/_config.py
+++ b/src/kaggle_benchmarks/_config.py
@@ -23,7 +23,14 @@ import dotenv
 import panel as pn
 
 base_dir = Path(__file__).parent.parent.parent
-dotenv.load_dotenv(override=True)
+
+_logger = logging.getLogger(__name__)
+_dotenv_path = dotenv.find_dotenv(usecwd=True)
+if _dotenv_path:
+    _logger.info("Loading environment variables from %s", _dotenv_path)
+    dotenv.load_dotenv(_dotenv_path, override=True)
+else:
+    _logger.info("No .env file found; skipping dotenv load")
 
 
 def string_to_bool(s: str) -> bool:


### PR DESCRIPTION
A code review flagged that `dotenv.load_dotenv(override=True)` silently
walks up from CWD to find a `.env` file, leaving users with no visibility
into which file (if any) was loaded. Resolve the path explicitly via
`find_dotenv()`, log it at INFO, and pass it to `load_dotenv()` so the
logged path matches what's actually loaded.

Co-authored-by: kaggle-agent <kaggle-agent@users.noreply.github.com>

---

Task: [limagoog-20260424193246-1b84b1e3](https://agents.dev.kaggle.net/tasks/limagoog-20260424193246-1b84b1e3)
Context: https://chat.kaggle.net/kaggle/pl/czr14w77mtrz3r3m55rshjf95o

