### PR TITLE
docs: add development and code review guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,3 +31,10 @@ All submissions, including submissions by project members, require review. We
 use GitHub pull requests for this purpose. Consult
 [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
 information on using pull requests.
+
+## Development resources
+
+For coding standards, architecture conventions, and testing workflows, see:
+
+- [**DEVELOPMENT.md**](DEVELOPMENT.md) — Architecture, coding conventions, testing, and a PR checklist for contributors.
+- [**REVIEWING.md**](REVIEWING.md) — What reviewers look for, how to give feedback, and when to block.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -248,6 +248,8 @@ uv run --group test pytest tests -v
 
 ## 5. Code Style & Tooling
 
+This project follows the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html) as its baseline coding standard. The tooling below automates and enforces many of these conventions.
+
 ### Formatting and Linting
 
 The project uses **ruff** for both formatting and linting. Always run these before committing:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,488 @@
+# Development Guide for Kaggle Benchmarks
+
+A practical guide for contributors — covering architecture, conventions, and common pitfalls.
+
+---
+
+## 1. Project Overview
+
+`kaggle-benchmarks` is a Python **library** (not an application or service) for evaluating LLMs using decorators, assertions, and tool-augmented interactions. Users write decorated functions (`@kbench.task`) that prompt LLMs and assert outputs; the library handles orchestration, caching, serialization, and UI rendering. The codebase is organized around reusable primitives, not around endpoints or CLI commands.
+
+### Key Subsystems
+
+The source lives in `src/kaggle_benchmarks/`. Here are the main subsystems — browse the directory for the full picture.
+
+| Subsystem | Key Modules | Responsibility |
+|-----------|------------|----------------|
+| **Core primitives** | `tasks.py`, `messages.py`, `runs.py`, `results.py` | Task/benchmark decorators, message types, execution records |
+| **LLM interaction** | `actors/` (incl. `llms.py`), `chats.py`, `prompting.py` | LLM abstraction (`LLMChat`, `OpenAI`, `GoogleGenAI`), conversation management, schema processing |
+| **Serialization** | `serializers/` | Translating messages to/from provider-specific API payloads |
+| **Content types** | `content_types/` | Provider-agnostic data models for images, audio, video |
+| **Configuration** | `_config.py` | Centralized `Config` dataclass, `ExecutionMode` enum |
+| **Platform integration** | `kaggle/`, `envs/` | Model loading, protobuf serialization, execution environments |
+| **Tooling** | `tools/` | Python interpreter, web search, tool invocation |
+| **UI** | `ui/`, `events.py` | Panel-based notebook rendering, lifecycle event hooks |
+
+Other top-level directories: `tests/` (mirrors `src/` structure), `golden_tests/` (end-to-end tests requiring API keys), `protos/` (Protocol Buffer schemas), `documentation/` (Quarto-based docs).
+
+### Key Mental Model
+
+The library has a clear **layered architecture** with strict separation of concerns:
+
+```
+User Code  →  @task / @benchmark decorators
+                   ↓
+             LLMChat.prompt()  →  Actor/LLM abstraction
+                   ↓
+             Serializers       →  Message ↔ API payload translation
+                   ↓
+             Provider SDKs     →  OpenAI / Google GenAI
+```
+
+Each layer has a single responsibility. Understanding which layer owns a piece of logic is critical for placing new code correctly.
+
+---
+
+## 2. Architecture & Design Principles
+
+### Content Types Are Provider-Agnostic
+
+Content objects (`ImageContent`, `VideoContent`, `AudioContent` in `content_types/`) represent **user data**. They must never contain provider-specific fields. If OpenAI needs a `detail` parameter on images or GenAI needs a `video_metadata` dict, that logic belongs in the corresponding serializer — not in the content type itself.
+
+```python
+# ❌ DON'T — this leaks OpenAI's API into a shared type
+class ImageContent:
+    detail: str = "auto"  # OpenAI-specific
+
+# ✅ DO — content types stay clean; serializers handle provider logic
+class ImageContent:
+    """Provider-agnostic image representation."""
+    ...
+```
+
+### Serialization Belongs in Serializers
+
+The codebase has a dedicated serializer layer built on `BaseSerializer` (in `serializers/base.py`). All message-to-API-payload translation happens here via dynamic dispatch on content type (`dump_text_message`, `dump_image`, `dump_video`, `dump_audio`, etc.). Never put serialization logic inline in client code.
+
+```python
+# ❌ DON'T — serialization inline in the client
+class MyClient:
+    def send(self, msg):
+        payload = {"parts": [{"text": msg.content}]}
+
+# ✅ DO — delegate to the serializer
+class MyClient:
+    def send(self, msg):
+        payload = list(self.serializer.dump_messages([msg]))
+```
+
+To add support for a new content type:
+1. Define the content class in `content_types/`
+2. Add a `dump_*` method to `BaseSerializer`
+3. Implement it in each concrete serializer (`GenAISerializer`, `ModelProxyOpenAISerializer`)
+
+### Prefer Subclasses Over Generic `**kwargs`
+
+When adding new modality support or specialized behavior, prefer **dedicated subclasses** with explicit parameters over generic `**kwargs` passthrough. This gives you stronger typing, better discoverability, and a clear place for specialized logic.
+
+```python
+# ❌ DON'T — generic kwargs are hard to validate and discover
+video = videos.from_url("https://youtube.com/...", video_metadata={"start_offset": "0s"})
+
+# ✅ DO — dedicated factory with explicit parameters
+video = videos.from_youtube("https://youtube.com/...", start_offset=0, end_offset=10)
+```
+
+### LLMChat Is Stateless
+
+`LLMChat` (in `actors/llms.py`) does not store conversation history, system instructions, or temperature settings. All state lives in the `chats.Chat` object, enabling clean nested threads where inner history is invisible to outer conversations. Respect this design — don't add stateful fields to `LLMChat`.
+
+### Keep the Public API Surface Small and Intentional
+
+Everything exported from `__init__.py` is the library's public contract. Once a parameter is added to `prompt()` or other user-facing methods, it's very hard to remove. Think carefully before expanding the API surface.
+
+```python
+# ⚠️ THINK TWICE — hard to change once adopted
+llm.prompt("...", api_params={"detail": "low"})
+
+# 💡 Consider alternatives for experimental features (context managers, config, etc.)
+```
+
+### Avoid Backend-Specific Coupling
+
+The library supports multiple LLM backends (OpenAI, GenAI). Don't hardcode assumptions about a single provider. Configuration validation should happen at the point of use (e.g., when an LLM is instantiated), not at import time.
+
+### Abstract Provider Differences Behind Unified Parameters
+
+When the same concept has different names across providers (e.g., OpenAI's `reasoning_effort` vs GenAI's `thinking_config`), introduce a single unified parameter that the SDK maps to provider-specific configurations internally. Users should never need `if/elif` branches per provider.
+
+```python
+# ❌ DON'T — forces users to know provider internals
+if llm.api == "openai":
+    llm.prompt("...", reasoning_effort="high")
+elif llm.api == "genai":
+    llm.prompt("...", thinking_config={"thinking_level": "HIGH"})
+
+# ✅ DO — SDK handles the mapping
+llm.prompt("...", reasoning="high")
+```
+
+### Keep Response Content Clean
+
+Response content (`message.content`) is consumed by structured output parsers, assertions, and user code. Be very careful not to pollute it with metadata or internal artifacts — anything mixed in can break JSON parsing or produce misleading assertion results.
+
+**Example:** When LLMs produce reasoning/thinking traces, they must be stored in `LLMMessage.thinking` (see `llm_messages.py`), not appended to `content`. If thinking text like `<think>The answer might be 42...</think>` ends up in `content`, a structured output parser will fail on the invalid JSON, and an `assert_contains("42", response)` will pass even when the final answer is wrong.
+
+---
+
+## 3. Configuration
+
+### Use the `Config` Dataclass
+
+All configuration flows through the central `Config` dataclass in `_config.py`. Don't scatter `os.getenv()` calls across modules. The established pattern uses `dataclasses.field(default_factory=...)` to read env vars with sensible defaults:
+
+```python
+@dataclasses.dataclass()
+class Config:
+    # ✅ Established pattern — centralized, with a default
+    max_name_length: int = dataclasses.field(
+        default_factory=lambda: int(os.getenv("KBENCH_MAX_NAME_LENGTH", "100"))
+    )
+```
+
+The config singleton is created at module level (`config = Config()`) and applied via `config.apply()` during library initialization. The `.env` file is loaded automatically via `python-dotenv`.
+
+### ExecutionMode
+
+The `ExecutionMode` enum (in `_config.py`) controls library behavior across different contexts:
+
+| Mode | Use Case |
+|------|----------|
+| `NOTEBOOK` / `INTERACTIVE` | Interactive notebook sessions |
+| `RUN` / `TRIAL` | Batch evaluation runs |
+| `TESTING` | Unit tests (mocked clients, no UI) |
+| `DEV` | Local development |
+| `DOC` | Documentation generation |
+
+In tests, always set `config.execution_mode = ExecutionMode.TESTING` (the `conftest.py` fixture does this automatically).
+
+---
+
+## 4. Testing
+
+### Test Structure
+
+Tests live in `tests/` and mirror the source layout. The naming convention is `test_<module>.py` for top-level modules and subdirectories for subsystems (e.g., `tests/serializers/`, `tests/actors/`).
+
+### The `context` Fixture
+
+Every test automatically uses the autouse `context` fixture from `tests/conftest.py`, which:
+- Enters a fresh execution context
+- Sets `ExecutionMode.TESTING`
+- Disables interactive mode and UI
+- Patches the client with `InMemoryClient`
+
+You don't need to set any of this up manually in your tests.
+
+### Mocking LLMs
+
+Use `MockedChat` (in `tests/mocks.py`) to simulate LLM responses without making real API calls:
+
+```python
+from tests.mocks import MockedChat
+
+# Single response
+llm = MockedChat.from_contents(["the answer is 42"])
+
+# Cycling responses (for multi-turn)
+llm = MockedChat.from_contents(["first", "second"], cycle=True)
+
+# JSON responses
+llm = MockedChat.from_contents_data([{"name": "Alice", "age": 30}])
+```
+
+The `conftest.py` provides pre-built fixtures: `duck` (responds "quack") and `goose` (responds "honk").
+
+### Cross-Provider Tests
+
+When a feature needs to work across both OpenAI and GenAI backends, write separate test cases for each serializer:
+
+```
+tests/serializers/test_genai_serializer.py
+tests/serializers/test_openai_serializer.py
+tests/test_genai_client.py
+tests/test_openai_client.py
+```
+
+### Golden Tests
+
+Golden tests (in `golden_tests/test_cookbook_examples.py`) validate end-to-end behavior against real LLM APIs. They are **not** part of the standard CI/CD pipeline (they require API keys).
+
+If your change touches serializers, actors, or the prompt pipeline, verify that golden tests still pass:
+
+```bash
+# Run all golden tests
+uv run pytest golden_tests/test_cookbook_examples.py
+
+# Run and update the report
+uv run pytest golden_tests/test_cookbook_examples.py --generate-report
+
+# Filter by API
+uv run pytest golden_tests/test_cookbook_examples.py -k "genai"
+```
+
+### Running Unit Tests
+
+```bash
+# All unit tests
+uv run --group test pytest tests
+
+# Specific file
+uv run --group test pytest tests/test_assertions.py
+
+# Verbose
+uv run --group test pytest tests -v
+```
+
+---
+
+## 5. Code Style & Tooling
+
+### Formatting and Linting
+
+The project uses **ruff** for both formatting and linting. Always run these before committing:
+
+```bash
+ruff format .          # Format code
+ruff check --fix .     # Lint + auto-fix (includes import sorting via isort)
+```
+
+Key ruff configuration from `pyproject.toml`:
+- `extend-select = ["I"]` — isort-compatible import sorting is enforced
+- `extend-exclude` — auto-generated `*_pb2.py` files are excluded
+- `__init__.py` files suppress `F401` (unused imports) and `F402` (import shadowing)
+
+### Pre-commit Hooks
+
+Install and use pre-commit hooks — they run `ruff`, `ruff-format`, and `addlicense` automatically:
+
+```bash
+pre-commit install
+pre-commit run --all-files
+```
+
+### License Headers
+
+Every `.py` file **must** have the Apache 2.0 license header. The `addlicense` pre-commit hook handles this automatically. The header format:
+
+```python
+# Copyright <year> Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# ...
+```
+
+### Type Checking
+
+The project uses **mypy**. Generated protobuf files (`*_pb2.py`) are excluded from type checking. Run with:
+
+```bash
+mypy src/
+```
+
+### Dependency Management
+
+Use **`uv`** for all dependency operations — never `pip` directly. Dependencies are organized into groups in `pyproject.toml`:
+
+| Group | Purpose |
+|-------|---------|
+| `test` | pytest and test utilities |
+| `kaggle` | Kaggle platform integration |
+| `docs` | Documentation example dependencies |
+| `dev` | All of the above + mypy, ruff, pre-commit |
+
+```bash
+# Install with dev dependencies
+uv pip install -e ".[dev]"
+
+# Run a command with a specific group
+uv run --group test pytest tests
+```
+
+> **Supply chain hardening:** The project pins an `exclude-newer` date in `pyproject.toml` to refuse packages published after that date. To upgrade dependencies, bump the date, then run `uv lock --upgrade`.
+
+---
+
+## 6. Import Conventions
+
+### Lazy Imports to Avoid Circular Dependencies
+
+The codebase uses lazy imports inside methods to break circular dependencies — especially for `ui`, `events`, `contexts`, and `llm_messages`:
+
+```python
+def respond(self, ...):
+    from kaggle_benchmarks import contexts, llm_messages  # Lazy import
+    ...
+```
+
+### `TYPE_CHECKING` for Type-Only Imports
+
+Use `if TYPE_CHECKING:` for imports that are only needed for type annotations. This is the standard pattern throughout the codebase:
+
+```python
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kaggle_benchmarks import actors
+```
+
+### Gotcha: Conditional Objects in `__init__.py`
+
+Some module-level objects (`kbench.llm`, `kbench.judge_llm`, `kbench.llms`) are only created when the Kaggle platform is configured. If you're writing examples or tests that reference these, be aware they may not exist in all environments:
+
+```python
+# ✅ Always works — import the submodule directly
+from kaggle_benchmarks import actors
+llm_chat = actors.LLMChat(...)
+
+# ⚠️ Only works when Kaggle is configured
+import kaggle_benchmarks as kbench
+kbench.llm  # AttributeError if not configured
+```
+
+---
+
+## 7. Error Handling Conventions
+
+### Exception Hierarchy
+
+The codebase defines a few custom exceptions with specific semantics:
+
+| Exception | When to Use |
+|-----------|-------------|
+| `NonRecoverableError` | Stops task execution entirely — the task cannot proceed |
+| `SchemaError` | Response parsing failures (e.g., LLM returned invalid JSON) |
+| `UnsupportedMessageFormat` | Serializer encounters an unknown message/content type |
+| `GetAssertExpressionError` | Internal — assertion source code retrieval failed |
+
+### Use `warnings.warn()` for Non-Fatal Issues
+
+For degraded functionality or deprecated behavior, use `warnings.warn()` instead of silently dropping data or raising an exception:
+
+```python
+# ✅ User sees a clear message about what happened
+warnings.warn("Reasoning traces are not available in streaming mode.")
+
+# ❌ DON'T — silently dropping data is confusing
+if not supported:
+    return  # Where did my data go?
+```
+
+### Use `logging` for Operational Messages
+
+Use the standard `logging` module for informational and diagnostic messages. Create a module-level logger:
+
+```python
+import logging
+logger = logging.getLogger(__name__)
+
+logger.info("Loading environment variables from %s", path)
+logger.warning("Reading cached run failed: %s", error)
+```
+
+---
+
+## 8. Protocol Buffers
+
+Proto definitions live in `protos/`. The generated Python files (`*_pb2.py`) are output to `src/kaggle_benchmarks/kaggle/`.
+
+**Never manually edit `*_pb2.py` files.** They are auto-generated. After editing any `.proto` file, rebuild with:
+
+```bash
+cd protos && ./build.sh
+```
+
+The build script runs `protoc` with both `--python_out` and `--mypy_out` to generate type stubs alongside the implementation.
+
+---
+
+## 9. Writing New Assertions
+
+Custom assertions use the `@assertion_handler` decorator (in `assertions.py`). The decorated function **must** be annotated to return `AssertionResult`:
+
+```python
+@assertions.assertion_handler()
+def assert_response_valid(response: str, expectation: str = "") -> assertions.AssertionResult:
+    """Verifies that the response is well-formed."""
+    passed = len(response) > 0 and not response.startswith("Error")
+    return assertions.AssertionResult(
+        passed=passed,
+        expectation=expectation or "Response should be non-empty and not an error",
+    )
+```
+
+The decorator automatically:
+- Captures the source code line that called the assertion
+- Reports results to the current run's `assertion_results`
+- Optionally raises `AssertionError` if `raises_assertion_error=True`
+
+---
+
+## 10. General Principles
+
+These are the recurring themes in code reviews. The examples are illustrative — the underlying principles apply broadly.
+
+### Respect Separation of Concerns
+
+Put code in the layer that owns that responsibility. If you're unsure, refer to the layered architecture diagram in §1.
+
+- **Example:** Provider-specific logic (like OpenAI's `detail` parameter on images) belongs in serializers, not in content types. Content types are provider-agnostic data containers.
+- **Example:** Scattered `os.getenv()` calls belong in the centralized `Config` dataclass, not spread across individual modules.
+
+### Don't Repeat Expensive Work
+
+If something can be computed once and reused, do so — especially for module-level setup.
+
+```python
+# ✅ Compile once at module level
+_PATTERN = re.compile(r"<think>.*?</think>", flags=re.DOTALL)
+
+def strip_tags(text):
+    return _PATTERN.sub("", text)
+```
+
+### Validate Ambiguous Inputs
+
+When a function accepts the same setting through multiple paths (e.g., a named parameter and a raw dict), validate for conflicts rather than silently picking one. Silent precedence rules are a source of bugs.
+
+### Document Workarounds
+
+If you introduce a temporary pattern or known limitation, leave a clear comment explaining why it exists and what the long-term fix looks like:
+
+```python
+# TODO: Remove this _meta workaround once respond() creates LLMMessage
+# instead of Message. At that point, LLMMessage.reasoning_traces
+# (the dataclass field) will be the single source of truth.
+msg._meta["reasoning_traces"] = traces
+```
+
+### Keep Documentation in Sync
+
+User-facing and public-API changes should include corresponding documentation updates in the same PR. Internal refactors don't necessarily need doc changes.
+
+---
+
+## Quick Reference Checklist
+
+Before opening a PR, verify:
+
+- [ ] `ruff format .` and `ruff check --fix .` pass cleanly
+- [ ] `uv run --group test pytest tests` — all unit tests pass
+- [ ] Golden tests verified if you touched serializers/actors/prompt pipeline
+- [ ] License header present on all `.py` files (`pre-commit run --all-files`)
+- [ ] New code lives in the correct architectural layer
+- [ ] Public API additions are intentional — they're permanent once shipped
+- [ ] Cross-provider tests exist for features that touch the LLM pipeline
+- [ ] Workarounds have explanatory comments
+- [ ] User-facing changes include documentation updates
+- [ ] Protobuf files regenerated if you edited any `.proto` file

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -1,0 +1,181 @@
+# Reviewing Code for Kaggle Benchmarks
+
+A guide for reviewers — what to look for, how to give feedback, and when to block.
+
+---
+
+## The Reviewer's Job
+
+Your goal is to keep the codebase **correct, consistent, and maintainable** while unblocking the contributor as quickly as possible. A good review does three things:
+
+1. **Catches bugs and design problems** before they ship
+2. **Teaches** — the contributor (and future readers) learn from your feedback
+3. **Stays focused** — reviews the code that's there, not the code you wish were there
+
+---
+
+## What to Look For
+
+### 1. Architecture & Layering
+
+This is the most common source of review feedback. The library has strict boundaries between layers:
+
+| Layer | Owns | Does NOT Own |
+|-------|------|-------------|
+| `content_types/` | Data representation (images, audio, video) | Provider-specific serialization |
+| `serializers/` | Message ↔ API payload translation | Business logic, LLM interaction |
+| `actors/llms.py` | LLM abstraction, `prompt()`, `respond()` | Conversation state (that's `chats.py`) |
+| `_config.py` | Centralized configuration | Per-module env var reads |
+
+**Ask yourself:** Does this code live in the right layer? If a provider-specific concept (like OpenAI's `detail` on images) is showing up in `content_types/`, that's a red flag — it belongs in the serializer.
+
+### 2. API Surface
+
+Changes to public-facing methods (`prompt()`, `assert_*`, `@task`) are effectively permanent. Scrutinize them more carefully than internal changes.
+
+**Questions to ask:**
+- Is this parameter necessary, or can the same goal be achieved via configuration or a context manager?
+- Does the parameter name match existing conventions? (e.g., `reasoning`, not `reasoning_effort` or `thinking_config`)
+- Will this be confusing alongside existing parameters?
+- If this is experimental, is it marked as such?
+
+### 3. Correctness
+
+- **Edge cases:** What happens with `None`, empty strings, malformed input? Ask explicitly — e.g., "if the input is malformed, does this return empty or raise?"
+- **Streaming vs non-streaming:** Features that work in non-streaming mode may silently break in streaming. If the PR touches the response pipeline, check both paths.
+- **Thinking traces:** If the change involves reasoning/thinking, verify that traces are separated from response content. Mixing them corrupts structured outputs and breaks assertions.
+- **Cross-provider behavior:** If it works on OpenAI, does it also work on GenAI? Are there tests for both serializer paths?
+
+### 4. Code Quality
+
+- **Workarounds documented:** If the code uses a temporary pattern or known limitation, is there a comment (e.g., `TODO`) explaining why and what the long-term fix looks like? Undocumented workarounds become mysteries for the next contributor.
+- **Performance-conscious patterns:** Watch for repeated work that could be done once (e.g., compiling regex patterns, re-reading config, redundant API calls). These aren't always blockers, but worth a `nit:` comment.
+- **No conflicting inputs:** If a function accepts the same setting through multiple paths (e.g., both a named parameter and a raw dict), is there validation to catch conflicts? Silent precedence rules are a source of bugs.
+- **Error handling:** Non-fatal issues should use `warnings.warn()`. Internal diagnostics should use `logging`. Recoverable errors should raise specific exceptions, not generic `Exception`.
+
+### 5. Tests
+
+- **Mocked correctly?** Tests should use `MockedChat`, not real API calls (those belong in `golden_tests/`).
+- **Cross-provider coverage?** Changes to the LLM pipeline should have tests in both `test_genai_serializer.py` and `test_openai_serializer.py`.
+- **Golden tests acknowledged?** If the change touches serializers/actors/prompt pipeline, the contributor should confirm golden tests still pass (even if they can't run in CI).
+
+### 6. Documentation
+
+- **Docs updated?** Every user-visible change needs corresponding documentation updates. Don't accept "I'll do it in a follow-up."
+- **Right location?** Stable features go in the cookbook. Experimental features go in an advanced usage section with a disclaimer.
+- **Examples work?** If the PR adds or modifies example code, verify the imports are correct (watch out for conditional initialization in `__init__.py`).
+
+---
+
+## How to Give Feedback
+
+### Be Specific and Actionable
+
+```
+# ❌ Vague
+"This doesn't feel right."
+
+# ✅ Specific
+"I think `api_params` belongs in the serializer, not in ImageContent.
+The content type should stay provider-agnostic. Could you move the
+parameter handling to GenAISerializer.dump_image() instead?"
+```
+
+### Distinguish Severity
+
+Use prefixes to signal how important a comment is:
+
+- **`nit:`** — Style or minor improvement. Not a blocker. (e.g., "nit: `Verifies` instead of `Verify`?")
+- **`suggestion:`** — An alternative approach worth considering, but the current code is acceptable.
+- **`question:`** — You need clarification before you can approve. (e.g., "Just to confirm, should this be `not in (None, 'none')`?")
+- **(no prefix)** — A problem that should be fixed before merging.
+
+### Ask Questions, Don't Just Assert
+
+When you're unsure about intent, ask before prescribing:
+
+```
+# ✅ Good
+"Just to confirm my understanding — we'll switch to reasoning_traces
+when we move from Message to LLMMessage later? If so, worth a TODO here."
+
+# ❌ Less good
+"This is wrong, it should use LLMMessage.reasoning_traces."
+```
+
+### Acknowledge Good Work
+
+A quick "LGTM — thanks for making this more robust!" goes a long way, especially on PRs that went through multiple revision rounds.
+
+---
+
+## Handling Scope and Disagreements
+
+### Keep PRs Focused
+
+If a reviewer spots an improvement opportunity that's unrelated to the PR's goal, don't ask the contributor to fix it in the same PR. Instead:
+
+- File it as a separate issue or note it as a follow-up
+- Comment: "This is unrelated to this PR, but we should discuss [X] separately"
+
+### When You Disagree with the Approach
+
+1. **State your concern clearly** with a concrete alternative
+2. **Listen to the response** — the contributor may have context you don't
+3. **Escalate only if it's architectural** — if it affects the library's public API or layering, bring in a second reviewer
+4. **Accept "good enough"** for non-architectural concerns — perfect is the enemy of shipped
+
+### When to Block vs. Approve-with-Comments
+
+**Block (Request Changes)** when:
+- The change breaks existing behavior or tests
+- Provider-specific logic is leaking into the wrong layer
+- The public API surface is expanding without clear justification
+- Thinking traces are mixed into response content
+- Tests are missing for a new code path
+
+**Approve with Comments** when:
+- Only nits and style suggestions remain
+- The approach is sound but has minor rough edges
+- Documentation could be slightly better but isn't misleading
+- You've suggested a TODO and the contributor agrees to add it
+
+---
+
+## Review Checklist
+
+A quick reference for each review pass:
+
+```
+Architecture
+  □ Code lives in the correct layer (content types / serializers / actors)
+  □ No provider-specific logic in content types
+  □ LLMChat stays stateless — no new state stored on the actor
+
+API Surface
+  □ New public parameters are intentional and well-named
+  □ Naming is consistent with existing conventions
+  □ Experimental features are clearly marked
+
+Correctness
+  □ Edge cases handled (None, empty, malformed)
+  □ Streaming and non-streaming paths both work
+  □ Thinking traces separated from content
+  □ No silent data loss
+
+Tests
+  □ Unit tests cover the new/changed behavior
+  □ Cross-provider tests exist (GenAI + OpenAI)
+  □ Golden test impact acknowledged
+
+Code Quality
+  □ Workarounds have explanatory comments (TODOs, etc.)
+  □ No obvious repeated work that could be done once
+  □ Config uses the Config dataclass, not scattered os.getenv()
+  □ License header present
+
+Documentation
+  □ Docs updated alongside the feature
+  □ Experimental features in advanced section, not cookbook
+  □ Examples use correct imports
+```


### PR DESCRIPTION
## Summary

Add two new guides synthesized from established architectural patterns and recent code review feedback:

### New Files

- **`DEVELOPMENT.md`** — A practical guide for contributors covering:
  - Project architecture and layered design (content types → serializers → actors → providers)
  - Design principles (provider-agnostic content types, stateless LLMChat, unified parameters)
  - Configuration patterns (centralized `Config` dataclass)
  - Testing conventions (MockedChat, cross-provider tests, golden tests)
  - Code style and tooling (ruff, mypy, pre-commit, license headers)
  - Import conventions and common gotchas
  - Error handling patterns
  - Protocol Buffers workflow
  - General principles and a PR checklist

- **`REVIEWING.md`** — A guide for reviewers covering:
  - What to look for (architecture, API surface, correctness, code quality, tests, docs)
  - How to give actionable feedback with severity prefixes (`nit:`, `suggestion:`, `question:`)
  - Handling scope and disagreements
  - When to block vs. approve-with-comments
  - A quick-reference review checklist

### Modified Files

- **`CONTRIBUTING.md`** — Added a 'Development resources' section linking to both new guides.

### Motivation

- These guides capture institutional knowledge that was previously only communicated through PR review comments. Having them documented should reduce onboarding time for new contributors and lead to more consistent PRs.
- Also useful for agents.