### PR TITLE
Initial implementation for console output for Benchmarks SDK

### DIFF
--- a/src/kaggle_benchmarks/_config.py
+++ b/src/kaggle_benchmarks/_config.py
@@ -16,11 +16,11 @@ import dataclasses
 import enum
 import logging
 import os
+import sys
 from pathlib import Path
 from typing import Any, Self, overload
 
 import dotenv
-import panel as pn
 
 base_dir = Path(__file__).parent.parent.parent
 
@@ -52,6 +52,27 @@ def _parse_int_env(name: str, default: int | None = None) -> int | None:
             f"Ignoring non-integer value for {name}={raw!r}; using {default}."
         )
         return default
+
+def _is_notebook_environment() -> bool:
+    """Detects if code is running inside a Jupyter notebook/lab kernel.
+
+    Avoids importing IPython if it isn't already loaded — a CLI process won't
+    have it in sys.modules, so we can short-circuit without triggering
+    IPython's (sometimes broken) import side effects.
+    """
+    if "IPython" not in sys.modules:
+        return False
+    try:
+        from IPython.core.getipython import get_ipython
+
+        ip = get_ipython()
+        if ip is None:
+            return False
+        # ZMQInteractiveShell = Jupyter notebook/lab kernel
+        # TerminalInteractiveShell = ipython CLI (not a notebook)
+        return type(ip).__name__ == "ZMQInteractiveShell"
+    except ImportError:
+        return False
 
 
 class ExecutionMode(enum.Enum):
@@ -128,17 +149,66 @@ class Config:
 
     show_message_details: bool = False
 
-    def apply(self) -> Self:
-        pn.config.theme = self.ui_theme  # type: ignore
+    console_mode: bool = dataclasses.field(
+        default_factory=lambda: string_to_bool(
+            os.environ.get("BENCHMARK_CONSOLE_UI", "False")
+        )
+    )
+    console_quiet: bool = dataclasses.field(
+        default_factory=lambda: string_to_bool(
+            os.environ.get("BENCHMARK_CONSOLE_QUIET", "False")
+        )
+    )
+    # None = auto-detect from TTY; True/False forces on/off
+    console_color: bool | None = dataclasses.field(
+        default_factory=lambda: (
+            string_to_bool(os.environ["BENCHMARK_CONSOLE_COLOR"])
+            if "BENCHMARK_CONSOLE_COLOR" in os.environ
+            else None
+        )
+    )
 
+    def apply(self) -> Self:
         if self.suppress_ui_warnings:
             logger = logging.getLogger("bokeh")
             logger.setLevel(logging.ERROR)
-        if self.interactive_mode:
-            from kaggle_benchmarks import events, ui
+
+        # Resolve which UI to use: explicit settings take priority,
+        # otherwise auto-detect based on environment.
+        use_panel = self.interactive_mode
+        use_console = self.console_mode
+
+        if not use_panel and not use_console and self.execution_mode != ExecutionMode.TESTING:
+            # Auto-detect: notebook -> PanelUI, otherwise -> ConsoleUI
+            if _is_notebook_environment():
+                use_panel = True
+            else:
+                use_console = True
+
+        if use_panel:
+            import panel as pn
+
+            pn.config.theme = self.ui_theme  # type: ignore
+            from kaggle_benchmarks import events
+            from kaggle_benchmarks.ui import (  # noqa: F401
+                ipython_magics,
+                panel,
+                setup_panel,
+            )
 
             if self.ui_handler is None:
-                self.ui_handler = ui.panel.PanelUI()
+                self.ui_handler = panel.PanelUI()
+                events.manager.bind(self.ui_handler)
+
+        elif use_console:
+            from kaggle_benchmarks import events
+            from kaggle_benchmarks.ui import console
+
+            if not isinstance(self.ui_handler, console.ConsoleUI):
+                self.ui_handler = console.ConsoleUI(
+                    quiet=self.console_quiet,
+                    color=self.console_color,
+                )
                 events.manager.bind(self.ui_handler)
 
         return self
@@ -160,6 +230,13 @@ class Config:
 
     def enable_interactive_mode(self):
         self.interactive_mode = True
+        self.apply()
+
+    def enable_console_mode(self, quiet: bool = False, color: bool | None = None):
+        self.console_mode = True
+        self.console_quiet = quiet
+        self.console_color = color
+        self.interactive_mode = False
         self.apply()
 
     def disable_tqdm(self):

--- a/src/kaggle_benchmarks/_config.py
+++ b/src/kaggle_benchmarks/_config.py
@@ -53,26 +53,41 @@ def _parse_int_env(name: str, default: int | None = None) -> int | None:
         )
         return default
 
-def _is_notebook_environment() -> bool:
-    """Detects if code is running inside a Jupyter notebook/lab kernel.
+class HostEnvironment(enum.Enum):
+    """Where the SDK is running. Used to pick the right UI + bokeh comms."""
+
+    TERMINAL = "terminal"              # CLI / script / IPython terminal
+    JUPYTER = "jupyter"                # JupyterLab / classic notebook kernel
+    VSCODE_NOTEBOOK = "vscode_notebook"  # Jupyter kernel hosted by VSCode
+
+
+def detect_host_environment() -> HostEnvironment:
+    """Detects the host environment (terminal, Jupyter kernel, or VSCode kernel).
 
     Avoids importing IPython if it isn't already loaded — a CLI process won't
     have it in sys.modules, so we can short-circuit without triggering
     IPython's (sometimes broken) import side effects.
