### PR TITLE
Drop noisy log when no .env file is found

### DIFF
--- a/src/kaggle_benchmarks/_config.py
+++ b/src/kaggle_benchmarks/_config.py
@@ -28,8 +28,6 @@ _logger = logging.getLogger(__name__)
 if _dotenv_path := dotenv.find_dotenv():
     _logger.info("Loading environment variables from %s", _dotenv_path)
     dotenv.load_dotenv(_dotenv_path, override=True)
-else:
-    _logger.info("No .env file found; skipping dotenv load")
 
 
 def string_to_bool(s: str) -> bool:


### PR DESCRIPTION
Removes the else-branch log message added in #140. Per review
feedback, there's no value in logging when no .env file is present —
it's the common case and just adds noise.

Co-authored-by: kaggle-agent <kaggle-agent@users.noreply.github.com>

---

Task: [limagoog-20260427181713-d811d1fd](https://agents.dev.kaggle.net/tasks/limagoog-20260427181713-d811d1fd)
Context: https://chat.kaggle.net/kaggle/pl/iyr8ioycotb97qw3u6tzjungio

