### PR TITLE
Fix reasoning for OpenAI models via OpenAI path

### DIFF
--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -392,7 +392,7 @@ class OpenAI(LLMChat):
             # inner one arrives at Model Proxy as a top-level field where it
             # reads google.thinking_config.  Without include_thoughts, the
             # frontend drops thinking traces from the response.
-            if kwargs["reasoning_effort"] != "none":
+            if kwargs["reasoning_effort"] != "none" and self.model.startswith("google/"):
                 kwargs.setdefault("extra_body", {})
                 kwargs["extra_body"].setdefault("extra_body", {})
                 kwargs["extra_body"]["extra_body"].setdefault("google", {})

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -197,13 +197,9 @@ def test_invoke():
     assert llm.kwargs.get("response_format") is None
 
 
-@pytest.mark.parametrize(
-    "model",
-    ["google/gemini-2.5-flash", "anthropic/claude-sonnet", "openai/gpt-5.4"],
-)
-def test_prompt_reasoning_sets_effort_and_thinking_config(model):
-    """Tests that reasoning sets reasoning_effort and include_thoughts for all models."""
-    llm = MockedOpenAI(model=model)
+def test_prompt_reasoning_sets_effort_and_thinking_config():
+    """Tests that reasoning sets reasoning_effort and thinking_config for Google models."""
+    llm = MockedOpenAI(model="google/gemini-2.5-flash")
     llm.prompt("Think hard", reasoning="high")
 
     assert llm.kwargs["reasoning_effort"] == "high"
@@ -397,6 +393,23 @@ def test_prompt_reasoning_none_sets_effort_without_thinking_config():
 
     assert llm.kwargs["reasoning_effort"] == "none"
     assert "extra_body" not in llm.kwargs
+
+
+def test_reasoning_extra_body_only_for_google_models():
+    """Tests that google thinking_config extra_body is only added for google/ models."""
+    google_llm = MockedOpenAI(model="google/gemini-2.5-flash")
+    google_llm.prompt("Hi", reasoning="high")
+    assert "extra_body" in google_llm.kwargs
+
+    openai_llm = MockedOpenAI(model="openai/gpt-5.4-2026-03-05")
+    openai_llm.prompt("Hi", reasoning="high")
+    assert "extra_body" not in openai_llm.kwargs
+    assert openai_llm.kwargs["reasoning_effort"] == "high"
+
+    anthropic_llm = MockedOpenAI(model="anthropic/claude-sonnet-4-6@default")
+    anthropic_llm.prompt("Hi", reasoning="high")
+    assert "extra_body" not in anthropic_llm.kwargs
+    assert anthropic_llm.kwargs["reasoning_effort"] == "high"
 
 
 def test_invoke_prompt():


### PR DESCRIPTION
Only inject `google.thinking_config` extra_body for google models (previously this was sent for all models, causing `Unknown parameter: 'extra_body'` errors for OpenAI models (e.g. openai/gpt-5.4)                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                           
Ran the golden tests (including on openai models) to confirm everything works as expected

[design doc](https://docs.google.com/document/d/16LU76WK-xngCzWj8L4uySMG45SHSHil_Pz_iERayw5U/edit?resourcekey=0-t0INHEgqdLzANbNliEoKMw&tab=t.0#heading=h.1sf05llk29fe)
BUG=b/496208368