+
+    VSCode injects VSCODE_PID / VSCODE_IPC_HOOK_CLI into kernel processes;
+    JupyterLab does not.
     """
     if "IPython" not in sys.modules:
-        return False
+        return HostEnvironment.TERMINAL
     try:
         from IPython.core.getipython import get_ipython
 
         ip = get_ipython()
-        if ip is None:
-            return False
-        # ZMQInteractiveShell = Jupyter notebook/lab kernel
-        # TerminalInteractiveShell = ipython CLI (not a notebook)
-        return type(ip).__name__ == "ZMQInteractiveShell"
     except ImportError:
-        return False
+        return HostEnvironment.TERMINAL
+    if ip is None:
+        return HostEnvironment.TERMINAL
+    # ZMQInteractiveShell = Jupyter notebook/lab kernel
+    # TerminalInteractiveShell = ipython CLI (not a notebook)
+    if type(ip).__name__ != "ZMQInteractiveShell":
+        return HostEnvironment.TERMINAL
+    if "VSCODE_PID" in os.environ or "VSCODE_IPC_HOOK_CLI" in os.environ:
+        return HostEnvironment.VSCODE_NOTEBOOK
+    return HostEnvironment.JUPYTER
 
 
 class ExecutionMode(enum.Enum):
@@ -179,11 +194,11 @@ class Config:
         use_console = self.console_mode
 
         if not use_panel and not use_console and self.execution_mode != ExecutionMode.TESTING:
-            # Auto-detect: notebook -> PanelUI, otherwise -> ConsoleUI
-            if _is_notebook_environment():
-                use_panel = True
-            else:
+            # Auto-detect: any notebook kernel -> PanelUI, otherwise -> ConsoleUI
+            if detect_host_environment() == HostEnvironment.TERMINAL:
                 use_console = True
+            else:
+                use_panel = True
 
         if use_panel:
             import panel as pn
@@ -196,7 +211,9 @@ class Config:
                 setup_panel,
             )
 
-            if self.ui_handler is None:
+            if not isinstance(self.ui_handler, panel.PanelUI):
+                if self.ui_handler is not None:
+                    events.manager.unbind(self.ui_handler)
                 self.ui_handler = panel.PanelUI()
                 events.manager.bind(self.ui_handler)
 
@@ -205,6 +222,8 @@ class Config:
             from kaggle_benchmarks.ui import console
 
             if not isinstance(self.ui_handler, console.ConsoleUI):
+                if self.ui_handler is not None:
+                    events.manager.unbind(self.ui_handler)
                 self.ui_handler = console.ConsoleUI(
                     quiet=self.console_quiet,
                     color=self.console_color,
@@ -237,6 +256,10 @@ class Config:
         self.console_quiet = quiet
         self.console_color = color
         self.interactive_mode = False
+        self.apply()
+
+    def disable_console_mode(self):
+        self.console_mode = False
         self.apply()
 
     def disable_tqdm(self):

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -267,10 +267,18 @@ class LLMChat(actors.Actor):
             response._meta["tool_calls"] = invoke_response.tool_calls
             response._meta.update(invoke_response.meta)
             response._meta["reasoning_traces"] = invoke_response.reasoning_traces
+            response.status = utils.Status.SUCCESS
+            chat.append(response)
         elif isinstance(invoke_response, Iterator):
+            # Append before streaming so UIs see new_message (with empty
+            # content + RUNNING status) before chunks arrive — lets them
+            # render the message header before tokens stream in.
+            chat.append(response)
             response.stream(invoke_response)
+            response.status = utils.Status.SUCCESS
         elif isinstance(invoke_response, llm_messages.LLMMessage):
             response = invoke_response
+            chat.append(response)
         else:
             raise TypeError("Unknown response type from LLM.")
 
@@ -293,10 +301,11 @@ class LLMChat(actors.Actor):
             raise e
 
         except StopIteration as e:
-            # StopIteration is expected as this is how you get returned value from a generator
+            # StopIteration is expected as this is how you get returned value
+            # from a generator. The message has already been appended and its
+            # status set above; here we just refine .content to the parsed
+            # schema value (may differ from the raw text the UI rendered).
             response.content = e.value
-            chat.append(response)
-            response.status = utils.Status.SUCCESS
 
         return response
 

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -295,8 +295,8 @@ class LLMChat(actors.Actor):
         except StopIteration as e:
             # StopIteration is expected as this is how you get returned value from a generator
             response.content = e.value
-            response.status = utils.Status.SUCCESS
             chat.append(response)
+            response.status = utils.Status.SUCCESS
 
         return response
 

--- a/src/kaggle_benchmarks/assertions.py
+++ b/src/kaggle_benchmarks/assertions.py
@@ -22,7 +22,6 @@ import textwrap
 import uuid
 from typing import Any, Callable, Iterable, Type
 
-import panel as pn
 import pydantic
 
 from kaggle_benchmarks import chats
@@ -36,8 +35,10 @@ class AssertionResult:
     details: dict[str, Any] | None = None
     id: str = dataclasses.field(default_factory=lambda: uuid.uuid4().hex)
 
-    def __panel__(self) -> pn.viewable.Viewable:
+    def __panel__(self):
         """Custom Panel representation for an AssertionResult."""
+        import panel as pn
+
         status_icon = "✅" if self.passed else "❌"
         title_color = "green" if self.passed else "red"
 

--- a/src/kaggle_benchmarks/content_types/audios.py
+++ b/src/kaggle_benchmarks/content_types/audios.py
@@ -16,7 +16,6 @@ import base64
 import mimetypes
 
 import httpx
-import panel as pn
 
 
 class AudioContent:
@@ -59,8 +58,10 @@ class AudioContent:
             html += f"\n\n{self.caption}"
         return html
 
-    def __panel__(self) -> pn.viewable.Viewable:
+    def __panel__(self):
         """Renders the audio using a Panel HTML pane."""
+        import panel as pn
+
         html = f'<audio controls src="{self.url}"></audio>'
         if self.caption:
             html += f"<p>{self.caption}</p>"

--- a/src/kaggle_benchmarks/content_types/images.py
+++ b/src/kaggle_benchmarks/content_types/images.py
@@ -20,7 +20,6 @@ import mimetypes
 
 import httpx
 import numpy as np
-import panel as pn
 
 
 class ImageContent(abc.ABC):
@@ -62,8 +61,10 @@ class ImageURL(ImageContent):
     def url(self) -> str:
         return self._url
 
-    def __panel__(self) -> pn.viewable.Viewable:
+    def __panel__(self):
         """Renders the image using a Panel Image pane."""
+        import panel as pn
+
         return pn.pane.image.Image(self.url)
 
     @property

--- a/src/kaggle_benchmarks/content_types/videos.py
+++ b/src/kaggle_benchmarks/content_types/videos.py
@@ -16,8 +16,6 @@ import abc
 import mimetypes
 import re
 
-import panel as pn
-
 _YOUTUBE_URL_PATTERN = re.compile(
     r"^https?://(?:www\.)?(?:youtube\.com/(?:watch\?v=|shorts/)|youtu\.be/)[\w-]+"
 )
@@ -49,8 +47,10 @@ class VideoURL(VideoContent):
     def url(self) -> str:
         return self._url
 
-    def __panel__(self) -> pn.viewable.Viewable:
+    def __panel__(self):
         """Renders the video as a clickable link."""
+        import panel as pn
+
         return pn.pane.HTML(f'<a href="{self.url}" target="_blank">{self.url}</a>')
 
     @property

--- a/src/kaggle_benchmarks/llm_messages.py
+++ b/src/kaggle_benchmarks/llm_messages.py
@@ -84,6 +84,6 @@ class LLMMessage(messages.Message[T]):
         return obj
 
     def __panel__(self):
-        from kaggle_benchmarks import ui
+        from kaggle_benchmarks.ui import panel
 
-        return ui.panel.render_llm_message(self)
+        return panel.render_llm_message(self)

--- a/src/kaggle_benchmarks/messages.py
+++ b/src/kaggle_benchmarks/messages.py
@@ -100,9 +100,9 @@ class Message(Generic[T]):
         return self.text
 
     def __panel__(self):
-        from kaggle_benchmarks import ui
+        from kaggle_benchmarks.ui import panel
 
-        return ui.panel.render_message(self)
+        return panel.render_message(self)
 
     def _repr_mimebundle_(self, include=None, exclude=None):
         return self.__panel__()._repr_mimebundle_(include, exclude)

--- a/src/kaggle_benchmarks/runs.py
+++ b/src/kaggle_benchmarks/runs.py
@@ -155,9 +155,9 @@ class Run(Generic[T]):
         return self.task.result_type.format(self)
 
     def __panel__(self):
-        from kaggle_benchmarks import ui
+        from kaggle_benchmarks.ui import panel
 
-        return ui.panel.render_run(self)
+        return panel.render_run(self)
 
     def _repr_mimebundle_(self, include=None, exclude=None):
         return self.__panel__()._repr_mimebundle_(include, exclude)
@@ -193,7 +193,7 @@ class Runs(Generic[T], abc.MutableSequence):
         ).set_index("run_id")
 
     def group_by(self, by="llm"):
-        from kaggle_benchmarks import ui
+        from kaggle_benchmarks.ui import panel
 
         runs = []
         for run in self.runs:
@@ -208,21 +208,21 @@ class Runs(Generic[T], abc.MutableSequence):
             key = f"{run.task.name}\n{params}"
             groups.setdefault(key, {})[str(run.params[by])] = run
 
-        return ui.panel.render_groups(groups=groups)
+        return panel.render_groups(groups=groups)
 
     def pivot(self, by: str = "llm", mode: Literal["tabs", "columns"] = "columns"):
-        from kaggle_benchmarks import ui
+        from kaggle_benchmarks.ui import panel
 
         groups: dict[Any, dict[str, Run]] = {}
         for run in self.runs:
             groups.setdefault(run.params[by], {})[run.param_id] = run
 
-        return ui.panel.render_pivot(groups, mode=mode)
+        return panel.render_pivot(groups, mode=mode)
 
     def __panel__(self):
-        from kaggle_benchmarks import ui
+        from kaggle_benchmarks.ui import panel
 
-        return ui.panel.render_runs(self)
+        return panel.render_runs(self)
 
     def _repr_mimebundle_(self, include=None, exclude=None):
         return self.__panel__()._repr_mimebundle_(include, exclude)

--- a/src/kaggle_benchmarks/ui/__init__.py
+++ b/src/kaggle_benchmarks/ui/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kaggle_benchmarks.ui import console, ipython_magics, panel, setup_panel
+from kaggle_benchmarks.ui import console

--- a/src/kaggle_benchmarks/ui/console.py
+++ b/src/kaggle_benchmarks/ui/console.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import os
 import shutil
 import sys
 import textwrap
@@ -50,7 +52,6 @@ def _supports_color(stream) -> bool:
     Disables color when NO_COLOR is set (https://no-color.org), forces it on
     when FORCE_COLOR is set, otherwise enables only for TTYs.
     """
