### PR TITLE
Make PanelUI opt-in in notebook kernels

### DIFF
--- a/src/kaggle_benchmarks/_config.py
+++ b/src/kaggle_benchmarks/_config.py
@@ -214,7 +214,6 @@ class Config:
         if host_env != HostEnvironment.TERMINAL:
             from kaggle_benchmarks.ui import (  # noqa: F401
                 ipython_magics,
-                panel as _panel_ui_mod,
                 setup_panel,
             )
 
@@ -225,8 +224,10 @@ class Config:
             from kaggle_benchmarks import events
             from kaggle_benchmarks.ui import (  # noqa: F401
                 ipython_magics,
-                panel as panel_ui,
                 setup_panel,
+            )
+            from kaggle_benchmarks.ui import (
+                panel as panel_ui,
             )
 
             if not isinstance(self.ui_handler, panel_ui.PanelUI):

--- a/src/kaggle_benchmarks/_config.py
+++ b/src/kaggle_benchmarks/_config.py
@@ -191,6 +191,7 @@ class Config:
         # otherwise auto-detect based on environment.
         use_panel = self.interactive_mode
         use_console = self.console_mode
+        host_env = detect_host_environment()
 
         if (
             not use_panel
@@ -201,8 +202,21 @@ class Config:
             # the handler unbound and rely on cell-output rendering via
             # __panel__/_repr_mimebundle_. Users can opt in to live PanelUI
             # streaming via enable_interactive_mode() or INTERACTIVE_UI=True.
-            if detect_host_environment() == HostEnvironment.TERMINAL:
+            if host_env == HostEnvironment.TERMINAL:
                 use_console = True
+
+        # Initialize Panel for cell-output rendering in any notebook kernel.
+        # _repr_mimebundle_ on Run/Runs/Chat/Message uses Panel widgets, which
+        # need pn.extension() (run as a side effect of importing setup_panel)
+        # to register their notebook comms. This runs even when PanelUI is not
+        # event-bound, since the passive cell-output path is independent of
+        # live event streaming.
+        if host_env != HostEnvironment.TERMINAL:
+            from kaggle_benchmarks.ui import (  # noqa: F401
+                ipython_magics,
+                panel as _panel_ui_mod,
+                setup_panel,
+            )
 
         if use_panel:
             import panel as pn
@@ -211,14 +225,14 @@ class Config:
             from kaggle_benchmarks import events
             from kaggle_benchmarks.ui import (  # noqa: F401
                 ipython_magics,
-                panel,
+                panel as panel_ui,
                 setup_panel,
             )
 
-            if not isinstance(self.ui_handler, panel.PanelUI):
+            if not isinstance(self.ui_handler, panel_ui.PanelUI):
                 if self.ui_handler is not None:
                     events.manager.unbind(self.ui_handler)
-                self.ui_handler = panel.PanelUI()
+                self.ui_handler = panel_ui.PanelUI()
                 events.manager.bind(self.ui_handler)
 
         elif use_console:

--- a/src/kaggle_benchmarks/_config.py
+++ b/src/kaggle_benchmarks/_config.py
@@ -205,13 +205,17 @@ class Config:
             if host_env == HostEnvironment.TERMINAL:
                 use_console = True
 
-        # Initialize Panel for cell-output rendering in any notebook kernel.
-        # _repr_mimebundle_ on Run/Runs/Chat/Message uses Panel widgets, which
-        # need pn.extension() (run as a side effect of importing setup_panel)
-        # to register their notebook comms. This runs even when PanelUI is not
-        # event-bound, since the passive cell-output path is independent of
-        # live event streaming.
-        if host_env != HostEnvironment.TERMINAL:
+        # Initialize Panel for cell-output rendering in any notebook kernel,
+        # and whenever PanelUI is being explicitly enabled. _repr_mimebundle_
+        # on Run/Runs/Chat/Message uses Panel widgets, which need
+        # pn.extension() (run as a side effect of importing setup_panel) to
+        # register their notebook comms. The TESTING guard keeps tests that
+        # patch detect_host_environment from triggering Panel imports.
+        notebook_kernel = (
+            host_env != HostEnvironment.TERMINAL
+            and self.execution_mode != ExecutionMode.TESTING
+        )
+        if use_panel or notebook_kernel:
             from kaggle_benchmarks.ui import (  # noqa: F401
                 ipython_magics,
                 setup_panel,
@@ -222,13 +226,7 @@ class Config:
 
             pn.config.theme = self.ui_theme  # type: ignore
             from kaggle_benchmarks import events
-            from kaggle_benchmarks.ui import (  # noqa: F401
-                ipython_magics,
-                setup_panel,
-            )
-            from kaggle_benchmarks.ui import (
-                panel as panel_ui,
-            )
+            from kaggle_benchmarks.ui import panel as panel_ui
 
             if not isinstance(self.ui_handler, panel_ui.PanelUI):
                 if self.ui_handler is not None:

--- a/src/kaggle_benchmarks/_config.py
+++ b/src/kaggle_benchmarks/_config.py
@@ -197,11 +197,12 @@ class Config:
             and not use_console
             and self.execution_mode != ExecutionMode.TESTING
         ):
-            # Auto-detect: any notebook kernel -> PanelUI, otherwise -> ConsoleUI
+            # Only auto-enable ConsoleUI in terminals. In notebook kernels, leave
+            # the handler unbound and rely on cell-output rendering via
+            # __panel__/_repr_mimebundle_. Users can opt in to live PanelUI
+            # streaming via enable_interactive_mode() or INTERACTIVE_UI=True.
             if detect_host_environment() == HostEnvironment.TERMINAL:
                 use_console = True
-            else:
-                use_panel = True
 
         if use_panel:
             import panel as pn

--- a/src/kaggle_benchmarks/_config.py
+++ b/src/kaggle_benchmarks/_config.py
@@ -268,6 +268,12 @@ class Config:
         self.interactive_mode = True
         self.apply()
 
+    # TODO: add a `disable_interactive_mode()` for API symmetry with
+    # disable_console_mode. Implementation needs to explicitly unbind any
+    # existing PanelUI handler — apply()'s auto-detect block no longer enters
+    # the panel branch in notebooks, so toggling interactive_mode=False alone
+    # would leave a stale handler bound.
+
     def enable_console_mode(self, quiet: bool = False, color: bool | None = None):
         self.console_mode = True
         self.console_quiet = quiet

--- a/tests/test_config_apply.py
+++ b/tests/test_config_apply.py
@@ -1,0 +1,111 @@
+# Copyright 2025 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Config.apply() auto-detect behavior.
+
+Notebook kernels (Jupyter, Kaggle, VSCode notebook) MUST NOT auto-bind
+PanelUI: large benchmarks crash the kernel under live streaming. Users
+opt in via enable_interactive_mode() / INTERACTIVE_UI=True. Terminals
+keep the auto-on ConsoleUI introduced in #149.
+"""
+
+import pytest
+
+from kaggle_benchmarks import _config, events
+from kaggle_benchmarks._config import ExecutionMode, HostEnvironment
+from kaggle_benchmarks.ui import console as console_ui
+
+
+@pytest.fixture
+def patch_host_env(monkeypatch):
+    """Return a setter that overrides _config.detect_host_environment."""
+
+    def _set(env: HostEnvironment):
+        monkeypatch.setattr(_config, "detect_host_environment", lambda: env)
+
+    return _set
+
+
+@pytest.mark.parametrize(
+    "host_env",
+    [HostEnvironment.JUPYTER, HostEnvironment.VSCODE_NOTEBOOK],
+)
+def test_notebook_kernel_does_not_autobind_panel_ui(cfg, patch_host_env, host_env):
+    """In any notebook kernel, default apply() leaves no handler bound."""
+    patch_host_env(host_env)
+    cfg.execution_mode = ExecutionMode.NOTEBOOK
+    cfg.interactive_mode = False
+    cfg.console_mode = False
+    cfg.ui_handler = None
+    events.manager.listeners = []
+
+    cfg.apply()
+
+    assert cfg.ui_handler is None
+    assert events.manager.listeners == []
+
+
+def test_notebook_kernel_enable_interactive_mode_binds_panel_ui(cfg, patch_host_env):
+    """enable_interactive_mode() in a notebook kernel must bind PanelUI."""
+    from kaggle_benchmarks.ui import panel as panel_ui
+
+    patch_host_env(HostEnvironment.JUPYTER)
+    cfg.execution_mode = ExecutionMode.NOTEBOOK
+    cfg.interactive_mode = False
+    cfg.console_mode = False
+    cfg.ui_handler = None
+    events.manager.listeners = []
+
+    cfg.enable_interactive_mode()
+
+    assert isinstance(cfg.ui_handler, panel_ui.PanelUI)
+    assert cfg.ui_handler in events.manager.listeners
+
+
+def test_terminal_default_autobinds_console_ui(cfg, patch_host_env):
+    """In a terminal host env, default apply() still auto-binds ConsoleUI."""
+    patch_host_env(HostEnvironment.TERMINAL)
+    cfg.execution_mode = ExecutionMode.NOTEBOOK
+    cfg.interactive_mode = False
+    cfg.console_mode = False
+    cfg.ui_handler = None
+    events.manager.listeners = []
+
+    cfg.apply()
+
+    assert isinstance(cfg.ui_handler, console_ui.ConsoleUI)
+    assert cfg.ui_handler in events.manager.listeners
+
+
+@pytest.mark.parametrize(
+    "host_env",
+    [
+        HostEnvironment.TERMINAL,
+        HostEnvironment.JUPYTER,
+        HostEnvironment.VSCODE_NOTEBOOK,
+    ],
+)
+def test_testing_mode_binds_nothing(cfg, patch_host_env, host_env):
+    """ExecutionMode.TESTING never auto-binds a handler regardless of host."""
+    patch_host_env(host_env)
+    cfg.execution_mode = ExecutionMode.TESTING
+    cfg.interactive_mode = False
+    cfg.console_mode = False
+    cfg.ui_handler = None
+    events.manager.listeners = []
+
+    cfg.apply()
+
+    assert cfg.ui_handler is None
+    assert events.manager.listeners == []

--- a/tests/test_config_apply.py
+++ b/tests/test_config_apply.py
@@ -20,6 +20,8 @@ opt in via enable_interactive_mode() / INTERACTIVE_UI=True. Terminals
 keep the auto-on ConsoleUI introduced in #149.
 """
 
+import sys
+
 import pytest
 
 from kaggle_benchmarks import _config, events
@@ -86,6 +88,29 @@ def test_terminal_default_autobinds_console_ui(cfg, patch_host_env):
 
     assert isinstance(cfg.ui_handler, console_ui.ConsoleUI)
     assert cfg.ui_handler in events.manager.listeners
+
+
+@pytest.mark.parametrize(
+    "host_env",
+    [HostEnvironment.JUPYTER, HostEnvironment.VSCODE_NOTEBOOK],
+)
+def test_notebook_kernel_initializes_setup_panel(cfg, patch_host_env, host_env):
+    """In a notebook host env, apply() must import setup_panel so
+    pn.extension() runs and cell-output rendering via _repr_mimebundle_
+    works — even when no event handler is bound."""
+    patch_host_env(host_env)
+    cfg.execution_mode = ExecutionMode.NOTEBOOK
+    cfg.interactive_mode = False
+    cfg.console_mode = False
+    cfg.ui_handler = None
+    events.manager.listeners = []
+
+    cfg.apply()
+
+    assert "kaggle_benchmarks.ui.setup_panel" in sys.modules
+    # Apply should still leave no event-bound handler.
+    assert cfg.ui_handler is None
+    assert events.manager.listeners == []
 
 
 @pytest.mark.parametrize(

--- a/user_guide.md
+++ b/user_guide.md
@@ -23,6 +23,7 @@
     `assess_response_with_judge`](#model-based-assertions-with-assess_response_with_judge)
 - [4. Evaluating Multiple Models on
   Kaggle](#4-evaluating-multiple-models-on-kaggle)
+- [5. Choosing a UI](#5-choosing-a-ui)
 
 This guide provides a deeper dive into the core APIs of the
 `kaggle-benchmarks` library. We’ll cover how to define tasks, interact
@@ -643,3 +644,43 @@ template.
 2.  On the created task page, use “Evaluate More Models” button to
     select the models you want to evaluate. Kaggle will then run your
     task, swapping in each model you choose to generate the leaderboard.
+
+## 5. Choosing a UI
+
+`kaggle-benchmarks` renders runs differently depending on where you
+execute them:
+
+- **Notebook kernels** (Jupyter, Kaggle, VSCode) display each `Run` via
+  its cell output (Panel-based rich widgets). No live event-bound UI is
+  attached by default, so heavy benchmarks (e.g. video QA) won't tax
+  the kernel with continuous redraws.
+- **Terminals / scripts** auto-bind `ConsoleUI`, which prints a
+  structured transcript of each run.
+
+### Opting in to live PanelUI streaming in notebooks
+
+If you want the live, streaming Panel UI inside a notebook (e.g. while
+iterating on a small task and you want to watch tokens arrive), opt in
+explicitly:
+
+``` python
+import kaggle_benchmarks as kbench
+
+kbench.config.enable_interactive_mode()
+```
+
+Equivalently, set `INTERACTIVE_UI=True` in your environment before
+importing the library.
+
+### Console output
+
+In a terminal, `ConsoleUI` is on by default. To force it on (for
+example, when running inside a notebook for log-friendly output) or
+tune its behavior, use:
+
+``` python
+kbench.config.enable_console_mode(quiet=False, color=None)
+```
+
+The corresponding environment variables are `BENCHMARK_CONSOLE_UI`,
+`BENCHMARK_CONSOLE_QUIET`, and `BENCHMARK_CONSOLE_COLOR`.


### PR DESCRIPTION
PR #149 made Config.apply() auto-bind PanelUI in any notebook kernel,
which crashes Kaggle notebooks for users running heavy benchmarks like
videoqa (context: https://chat.kaggle.net/kaggle/pl/zrao77bgxby38qramth4anhthe).
Restore the pre-#149 behavior in notebooks: no event-bound handler by
default, with cell-output rendering still working via
__panel__/_repr_mimebundle_. Users opt in to live streaming via
enable_interactive_mode() or INTERACTIVE_UI=True. Terminal auto-on
ConsoleUI from #149 is unchanged, and the user guide gains a "Choosing
a UI" section covering the new defaults and opt-in paths.

---

Task: [limagoog-20260506163956-bf099c1f](https://agents.dev.kaggle.net/tasks/limagoog-20260506163956-bf099c1f)
Context: https://chat.kaggle.net/kaggle/pl/zrao77bgxby38qramth4anhthe

