### PR TITLE
Coerce nested evaluate() max_attempts to 1 with warning

### DIFF
--- a/quick_start.md
+++ b/quick_start.md
@@ -380,8 +380,7 @@ def multi_qa_task(llm, df) -> tuple[float, float]:
     with kbench.client.enable_cache():
         runs = single_qa_task.evaluate(
             stop_condition=lambda runs: len(runs) == df.shape[0],
-            max_attempts=50,
-            retry_delay=15,
+            max_attempts=1,
             llm=[llm],
             evaluation_data=df,
             n_jobs=2,

--- a/src/kaggle_benchmarks/tasks.py
+++ b/src/kaggle_benchmarks/tasks.py
@@ -174,6 +174,9 @@ class Task(Generic[T]):
                             condition is met.
             max_attempts: The maximum number of evaluation attempts.
                           Defaults to 1 (no retries).
+                          Note: Nested task evaluations always run with
+                          `max_attempts=1` regardless of the value passed;
+                          a warning is logged if a different value is provided.
             retry_delay: The delay in seconds between retry attempts.
             remove_run_files: Remove generated run files when done.
             **kwargs: Alternative way to specify the parameter grid.
@@ -187,9 +190,11 @@ class Task(Generic[T]):
 
         ctx = contexts.get_current()
         if ctx.parent and ctx.parent.run and max_attempts > 1:
-            raise NonRecoverableError(
-                "`max_attempts` must be 1 for nested task evaluations. Retries are not supported in this context."
+            logger.warning(
+                "`max_attempts` must be 1 for nested task evaluations; coercing from %d to 1.",
+                max_attempts,
             )
+            max_attempts = 1
 
         if grid is None:
             grid = kwargs

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -356,18 +356,25 @@ def test_partial():
     assert partial.run(x=1, y=2).result == 3
 
 
-def test_nested_task_evaluate_with_retries_fails(duck):
+def test_nested_task_evaluate_with_retries_coerces_to_one(duck, caplog):
     @tasks.task()
     def single_task(llm, x):
         return llm.prompt(str(x))
 
     @tasks.task()
     def multi_task(llm, df):
-        single_task.evaluate(llm=[llm], evaluation_data=df, max_attempts=2)
+        return single_task.evaluate(
+            llm=[llm], evaluation_data=df, max_attempts=2
+        )
 
     df = pd.DataFrame({"x": [1, 2, 3]})
-    with pytest.raises(
-        tasks.NonRecoverableError,
-        match="`max_attempts` must be 1 for nested task evaluations.",
-    ):
-        multi_task.run(duck, df)
+    with caplog.at_level("WARNING", logger="kaggle_benchmarks.tasks"):
+        run = multi_task.run(duck, df)
+
+    assert any(
+        "`max_attempts` must be 1 for nested task evaluations" in record.message
+        for record in caplog.records
+    )
+    nested_runs = run.result
+    assert isinstance(nested_runs, runs.Runs)
+    assert len(nested_runs) == df.shape[0]


### PR DESCRIPTION
Calling `Task.evaluate(max_attempts=N>1)` from inside another task's
run context previously raised `NonRecoverableError`, which forced
users to special-case nested evaluations. Log a warning and silently
coerce to 1 instead so existing scripts (including the quick-start
example) keep working. Updates the docstring, test, and quick-start
example accordingly.

Co-authored-by: kaggle-agent <kaggle-agent@users.noreply.github.com>

---

Task: [limagoog-20260427161007-fa960377](https://agents.dev.kaggle.net/tasks/limagoog-20260427161007-fa960377)
Context: https://chat.kaggle.net/kaggle/pl/k5mhb7fc6i8wiyt5pufb9ebwaw