-    import os
     if os.environ.get("NO_COLOR"):
         return False
     if os.environ.get("FORCE_COLOR"):
@@ -79,6 +80,11 @@ class ConsoleUI:
         self._c = _Colors() if self.color else _NoColors()
         self._in_run = False
         self._run_depth = 0
+        # Tracks message ids whose body was already rendered via new_chunk
+        # events; new_message skips the eager body print for these so the
+        # text isn't duplicated. Stores id(message) to avoid pinning Message
+        # objects in memory.
+        self._streamed_messages: set[int] = set()
 
     @property
     def width(self) -> int:
@@ -139,6 +145,9 @@ class ConsoleUI:
         result_width = 8  # "✅ PASS" / "❌ FAIL"
         effective_width = self.width - self._run_depth * self.tab_size
         expect_width = effective_width - line_width - result_width - 4  # 2x2 gaps
+        # Floor at 10 so textwrap.wrap doesn't blow up (raises ValueError on
+        # width<=0) when the terminal is narrow or run depth is deep.
+        expect_width = max(expect_width, 10)
         sep_line = self._colorize("-" * effective_width, c.DIM)
 
         lines = []
@@ -197,6 +206,9 @@ class ConsoleUI:
 
     def _quiet_new_message(self, chat, message):
         if isinstance(message, chats.Chat):
+            return
+        # If this message was streamed, chunks already rendered the body.
+        if id(message) in self._streamed_messages:
             return
         print(
             message.__str__(indent=" " * (self.depth * self.tab_size)),
@@ -290,7 +302,6 @@ class ConsoleUI:
         if isinstance(content, str):
             text = content
         elif hasattr(content, "model_dump"):
-            import json
             text = json.dumps(content.model_dump(), default=str)
         else:
             text = str(content)
@@ -316,38 +327,45 @@ class ConsoleUI:
             self._quiet_new_message(chat, message)
             return
 
-        # Skip assertion result messages -- they're shown in the assertion table
+        # Skip assertion result messages -- they're shown in the assertion
+        # table. Everything else falls through to the role-based rendering
+        # below; in particular, messages with is_visible_to_llm=False (e.g.
+        # tool/debug output) are still useful to surface in the console.
         if isinstance(message.content, assertions.AssertionResult):
-            return
-        # Skip messages not visible to LLM (internal framework messages)
-        if not message.is_visible_to_llm:
             return
 
         c = self._c
         role = message.sender.role
         name = message.sender.name
         text = self._format_content(message.content)
+        # Print body unless chunks already streamed it. Header still prints
+        # so the [ROLE] label appears above the streamed tokens regardless
+        # of whether append happened before or after stream().
+        print_body = bool(text) and id(message) not in self._streamed_messages
 
         if role == "user":
             self._print(self._colorize("\n[PROMPT]", c.CYAN))
-            self._print(text)
+            if print_body:
+                self._print(text)
         elif role == "assistant":
             self._print(self._colorize(f"\n[RESPONSE: {name}]", c.CYAN))
-            # Print eagerly if content is already populated (non-streaming path);
-            # otherwise let new_chunk handlers stream it in.
-            if text:
+            if print_body:
                 self._print(text)
         elif role == "system":
             self._print(self._colorize("\n[SYSTEM]", c.DIM))
-            self._print(text)
+            if print_body:
+                self._print(text)
         elif role == "tool":
             self._print(self._colorize(f"\n[TOOL: {name}]", c.DIM))
-            self._print(text)
+            if print_body:
+                self._print(text)
         else:
             self._print(f"\n[{name}]")
-            self._print(text)
+            if print_body:
+                self._print(text)
 
     def new_chunk(self, message, chunk):
+        self._streamed_messages.add(id(message))
         if self.quiet:
             self._quiet_new_chunk(message, chunk)
             return
@@ -356,19 +374,11 @@ class ConsoleUI:
             print(chunk_text, end="", flush=True, file=self._output)
 
     def end_content(self, message):
-        c = self._c
         if self.quiet:
             self._quiet_end_content(message)
             return
         with self._lock:
             print(file=self._output)
-
-        # Print metrics if available
-        if not self._in_run:
-            return
-        usage = message.usage
-        if usage is None:
-            return
-        usage_str = self._format_usage(usage)
-        if usage_str:
-            self._print(f"\n{self._colorize('METRICS:', c.BOLD)}  {usage_str}")
+        # Per-message metrics intentionally omitted: end_run prints the
+        # aggregate METRICS line from chat.usage. Printing here would
+        # double up for assistant-role messages.

--- a/src/kaggle_benchmarks/ui/console.py
+++ b/src/kaggle_benchmarks/ui/console.py
@@ -139,7 +139,7 @@ class ConsoleUI:
         result_width = 8  # "✅ PASS" / "❌ FAIL"
         effective_width = self.width - self._run_depth * self.tab_size
         expect_width = effective_width - line_width - result_width - 4  # 2x2 gaps
-        sep_line = "-" * effective_width
+        sep_line = self._colorize("-" * effective_width, c.DIM)
 
         lines = []
         lines.append("")
@@ -247,7 +247,7 @@ class ConsoleUI:
         if run.chat and run.chat.usage:
             usage_str = self._format_usage(run.chat.usage)
             if usage_str:
-                self._print(f"\nMETRICS:  {usage_str}")
+                self._print(f"\n{self._colorize('METRICS:', c.BOLD)}  {usage_str}")
 
         # Result or error
         if run.status == utils.Status.FAILED:
@@ -255,7 +255,7 @@ class ConsoleUI:
             self._print(self._colorize(f"ERROR:    {error_msg}", c.RED))
         else:
             result_str = run.format_result().strip()
-            self._print(f"RESULT:   {result_str}")
+            self._print(f"{self._colorize('RESULT:', c.BOLD)}   {result_str}")
 
         # Closing bar
         if self._run_depth == 0:
@@ -356,6 +356,7 @@ class ConsoleUI:
             print(chunk_text, end="", flush=True, file=self._output)
 
     def end_content(self, message):
+        c = self._c
         if self.quiet:
             self._quiet_end_content(message)
             return
@@ -370,4 +371,4 @@ class ConsoleUI:
             return
         usage_str = self._format_usage(usage)
         if usage_str:
-            self._print(f"\nMETRICS:  {usage_str}")
+            self._print(f"\n{self._colorize('METRICS:', c.BOLD)}  {usage_str}")

--- a/src/kaggle_benchmarks/ui/console.py
+++ b/src/kaggle_benchmarks/ui/console.py
@@ -12,31 +12,362 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kaggle_benchmarks import chats, messages, utils
+import shutil
+import sys
+import textwrap
+import threading
+
+from kaggle_benchmarks import assertions, chats, utils
+
+_DEFAULT_MIN_WIDTH = 40
+_DEFAULT_MAX_WIDTH = 120
+_FALLBACK_WIDTH = 80
+
+
+class _Colors:
+    GREEN = "\033[32m"
+    RED = "\033[31m"
+    CYAN = "\033[36m"
+    YELLOW = "\033[33m"
+    BOLD = "\033[1m"
+    DIM = "\033[2m"
+    RESET = "\033[0m"
+
+
+class _NoColors:
+    GREEN = ""
+    RED = ""
+    CYAN = ""
+    YELLOW = ""
+    BOLD = ""
+    DIM = ""
+    RESET = ""
+
+
+def _supports_color(stream) -> bool:
+    """Auto-detect whether the given stream supports ANSI colors.
+
+    Disables color when NO_COLOR is set (https://no-color.org), forces it on
+    when FORCE_COLOR is set, otherwise enables only for TTYs.
+    """
+    import os
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("FORCE_COLOR"):
+        return True
+    return hasattr(stream, "isatty") and stream.isatty()
 
 
 class ConsoleUI:
-    def __init__(self, tab_size: int = 2):
+    def __init__(
+        self, tab_size: int = 2, quiet: bool = False, color: bool | None = None,
+        width: int | None = None, min_width: int = _DEFAULT_MIN_WIDTH,
+        max_width: int = _DEFAULT_MAX_WIDTH, output=None,
+    ):
         self.depth = 0
         self.tab_size = tab_size
+        self.quiet = quiet
+        self._output = output or sys.stdout
+        # Auto-detect color from TTY if not explicitly set
+        self.color = _supports_color(self._output) if color is None else color
+        # If width is None, auto-detect from terminal size on each access,
+        # clamped to [min_width, max_width]. Otherwise use the fixed value.
+        self._fixed_width = width
+        self.min_width = min_width
+        self.max_width = max_width
+        self._lock = threading.Lock()
+        self._c = _Colors() if self.color else _NoColors()
+        self._in_run = False
+        self._run_depth = 0
 
-    def new_chat(self, chat: chats.Chat):
-        print(chat.__str__(indent=" " * (self.depth * self.tab_size)), end="")
+    @property
+    def width(self) -> int:
+        if self._fixed_width is not None:
+            return self._fixed_width
+        try:
+            cols = shutil.get_terminal_size(fallback=(_FALLBACK_WIDTH, 24)).columns
+        except (OSError, ValueError):
+            cols = _FALLBACK_WIDTH
+        return max(self.min_width, min(self.max_width, cols))
+
+    # -- Internal helpers --
+
+    def _print(self, *args, **kwargs):
+        kwargs.setdefault("file", self._output)
+        indent = " " * (self._run_depth * self.tab_size) if self._run_depth > 0 else ""
+        with self._lock:
+            if indent and args:
+                # Indent every line of multi-line content
+                text = str(args[0])
+                indented = "\n".join(
+                    indent + line if line else line
+                    for line in text.splitlines()
+                )
+                print(indented, *args[1:], **kwargs)
+            else:
+                print(*args, **kwargs)
+
+    def _header_bar(self, char="="):
+        return char * self.width
+
+    def _colorize(self, text, color_code):
+        if not self.color:
+            return text
+        return f"{color_code}{text}{self._c.RESET}"
+
+    def _format_usage(self, usage):
+        parts = []
+        if usage.input_tokens is not None:
+            parts.append(f"Input: {usage.input_tokens}")
+        if usage.output_tokens is not None:
+            parts.append(f"Output: {usage.output_tokens}")
+        if usage.total_cost_nanodollars is not None:
+            cost_dollars = usage.total_cost_nanodollars / 1e9
+            parts.append(f"Cost: ${cost_dollars:.6f}")
+        if usage.total_backend_latency_ms is not None:
+            parts.append(f"Latency: {usage.total_backend_latency_ms}ms")
+        if not parts:
+            return ""
+        return " · ".join(parts)
+
+    def _format_assertion_table(self, assertion_results):
+        if not assertion_results:
+            return ""
+
+        c = self._c
+        line_width = 6
+        result_width = 8  # "✅ PASS" / "❌ FAIL"
+        effective_width = self.width - self._run_depth * self.tab_size
+        expect_width = effective_width - line_width - result_width - 4  # 2x2 gaps
+        sep_line = "-" * effective_width
+
+        lines = []
+        lines.append("")
+        lines.append(sep_line)
+        lines.append(
+            f"{'Line':>{line_width}}  {'Expectation':<{expect_width}}  Result"
+        )
+        lines.append(sep_line)
+
+        for result in assertion_results:
+            expectation = result.expectation or ""
+            line_no = ""
+            if result.details:
+                ln = result.details.get("line_number")
+                if ln is not None:
+                    line_no = str(ln)
+
+            assert_type = ""
+            if result.details:
+                assert_type = result.details.get("assertion_type", "")
+            if assert_type:
+                expectation = f"{assert_type}: {expectation}" if expectation else assert_type
+
+            if result.passed:
+                status = self._colorize("✅ Pass", c.GREEN)
+            else:
+                status = self._colorize("❌ Fail", c.RED)
+
+            wrapped = textwrap.wrap(expectation, width=expect_width) or [""]
+
+            line_no_cell = self._colorize(f"{line_no:>{line_width}}", c.BOLD)
+            lines.append(
+                f"{line_no_cell}  {wrapped[0]:<{expect_width}}  {status}"
+            )
+            for continuation in wrapped[1:]:
+                lines.append(
+                    f"{'':>{line_width}}  {continuation:<{expect_width}}"
+                )
+
+        lines.append(sep_line)
+        return "\n".join(lines)
+
+    # -- Quiet mode handlers (original behavior) --
+
+    def _quiet_new_chat(self, chat):
+        print(
+            chat.__str__(indent=" " * (self.depth * self.tab_size)),
+            end="",
+            file=self._output,
+        )
         self.depth += 1
 
-    def end_chat(self, chat: chats.Chat):
+    def _quiet_end_chat(self, chat):
         self.depth -= 1
 
-    def new_message(self, chat: chats.Chat, message: messages.Message):
+    def _quiet_new_message(self, chat, message):
         if isinstance(message, chats.Chat):
             return
         print(
             message.__str__(indent=" " * (self.depth * self.tab_size)),
             end="" if message.status == utils.Status.RUNNING else "\n",
+            file=self._output,
         )
 
-    def new_chunk(self, message: messages.Message, token: str):
-        print(token, end="")
+    def _quiet_new_chunk(self, message, token):
+        print(token, end="", file=self._output)
 
-    def end_content(self, message: messages.Message):
-        print()
+    def _quiet_end_content(self, message):
+        print(file=self._output)
+
+    # -- Event handlers --
+
+    def new_run(self, run):
+        if self.quiet:
+            return
+        c = self._c
+        self._in_run = True
+        if self._run_depth == 0:
+            bar = self._colorize(self._header_bar("="), c.BOLD)
+            title = self._colorize(
+                f"TASK: {run.task.name}: {run.id}", c.BOLD
+            )
+            self._print(bar)
+            self._print(title)
+            self._print(bar)
+        else:
+            bar = self._header_bar("-")
+            self._print(bar)
+            self._print(f"SUBTASK: {run.task.name}: {run.id}")
+            self._print(bar)
+        self._run_depth += 1
+
+    def end_run(self, run):
+        if self.quiet:
+            return
+        c = self._c
+        self._run_depth -= 1
+
+        # Assertion table
+        if run.assertion_results:
+            table = self._format_assertion_table(run.assertion_results)
+            self._print(table)
+
+        # Metrics + Result, grouped together
+        if run.chat and run.chat.usage:
+            usage_str = self._format_usage(run.chat.usage)
+            if usage_str:
+                self._print(f"\nMETRICS:  {usage_str}")
+
+        # Result or error
+        if run.status == utils.Status.FAILED:
+            error_msg = run.error_message or "Unknown Error"
+            self._print(self._colorize(f"ERROR:    {error_msg}", c.RED))
+        else:
+            result_str = run.format_result().strip()
+            self._print(f"RESULT:   {result_str}")
+
+        # Closing bar
+        if self._run_depth == 0:
+            self._print(self._colorize(self._header_bar("="), c.BOLD))
+        else:
+            self._print(self._header_bar("-"))
+        self._print("")
+
+        if self._run_depth == 0:
+            self._in_run = False
+
+    def new_chat(self, chat):
+        if self.quiet:
+            self._quiet_new_chat(chat)
+            return
+        if not self._in_run:
+            self._quiet_new_chat(chat)
+            return
+        # Inside a run: only print nested subchats
+        self.depth += 1
+        if self.depth > 2:
+            self._print(self._colorize(f"\n[CHAT: {chat.name}]", self._c.DIM))
+
+    def end_chat(self, chat):
+        if self.quiet:
+            self._quiet_end_chat(chat)
+            return
+        self.depth -= 1
+
+    def _format_content(self, content):
+        """Format message content as readable text, handling non-string types."""
+        if isinstance(content, str):
+            text = content
+        elif hasattr(content, "model_dump"):
+            import json
+            text = json.dumps(content.model_dump(), default=str)
+        else:
+            text = str(content)
+        # Wrap long lines to fit terminal width (account for run-depth indent)
+        max_width = self.width - self._run_depth * self.tab_size
+        wrapped_lines = []
+        for line in text.splitlines():
+            if len(line) > max_width:
+                wrapped_lines.extend(
+                    textwrap.wrap(line, width=max_width) or [""]
+                )
+            else:
+                wrapped_lines.append(line)
+        return "\n".join(wrapped_lines)
+
+    def new_message(self, chat, message):
+        if self.quiet:
+            self._quiet_new_message(chat, message)
+            return
+        if isinstance(message, chats.Chat):
+            return
+        if not self._in_run:
+            self._quiet_new_message(chat, message)
+            return
+
+        # Skip assertion result messages -- they're shown in the assertion table
+        if isinstance(message.content, assertions.AssertionResult):
+            return
+        # Skip messages not visible to LLM (internal framework messages)
+        if not message.is_visible_to_llm:
+            return
+
+        c = self._c
+        role = message.sender.role
+        name = message.sender.name
+        text = self._format_content(message.content)
+
+        if role == "user":
+            self._print(self._colorize("\n[PROMPT]", c.CYAN))
+            self._print(text)
+        elif role == "assistant":
+            self._print(self._colorize(f"\n[RESPONSE: {name}]", c.CYAN))
+            # Print eagerly if content is already populated (non-streaming path);
+            # otherwise let new_chunk handlers stream it in.
+            if text:
+                self._print(text)
+        elif role == "system":
+            self._print(self._colorize("\n[SYSTEM]", c.DIM))
+            self._print(text)
+        elif role == "tool":
+            self._print(self._colorize(f"\n[TOOL: {name}]", c.DIM))
+            self._print(text)
+        else:
+            self._print(f"\n[{name}]")
+            self._print(text)
+
+    def new_chunk(self, message, chunk):
+        if self.quiet:
+            self._quiet_new_chunk(message, chunk)
+            return
+        chunk_text = chunk if isinstance(chunk, str) else getattr(chunk, "content", "")
+        with self._lock:
+            print(chunk_text, end="", flush=True, file=self._output)
+
+    def end_content(self, message):
+        if self.quiet:
+            self._quiet_end_content(message)
+            return
+        with self._lock:
+            print(file=self._output)
+
+        # Print metrics if available
+        if not self._in_run:
+            return
+        usage = message.usage
+        if usage is None:
+            return
+        usage_str = self._format_usage(usage)
+        if usage_str:
+            self._print(f"\nMETRICS:  {usage_str}")

--- a/src/kaggle_benchmarks/ui/setup_panel.py
+++ b/src/kaggle_benchmarks/ui/setup_panel.py
@@ -12,10 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import panel as pn
 from panel import theme
 
 from kaggle_benchmarks._config import ExecutionMode, config
+
+
+def _is_vscode_kernel() -> bool:
+    """Detects if the kernel is hosted by the VSCode Jupyter extension.
+
+    VSCode injects these env vars into the kernel process; JupyterLab does not.
+    """
+    return "VSCODE_PID" in os.environ or "VSCODE_IPC_HOOK_CLI" in os.environ
 
 # css overrides to make the HoloViz output work with Kaggle theming.
 global_css = """
@@ -84,6 +94,14 @@ if (
     or config.execution_mode == ExecutionMode.DOC
 ):
     kwargs = {}
+elif _is_vscode_kernel():
+    # The VSCode Jupyter renderer doesn't register the @bokeh/jupyter_bokeh
+    # widget JS, so the BokehModel ipywidget that comms="vscode"/"ipywidgets"
+    # produce can't be rendered. Force comms="default" to bypass ipywidget
+    # rendering and use Bokeh's inline JS path. Must be passed explicitly:
+    # Panel's _detect_comms otherwise auto-overrides to "vscode" when
+    # VSCODE_PID is set.
+    kwargs = dict(comms="default")
 elif config.execution_mode == ExecutionMode.DEV:
     kwargs = dict(comms="vscode")
 else:

--- a/src/kaggle_benchmarks/ui/setup_panel.py
+++ b/src/kaggle_benchmarks/ui/setup_panel.py
@@ -12,20 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import panel as pn
 from panel import theme
 
-from kaggle_benchmarks._config import ExecutionMode, config
-
-
-def _is_vscode_kernel() -> bool:
-    """Detects if the kernel is hosted by the VSCode Jupyter extension.
-
-    VSCode injects these env vars into the kernel process; JupyterLab does not.
-    """
-    return "VSCODE_PID" in os.environ or "VSCODE_IPC_HOOK_CLI" in os.environ
+from kaggle_benchmarks._config import (
+    ExecutionMode,
+    HostEnvironment,
+    config,
+    detect_host_environment,
+)
 
 # css overrides to make the HoloViz output work with Kaggle theming.
 global_css = """
@@ -94,7 +89,7 @@ if (
     or config.execution_mode == ExecutionMode.DOC
 ):
     kwargs = {}
-elif _is_vscode_kernel():
+elif detect_host_environment() == HostEnvironment.VSCODE_NOTEBOOK:
     # The VSCode Jupyter renderer doesn't register the @bokeh/jupyter_bokeh
     # widget JS, so the BokehModel ipywidget that comms="vscode"/"ipywidgets"
     # produce can't be rendered. Force comms="default" to bypass ipywidget

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,8 @@ def context(monkeypatch):
         config.execution_mode = ExecutionMode.TESTING
         config.interactive_mode = False
         config.console_mode = False
+        config.console_quiet = False
+        config.console_color = None
         events.manager.listeners = []
         config.ui_handler = None
         config.apply()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ def context(monkeypatch):
     with contexts.enter():
         config.execution_mode = ExecutionMode.TESTING
         config.interactive_mode = False
+        config.console_mode = False
         events.manager.listeners = []
         config.ui_handler = None
         config.apply()

--- a/tests/test_console_ui.py
+++ b/tests/test_console_ui.py
@@ -1,0 +1,259 @@
+# Copyright 2025 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+
+import pytest
+
+from kaggle_benchmarks import assertions, chats, config, events, system, tasks, ui, user
+from tests.mocks import MockedChat
+
+
+@pytest.fixture
+def duck():
+    yield MockedChat.from_contents(["quack"], name="Duck", cycle=True)
+
+
+def _make_handler(quiet=False, color=False):
+    output = io.StringIO()
+    handler = ui.console.ConsoleUI(quiet=quiet, color=color, output=output)
+    events.manager.bind(handler)
+    return handler, output
+
+
+def _get_output(output):
+    return output.getvalue()
+
+
+class TestQuietMode:
+    def test_quiet_mode_matches_original_behavior(self):
+        handler, output = _make_handler(quiet=True)
+        with chats.new("test") as chat:
+            user.send("hi")
+            system.send("The end")
+
+        captured = _get_output(output)
+        assert captured.strip() == str(chat).strip()
+
+    def test_quiet_mode_streaming(self):
+        handler, output = _make_handler(quiet=True)
+        with chats.new("test"):
+            user.stream("one two three".split())
+
+        captured = _get_output(output)
+        assert "onetwothree" in captured
+
+    def test_quiet_mode_ignores_runs(self):
+        handler, output = _make_handler(quiet=True)
+
+        @tasks.task(name="Quiet Task", store_task=False, store_run=False)
+        def quiet_task():
+            user.send("hello")
+
+        quiet_task.run()
+        captured = _get_output(output)
+        # In quiet mode, run headers should not appear
+        assert "TASK" not in captured
+        assert "====" not in captured
+
+
+class TestRichMode:
+    def test_run_header_and_footer(self):
+        handler, output = _make_handler()
+
+        @tasks.task(name="My Task", store_task=False, store_run=False)
+        def my_task():
+            pass
+
+        my_task.run()
+        captured = _get_output(output)
+        assert "=" * 80 in captured
+        assert "TASK: My Task:" in captured
+        assert "RESULT:" in captured
+
+    def test_prompt_and_response(self, duck):
+        handler, output = _make_handler()
+
+        @tasks.task(name="Chat Task", store_task=False, store_run=False)
+        def chat_task(llm):
+            llm.prompt("What sound do you make?")
+
+        chat_task.run(duck)
+        captured = _get_output(output)
+        assert "[PROMPT]" in captured
+        assert "What sound do you make?" in captured
+        assert "[RESPONSE: Duck]" in captured
+        assert "quack" in captured
+
+    def test_system_message(self):
+        handler, output = _make_handler()
+
+        @tasks.task(name="Sys Task", store_task=False, store_run=False)
+        def sys_task():
+            system.send("System info here")
+
+        sys_task.run()
+        captured = _get_output(output)
+        assert "[SYSTEM]" in captured
+        assert "System info here" in captured
+
+    def test_assertion_table_pass(self):
+        handler, output = _make_handler()
+
+        @tasks.task(name="Assert Task", store_task=False, store_run=False)
+        def assert_task():
+            assertions.assert_true(True, expectation="Value should be true")
+
+        assert_task.run()
+        captured = _get_output(output)
+        assert "✅ Pass" in captured
+        assert "Value should be true" in captured
+        assert "Expectation" in captured
+
+    def test_assertion_table_fail(self, monkeypatch):
+        monkeypatch.setattr(config, "continue_with_exceptions", True)
+        handler, output = _make_handler()
+
+        @tasks.task(name="Fail Task", store_task=False, store_run=False)
+        def fail_task():
+            assertions.assert_true(False, expectation="This should fail")
+
+        fail_task.run()
+        captured = _get_output(output)
+        assert "❌ Fail" in captured
+        assert "This should fail" in captured
+
+    def test_assertion_table_mixed(self, monkeypatch):
+        monkeypatch.setattr(config, "continue_with_exceptions", True)
+        handler, output = _make_handler()
+
+        @tasks.task(name="Mixed Task", store_task=False, store_run=False)
+        def mixed_task():
+            assertions.assert_true(True, expectation="First check")
+            assertions.assert_true(False, expectation="Second check")
+            assertions.assert_equal("a", "a", expectation="Third check")
+
+        mixed_task.run()
+        captured = _get_output(output)
+        assert captured.count("✅ Pass") == 2
+        assert captured.count("❌ Fail") == 1
+        assert "RESULT:" in captured
+
+    def test_error_run(self, monkeypatch):
+        monkeypatch.setattr(config, "continue_with_exceptions", True)
+        handler, output = _make_handler()
+
+        @tasks.task(name="Error Task", store_task=False, store_run=False)
+        def error_task():
+            raise ValueError("Something broke")
+
+        error_task.run()
+        captured = _get_output(output)
+        assert "ERROR:" in captured
+        assert "Something broke" in captured
+
+    def test_result_format(self, duck):
+        handler, output = _make_handler()
+
+        @tasks.task(name="Bool Task", store_task=False, store_run=False)
+        def bool_task(llm) -> bool:
+            return llm.prompt("test") == "quack"
+
+        bool_task.run(duck)
+        captured = _get_output(output)
+        assert "RESULT:" in captured
+
+    def test_streaming(self):
+        handler, output = _make_handler()
+
+        @tasks.task(name="Stream Task", store_task=False, store_run=False)
+        def stream_task():
+            user.stream(["hello", " ", "world"])
+
+        stream_task.run()
+        captured = _get_output(output)
+        assert "hello world" in captured
+
+
+class TestColorMode:
+    def test_color_pass(self):
+        handler, output = _make_handler(color=True)
+
+        @tasks.task(name="Color Task", store_task=False, store_run=False)
+        def color_task():
+            assertions.assert_true(True, expectation="Check it")
+
+        color_task.run()
+        captured = _get_output(output)
+        # ANSI green should wrap the PASS icon
+        assert "\033[32m✅ Pass\033[0m" in captured
+
+    def test_color_fail(self, monkeypatch):
+        monkeypatch.setattr(config, "continue_with_exceptions", True)
+        handler, output = _make_handler(color=True)
+
+        @tasks.task(name="Color Fail", store_task=False, store_run=False)
+        def color_fail_task():
+            assertions.assert_true(False, expectation="Check it")
+
+        color_fail_task.run()
+        captured = _get_output(output)
+        # ANSI red should wrap the FAIL icon
+        assert "\033[31m❌ Fail\033[0m" in captured
+
+    def test_color_headers(self):
+        handler, output = _make_handler(color=True)
+
+        @tasks.task(name="Color Header", store_task=False, store_run=False)
+        def color_header_task():
+            user.send("hello")
+
+        color_header_task.run()
+        captured = _get_output(output)
+        # ANSI bold should wrap the title bar
+        assert "\033[1m" in captured
+        # ANSI cyan should wrap [PROMPT]
+        assert "\033[36m" in captured
+
+    def test_no_color_has_no_ansi(self):
+        handler, output = _make_handler(color=False)
+
+        @tasks.task(name="No Color", store_task=False, store_run=False)
+        def no_color_task():
+            assertions.assert_true(True, expectation="Check it")
+            user.send("hello")
+
+        no_color_task.run()
+        captured = _get_output(output)
+        assert "\033[" not in captured
+
+
+class TestNestedRuns:
+    def test_subrun_formatting(self, duck):
+        handler, output = _make_handler()
+
+        @tasks.task(name="Inner Task", store_task=False, store_run=False)
+        def inner_task(llm):
+            llm.prompt("inner question")
+
+        @tasks.task(name="Outer Task", store_task=False, store_run=False)
+        def outer_task(llm):
+            inner_task.run(llm)
+
+        outer_task.run(duck)
+        captured = _get_output(output)
+        # Both tasks should appear
+        assert "Outer Task" in captured
+        assert "Inner Task" in captured
+        assert "SUBTASK" in captured

--- a/tests/test_console_ui.py
+++ b/tests/test_console_ui.py
@@ -16,8 +16,41 @@ import io
 
 import pytest
 
-from kaggle_benchmarks import assertions, chats, config, events, system, tasks, ui, user
+from kaggle_benchmarks import (
+    actors,
+    assertions,
+    chats,
+    config,
+    events,
+    system,
+    tasks,
+    ui,
+    user,
+)
+from kaggle_benchmarks.actors import llms
 from tests.mocks import MockedChat
+
+
+class _StreamingLLM(actors.LLMChat):
+    """LLM whose invoke() returns an Iterator (exercises the streaming path)."""
+
+    def __init__(self, chunks, name="Stream", **kwargs):
+        super().__init__(name=name, **kwargs)
+        self._chunks = list(chunks)
+
+    def invoke(self, messages, **kwargs):
+        return iter(self._chunks)
+
+
+class _NonStreamingLLM(actors.LLMChat):
+    """LLM whose invoke() returns an LLMResponse (non-streaming path)."""
+
+    def __init__(self, content, name="NonStream", **kwargs):
+        super().__init__(name=name, **kwargs)
+        self._content = content
+
+    def invoke(self, messages, **kwargs):
+        return llms.LLMResponse(content=self._content)
 
 
 @pytest.fixture
@@ -257,3 +290,222 @@ class TestNestedRuns:
         assert "Outer Task" in captured
         assert "Inner Task" in captured
         assert "SUBTASK" in captured
+
+
+class TestLLMResponseRendering:
+    """Verify the rendering ordering for each LLMChat.respond() invoke branch.
+
+    These exercise the actual code paths in actors/llms.py — MockedChat only
+    hits the LLMMessage branch, so we need fakes for LLMResponse and Iterator.
+    """
+
+    def test_non_streaming_quiet_preserves_newline(self):
+        """LLMResponse path in quiet mode must terminate each message with \\n.
+
+        Regression: an earlier version swapped chat.append/status order so
+        new_message fired with status=RUNNING, causing _quiet_new_message to
+        omit the trailing newline and glue messages together.
+        """
+        handler, output = _make_handler(quiet=True)
+        llm = _NonStreamingLLM(content="alpha")
+        with chats.new("test"):
+            llm.prompt("first")
+            llm.prompt("second")
+        captured = _get_output(output)
+        # Each message must end with a newline; lines must not be glued.
+        assert "alpha\n" in captured
+        assert "alpha  " not in captured  # not followed by next message inline
+
+    def test_streaming_header_before_chunks_in_rich_mode(self):
+        """Streaming path must dispatch new_message BEFORE chunks stream in,
+        so the rich UI's [RESPONSE: name] header appears above the tokens."""
+        handler, output = _make_handler()
+
+        @tasks.task(name="StreamTask", store_task=False, store_run=False)
+        def stream_task(llm):
+            llm.prompt("go")
+
+        stream_task.run(_StreamingLLM(chunks=["hel", "lo ", "world"]))
+        captured = _get_output(output)
+        header_idx = captured.find("[RESPONSE: Stream]")
+        body_idx = captured.find("hello world")
+        assert header_idx != -1, captured
+        assert body_idx != -1, captured
+        assert header_idx < body_idx, (
+            f"[RESPONSE] header at {header_idx} must precede streamed body "
+            f"at {body_idx}:\n{captured}"
+        )
+
+    def test_streaming_no_duplicate_body(self):
+        """Streamed text should appear exactly once, not also re-printed by
+        a later new_message dispatch."""
+        handler, output = _make_handler()
+
+        @tasks.task(name="StreamDup", store_task=False, store_run=False)
+        def stream_task(llm):
+            llm.prompt("go")
+
+        stream_task.run(_StreamingLLM(chunks=["uniq", "ue!"]))
+        captured = _get_output(output)
+        assert captured.count("unique!") == 1, captured
+
+    def test_non_streaming_rich_renders_response(self):
+        """LLMResponse path inside @task should print header + body once."""
+        handler, output = _make_handler()
+
+        @tasks.task(name="NonStreamTask", store_task=False, store_run=False)
+        def t(llm):
+            llm.prompt("go")
+
+        t.run(_NonStreamingLLM(content="answer-text"))
+        captured = _get_output(output)
+        assert "[RESPONSE: NonStream]" in captured
+        assert captured.count("answer-text") == 1, captured
+
+    def test_invisible_to_llm_messages_still_render(self):
+        """Messages with is_visible_to_llm=False (e.g. tool debug output)
+        should still appear in the console — that flag controls inclusion
+        in the LLM context window, not user-facing visibility."""
+        from kaggle_benchmarks import actors, messages
+
+        handler, output = _make_handler(quiet=False)
+
+        @tasks.task(name="ToolTask", store_task=False, store_run=False)
+        def tool_task():
+            tool_actor = actors.Actor(name="Docker", role="tool")
+            chats.get_current_chat().append(
+                messages.Message(
+                    sender=tool_actor,
+                    content="container exited with code 0",
+                    is_visible_to_llm=False,
+                )
+            )
+
+        tool_task.run()
+        captured = _get_output(output)
+        assert "[TOOL: Docker]" in captured, captured
+        assert "container exited with code 0" in captured, captured
+
+    def test_streaming_does_not_double_print(self):
+        """If a message is streamed and *then* appended (the inverse of the
+        canonical order), new_message should still print the role header but
+        skip the body since chunks already rendered it."""
+        from kaggle_benchmarks import actors, messages, utils
+
+        handler, output = _make_handler(quiet=False)
+
+        @tasks.task(name="Stream Test", store_task=False, store_run=False)
+        def stream_task():
+            msg = messages.Message(
+                sender=actors.system, content="", _status=utils.Status.RUNNING
+            )
+            msg.stream(iter(["hello", " world"]))
+            chats.get_current_chat().append(msg)
+
+        stream_task.run()
+        captured = _get_output(output)
+        assert captured.count("hello world") == 1, captured
+        # Header should still appear so the [SYSTEM] label is visible.
+        assert "[SYSTEM]" in captured
+
+    def test_streaming_with_usage_prints_metrics_once(self):
+        """For assistant-role streaming responses with usage, METRICS must
+        be printed exactly once (by end_run from chat.usage), not also by
+        end_content per-message."""
+        from dataclasses import dataclass, field
+
+        from kaggle_benchmarks import actors, messages, utils
+
+        @dataclass
+        class Chunk:
+            content: str
+            meta: dict = field(default_factory=dict)
+
+        handler, output = _make_handler()
+
+        @tasks.task(name="Metrics Task", store_task=False, store_run=False)
+        def metrics_task():
+            llm_actor = actors.Actor(name="TestLLM", role="assistant")
+            msg = messages.Message(
+                sender=llm_actor, content="", _status=utils.Status.RUNNING
+            )
+            chunks = [
+                Chunk("hello"),
+                Chunk(" world", meta={"input_tokens": 10, "output_tokens": 5}),
+            ]
+            chats.get_current_chat().append(msg)
+            msg.stream(chunks)
+            msg.status = utils.Status.SUCCESS
+
+        metrics_task.run()
+        captured = _get_output(output)
+        assert captured.count("METRICS:") == 1, captured
+
+    def test_assertion_table_narrow_terminal(self):
+        """expect_width must stay positive even when terminal is very narrow
+        and run depth is deep, otherwise textwrap.wrap raises ValueError."""
+        output = io.StringIO()
+        handler = ui.console.ConsoleUI(
+            quiet=False, color=False, output=output, width=30, min_width=30
+        )
+        handler._run_depth = 8  # raw expect_width would be -4 without the floor
+        results = [
+            assertions.AssertionResult(passed=True, expectation="Some expectation")
+        ]
+        table = handler._format_assertion_table(results)
+        assert isinstance(table, str)
+        assert "Some expectation" in table or "Some" in table
+
+    def test_switching_ui_unbinds_old_handler(self, cfg):
+        """Switching UI mode must unbind the previous handler so events
+        aren't dispatched to both."""
+        cfg.enable_interactive_mode()  # binds PanelUI
+        old_handler = cfg.ui_handler
+        from kaggle_benchmarks.ui import panel as panel_ui
+
+        assert isinstance(old_handler, panel_ui.PanelUI)
+        assert old_handler in events.manager.listeners
+
+        cfg.enable_console_mode()  # should unbind PanelUI, bind ConsoleUI
+        assert old_handler not in events.manager.listeners
+        assert isinstance(cfg.ui_handler, ui.console.ConsoleUI)
+        assert cfg.ui_handler in events.manager.listeners
+
+        # And the reverse: console -> panel must also unbind.
+        console_handler = cfg.ui_handler
+        cfg.enable_interactive_mode()
+        assert console_handler not in events.manager.listeners
+        assert isinstance(cfg.ui_handler, panel_ui.PanelUI)
+
+    def test_llm_message_branch_dispatches_new_message_once(self):
+        """LLMMessage returned from invoke() should produce exactly one
+        new_message event for the response (the chat.append in respond()).
+
+        Guards against future regressions if invoke() starts using
+        LLMMessage.from_chunks (which dispatches new_message itself) — that
+        would need chat.history.append, not chat.append, to avoid a duplicate.
+        """
+        events_seen = []
+
+        class Spy:
+            def new_message(self, chat, message):
+                events_seen.append(message)
+
+        events.manager.listeners = []
+        config.ui_handler = None
+        events.manager.bind(Spy())
+
+        llm = MockedChat.from_contents(["only-once"])
+        with chats.new("t"):
+            user.send("hi")
+            llm.respond()
+
+        # Filter to just message events (not chat-open events).
+        msgs = [m for m in events_seen if not isinstance(m, chats.Chat)]
+        # Expect exactly two: the user prompt, and the LLM response.
+        # If respond() dispatches twice for the LLMMessage branch this jumps to 3.
+        assert len(msgs) == 2, (
+            f"Expected 2 message events, got {len(msgs)}: "
+            f"{[m.content for m in msgs]}"
+        )
+        assert msgs[-1].content == "only-once"

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -67,7 +67,9 @@ def test_console_ui(capsys):
 
 
 def test_panel_ui():
-    handler = ui.panel.PanelUI()
+    from kaggle_benchmarks.ui import panel
+
+    handler = panel.PanelUI()
     events.manager.bind(handler)
     with chats.new("test") as chat:
         assert chat in handler

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -16,7 +16,8 @@
 import panel as pn
 import pytest
 
-from kaggle_benchmarks import actors, chats, llm_messages, tools, ui
+from kaggle_benchmarks import actors, chats, llm_messages, tools
+from kaggle_benchmarks.ui import panel as ui_panel
 
 
 def test_render_thread():
@@ -29,7 +30,7 @@ def test_render_thread():
             chats.Message("Meow!", sender=cat),
         ]
     )
-    rendered = ui.panel.render_chat_to_html(chat)
+    rendered = ui_panel.render_chat_to_html(chat)
 
     assert "Chirp chirp" in rendered
     assert goose.name in rendered
@@ -114,5 +115,5 @@ COMPLEX_USAGE = llm_messages.Usage(input_tokens=100, output_tokens=50)
     ],
 )
 def test_render_llm_message_combinations(message):
-    rendered = ui.panel.render_llm_message(message)
+    rendered = ui_panel.render_llm_message(message)
     assert isinstance(rendered, pn.chat.ChatMessage)


### PR DESCRIPTION
- Implement console output for the SDK - example:
```
michaelaaron@michaelaaron3 ~/k/kaggle-benchmarks (console-ui-output)> ./.venv/bin/python3 ./documentation/examples/anagrams.py
========================================================================================================================
TASK: Anagram writing: Run #1
========================================================================================================================
  
  [PROMPT]
  Generate anagrams of `triangle`
  
  [RESPONSE: google/gemini-3-flash-preview]
  {"comment": "Anagrams for the word 'triangle'.", "anagrams": ["altering", "integral", "relating", "alerting"]}

------------------------------------------------------------------------------------------------------------------------
  Line  Expectation                                                                                             Result
------------------------------------------------------------------------------------------------------------------------
    35  assert_empty: Mistakes found:                                                                           ✅ Pass
------------------------------------------------------------------------------------------------------------------------

METRICS:  Input: 91 · Output: 24 · Cost: $0.000924 · Latency: 2082ms
RESULT:   4
========================================================================================================================
```
- Refactor panel usage to make sure it's only imported when required using dynamic imports (happy to do something different here if there is a more preferred solution) 
- Add various utilities to figure out which environment the SDK is running in to decide on the outputs.
Example of VSCode in JL Frame:
<img width="2561" height="1405" alt="Screenshot From 2026-04-28 11-44-53" src="https://github.com/user-attachments/assets/4442c652-40ff-4beb-a42b-eda0dfe679de" />
