### PR TITLE
fix: native model tool calling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,4 +24,4 @@ repos:
   hooks:
   - id: addlicense
     args: [ "-c", "Kaggle Inc.", "-l", "apache", "*.py" ]
-    exclude: ^(src/kaggle_benchmarks/kaggle/benchmark_types_pb2\.py|\.github/)
+    exclude: ^(src/kaggle_benchmarks/kaggle/benchmark_types_pb2\.py|\.github/|golden_tests/test_cookbook_examples_report\.yaml)

--- a/cookbook.md
+++ b/cookbook.md
@@ -667,9 +667,12 @@ def python_task(llm):
 
 ### Recipe: Equipping Models with Custom Tools
 
-You can also pass your own Python functions as tools. The model can then
-call these functions to retrieve information or perform actions. Please
-note this is currently an experimental feature.
+You can pass your own Python functions as tools. The model can then
+call these functions to retrieve information or perform actions. The
+library handles the multi-turn tool calling loop automatically:
+converting your functions to tool schemas, executing requested calls,
+feeding results back, and repeating until the model produces a final
+answer.
 
 ``` python
 def get_weather(city: str) -> str:
@@ -679,15 +682,40 @@ def get_weather(city: str) -> str:
 @kbench.task()
 def weather_task(llm):
     # Pass the function directly to the 'tools' argument
-    # Note: Works best with 'genai' API models
-    llm.prompt("Weather in Tokyo?", tools=[get_weather])
+    response = llm.prompt("Weather in Tokyo?", tools=[get_weather])
 
-llm= models.load_model(
-    model_name=kbench.llm.name,
-    api="genai",
-)
+    # Verify that the tool was actually called
+    kbench.assertions.assert_tool_was_invoked(get_weather)
 
-weather_task.run(llm)
+weather_task.run(kbench.llm)
+```
+
+You can combine tools with `schema` to get structured output after the
+tool-calling phase:
+
+``` python
+from dataclasses import dataclass
+
+def lookup_population(city: str) -> int:
+    """Looks up the population of a city."""
+    return 14_000_000
+
+@dataclass
+class CityReport:
+    city: str
+    population: int
+
+@kbench.task()
+def city_report_task(llm):
+    report = llm.prompt(
+        "Look up Tokyo's population and return a CityReport.",
+        tools=[lookup_population],
+        schema=CityReport,
+    )
+    kbench.assertions.assert_tool_was_invoked(lookup_population)
+    kbench.assertions.assert_equal("Tokyo", report.city)
+
+city_report_task.run(kbench.llm)
 ```
 
 [See Example: Using Tools

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -842,7 +842,20 @@ def run_simple_calculator(a: float, b: float, operator: str) -> float:
 #     works). Gemini 3 works fine through the OpenAI backend.
 #   - Non-Google models (Anthropic, DeepSeek, Qwen, GLM): Require function_call.id
 #     and function_response.id to be populated in GenAI Parts.
-@benchmark_test(exclude={"google/gemma-3-12b", "deepseek-ai/deepseek-r1-0528"})
+#   - Anthropic models (all Claude variants): Model Proxy fails to translate
+#     parameterless tools (e.g. increment_counter(), flaky_tool()) from OpenAI
+#     format to Anthropic's native format, returning choices=None on both
+#     backends. Tools with parameters (e.g. run_simple_calculator(a, b, op))
+#     work correctly. The SDK generates the correct schema per both OpenAI and
+#     Anthropic specs; this is a Model Proxy translation bug. Affects
+#     test_stateful_tool_double_execution and test_tool_error_handling.
+@benchmark_test(
+    exclude={
+        "google/gemma-3-12b",
+        "deepseek-ai/deepseek-r1-0528",
+        "deepseek-ai/deepseek-v3.2",
+    }
+)
 @kbench.task()
 def test_simple_tool_use(llm):
     problem = "What is 50 plus 25?"
@@ -864,7 +877,18 @@ def increment_counter() -> int:
     return increment_counter.count
 
 
-@benchmark_test(exclude={"google/gemma-3-12b", "deepseek-ai/deepseek-r1-0528"})
+# Anthropic models excluded: Model Proxy fails to translate parameterless tools
+# from OpenAI format to Anthropic's native format, returning choices=None.
+# The SDK schema is correct; this is a Model Proxy bug.
+@benchmark_test(
+    exclude={
+        "google/gemma-3-12b",
+        "deepseek-ai/deepseek-r1-0528",
+        "anthropic/claude-haiku-4-5@20251001",
+        "anthropic/claude-opus-4-5@20251101",
+        "anthropic/claude-sonnet-4-5@20250929",
+    }
+)
 @kbench.task()
 def test_stateful_tool_double_execution(llm):
     increment_counter.count = 0  # Reset for each test run
@@ -889,6 +913,10 @@ def multiply_tool(a: float, b: float) -> float:
     return a * b
 
 
+# NOTE: Gemini 2.x models fail this test via the OpenAI backend because Model
+# Proxy's OpenAI-compatible endpoint rejects requests with multiple tool
+# declarations (400: "Multiple tools are supported only..."). The same models
+# pass via the GenAI backend, which supports multiple tools natively.
 @benchmark_test(exclude={"google/gemma-3-12b", "deepseek-ai/deepseek-r1-0528"})
 @kbench.task()
 def test_multiple_tool_selection(llm):
@@ -935,7 +963,18 @@ def flaky_tool() -> str:
     raise ValueError("Tool execution failed simulated error.")
 
 
-@benchmark_test(exclude={"google/gemma-3-12b", "deepseek-ai/deepseek-r1-0528"})
+# Anthropic models excluded: Model Proxy fails to translate parameterless tools
+# from OpenAI format to Anthropic's native format, returning choices=None.
+# The SDK schema is correct; this is a Model Proxy bug.
+@benchmark_test(
+    exclude={
+        "google/gemma-3-12b",
+        "deepseek-ai/deepseek-r1-0528",
+        "anthropic/claude-haiku-4-5@20251001",
+        "anthropic/claude-opus-4-5@20251101",
+        "anthropic/claude-sonnet-4-5@20250929",
+    }
+)
 @kbench.task()
 def test_tool_error_handling(llm):
     response = llm.prompt(

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -817,9 +817,6 @@ def test_image_with_media_resolution(llm, api):
 
 # %%
 # --- Test Case: Tool Use ---
-# This doesn't work with "genai" API for now
-# So test it with `-k "openai"` only.
-# TODO: Rewrite this test after tool refactoring.
 
 
 def run_simple_calculator(a: float, b: float, operator: str) -> float:
@@ -835,23 +832,10 @@ def run_simple_calculator(a: float, b: float, operator: str) -> float:
     raise ValueError(f"Unknown operator: {operator}")
 
 
-# TODO(tool-calling): Multi-turn tool calling via the GenAI backend has known
-# limitations on Model Proxy:
-#   - gemini-3-flash-preview / gemini-3.1-flash-lite-preview: Multi-turn tool
-#     calling is broken in the GenAI → Gemini 3 translation layer (single-turn
-#     works). Gemini 3 works fine through the OpenAI backend.
-#   - Non-Google models (Anthropic, DeepSeek, Qwen, GLM): Require function_call.id
-#     and function_response.id to be populated in GenAI Parts.
-#   - Anthropic models (all Claude variants): Model Proxy fails to translate
-#     parameterless tools (e.g. increment_counter(), flaky_tool()) from OpenAI
-#     format to Anthropic's native format, returning choices=None on both
-#     backends. Tools with parameters (e.g. run_simple_calculator(a, b, op))
-#     work correctly. The SDK generates the correct schema per both OpenAI and
-#     Anthropic specs; this is a Model Proxy translation bug. Affects
-#     test_stateful_tool_double_execution and test_tool_error_handling.
 @benchmark_test(
     exclude={
         "google/gemma-3-12b",
+        "google/gemini-2.0-flash",
         "deepseek-ai/deepseek-r1-0528",
         "deepseek-ai/deepseek-v3.2",
     }
@@ -877,16 +861,12 @@ def increment_counter() -> int:
     return increment_counter.count
 
 
-# Anthropic models excluded: Model Proxy fails to translate parameterless tools
-# from OpenAI format to Anthropic's native format, returning choices=None.
-# The SDK schema is correct; this is a Model Proxy bug.
+# Anthropic: fails on parameterless tools (Model Proxy bug, not SDK).
 @benchmark_test(
     exclude={
         "google/gemma-3-12b",
+        "google/gemini-2.0-flash",
         "deepseek-ai/deepseek-r1-0528",
-        "anthropic/claude-haiku-4-5@20251001",
-        "anthropic/claude-opus-4-5@20251101",
-        "anthropic/claude-sonnet-4-5@20250929",
     }
 )
 @kbench.task()
@@ -913,11 +893,15 @@ def multiply_tool(a: float, b: float) -> float:
     return a * b
 
 
-# NOTE: Gemini 2.x models fail this test via the OpenAI backend because Model
-# Proxy's OpenAI-compatible endpoint rejects requests with multiple tool
-# declarations (400: "Multiple tools are supported only..."). The same models
-# pass via the GenAI backend, which supports multiple tools natively.
-@benchmark_test(exclude={"google/gemma-3-12b", "deepseek-ai/deepseek-r1-0528"})
+# Gemini 2.x via OpenAI backend rejects multiple tool declarations (400).
+# GenAI backend handles multiple tools correctly.
+@benchmark_test(
+    exclude={
+        "google/gemma-3-12b",
+        "google/gemini-2.0-flash",
+        "deepseek-ai/deepseek-r1-0528",
+    }
+)
 @kbench.task()
 def test_multiple_tool_selection(llm):
     add_tool.calls = 0
@@ -944,7 +928,13 @@ def get_user_profile(user_id: str) -> dict:
     return {"name": "Unknown", "role": "User", "skills": []}
 
 
-@benchmark_test(exclude={"google/gemma-3-12b", "deepseek-ai/deepseek-r1-0528"})
+@benchmark_test(
+    exclude={
+        "google/gemma-3-12b",
+        "google/gemini-2.0-flash",
+        "deepseek-ai/deepseek-r1-0528",
+    }
+)
 @kbench.task()
 def test_complex_tool_return(llm):
     response = llm.prompt(
@@ -963,16 +953,12 @@ def flaky_tool() -> str:
     raise ValueError("Tool execution failed simulated error.")
 
 
-# Anthropic models excluded: Model Proxy fails to translate parameterless tools
-# from OpenAI format to Anthropic's native format, returning choices=None.
-# The SDK schema is correct; this is a Model Proxy bug.
+# Anthropic: fails on parameterless tools (Model Proxy bug, not SDK).
 @benchmark_test(
     exclude={
         "google/gemma-3-12b",
+        "google/gemini-2.0-flash",
         "deepseek-ai/deepseek-r1-0528",
-        "anthropic/claude-haiku-4-5@20251001",
-        "anthropic/claude-opus-4-5@20251101",
-        "anthropic/claude-sonnet-4-5@20250929",
     }
 )
 @kbench.task()
@@ -985,4 +971,132 @@ def test_tool_error_handling(llm):
         r"(?i)error|failed|valueerror",
         response,
         expectation="Model should report the tool failure.",
+    )
+
+
+# %%
+# --- Test Case: Multi-Step Tool Chain ---
+
+
+def lookup_city_population(city: str) -> int:
+    """Looks up the population of a city. Returns the population as an integer."""
+    populations = {"Tokyo": 14_000_000, "Paris": 2_100_000, "London": 9_000_000}
+    return populations.get(city, 0)
+
+
+def format_population(population: int) -> str:
+    """Formats a population number with thousands separators."""
+    return f"{population:,}"
+
+
+@pytest.mark.slow
+@benchmark_test(
+    exclude={
+        "google/gemma-3-12b",
+        "google/gemini-2.0-flash",
+        "deepseek-ai/deepseek-r1-0528",
+    }
+)
+@kbench.task()
+def test_multi_step_tool_chain(llm):
+    """Tests that the LLM can chain tool calls: look up a value then format it."""
+    response = llm.prompt(
+        "What is the population of Tokyo? "
+        "First look it up with lookup_city_population, "
+        "then format the result with format_population.",
+        tools=[lookup_city_population, format_population],
+    )
+
+    kbench.assertions.assert_tool_was_invoked(lookup_city_population)
+    kbench.assertions.assert_contains_regex(
+        r"14.000.000",
+        response,
+        expectation="Response should contain the formatted population of Tokyo.",
+    )
+
+
+# %%
+# Anthropic works with parametered tools; parameterless failures are a
+# Model Proxy bug. This test verifies the distinction.
+
+ANTHROPIC_MODELS = {name for name in TEST_LLM_NAMES if "anthropic" in name.lower()}
+
+
+def celsius_to_fahrenheit(celsius: float) -> float:
+    """Converts a temperature from Celsius to Fahrenheit."""
+    return (celsius * 9 / 5) + 32
+
+
+@benchmark_test(include=ANTHROPIC_MODELS)
+@kbench.task()
+def test_anthropic_parametered_tool(llm):
+    """Verifies Anthropic models work with tools that have parameters."""
+    response = llm.prompt(
+        "Convert 100 degrees Celsius to Fahrenheit using the tool.",
+        tools=[celsius_to_fahrenheit],
+    )
+
+    kbench.assertions.assert_tool_was_invoked(celsius_to_fahrenheit)
+    kbench.assertions.assert_contains_regex(
+        r"212",
+        response,
+        expectation="Model should return 212 (100°C = 212°F).",
+    )
+
+
+# %%
+# --- Test Case: Tools with Structured Output ---
+
+
+class CityInfo(BaseModel):
+    """Structured info about a city."""
+
+    name: str = Field(description="The city name.")
+    population: int = Field(description="The city's population.")
+
+
+def get_city_data(city_name: str) -> dict:
+    """Returns data about a city including its population."""
+    data = {
+        "Berlin": {"name": "Berlin", "population": 3_700_000},
+        "Sydney": {"name": "Sydney", "population": 5_300_000},
+    }
+    return data.get(city_name, {"name": city_name, "population": 0})
+
+
+# TODO: schema= + tools= is broken on all backends:
+# - OpenAI SDK requires strict=True on tools when response_format is set.
+# - GenAI: tool loop passes schema= every round, causing the model to return
+#   tool_calls instead of schema-formatted content on intermediate rounds.
+# Fix: apply schema= only on the final (no tool_calls) round.
+@pytest.mark.xfail(reason="schema + tools not yet supported")
+@benchmark_test(
+    exclude={
+        "google/gemma-3-12b",
+        "google/gemini-2.0-flash",
+        "deepseek-ai/deepseek-r1-0528",
+    }
+)
+@kbench.task()
+def test_tool_with_schema_output(llm):
+    """Tests that tools and schema= work together: tool provides data,
+    LLM returns structured output."""
+    result = llm.prompt(
+        "Look up the city data for Berlin and return it as a CityInfo.",
+        tools=[get_city_data],
+        schema=CityInfo,
+    )
+
+    kbench.assertions.assert_tool_was_invoked(get_city_data)
+    kbench.assertions.assert_true(
+        isinstance(result, CityInfo),
+        f"Expected CityInfo, got {type(result).__name__}",
+    )
+    kbench.assertions.assert_equal(
+        "Berlin", result.name, expectation="City name should be Berlin."
+    )
+    kbench.assertions.assert_equal(
+        3_700_000,
+        result.population,
+        expectation="Population should be 3,700,000.",
     )

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -611,7 +611,8 @@ def test_reasoning_param(llm):
 
 
 # Only Gemini models expose reasoning traces via the API.
-# Known failures: gemini-3-flash-preview — intermittently returns empty traces.
+# Known failures: gemini-3-flash-preview — intermittently returns empty traces
+# (flaky, currently passing).
 @benchmark_test(
     include={
         "google/gemini-2.5-flash",
@@ -965,6 +966,7 @@ def format_population(population: int) -> str:
 
 
 # Known failures (openai): Gemini 2.x rejects multiple tool declarations.
+# Known failures (genai): deepseek-v3.2 — flaky 500 errors on multi-step chains.
 @pytest.mark.slow
 @benchmark_test(
     exclude={
@@ -1009,12 +1011,13 @@ def get_city_data(city_name: str) -> dict:
     return data.get(city_name, {"name": city_name, "population": 0})
 
 
-# TODO: schema= + tools= is broken on all backends:
-# - OpenAI SDK requires strict=True on tools when response_format is set.
-# - GenAI: tool loop passes schema= every round, causing the model to return
-#   tool_calls instead of schema-formatted content on intermediate rounds.
-# Fix: apply schema= only on the final (no tool_calls) round.
-# V3.2: returns plain text instead of structured JSON when both are combined.
+# Known failures:
+# - Gemini 2.0-flash / 2.5-pro (flaky): the model sometimes refuses to call
+#   the tool when the user prompt references a schema type (e.g. "CityInfo")
+#   that isn't explained during the tool-calling phase. The two-phase loop
+#   withholds schema= from tool rounds, so the model doesn't know what
+#   "CityInfo" means and asks for clarification instead of calling the tool.
+#   This does not affect Gemini 3.x or other model families.
 @benchmark_test(
     exclude={
         "deepseek-ai/deepseek-r1-0528",

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -26,6 +26,8 @@ Usage:
         `uv run pytest golden_tests/test_cookbook_examples.py::test_extract_int`
     - Run tests for a specific API (e.g., genai/openai):
         `uv run pytest golden_tests/test_cookbook_examples.py -k "genai"`
+    - Run tests for a specific feature (e.g., tool/audio/image):
+        `uv run pytest golden_tests/test_cookbook_examples.py -k "tool"`
     - Run tests and update the report:
         `uv run pytest golden_tests/test_cookbook_examples.py --generate-report`
 """
@@ -844,7 +846,6 @@ def increment_counter() -> int:
     return increment_counter.count
 
 
-# Known failures: claude — does not invoke parameterless tools.
 @benchmark_test(
     exclude={
         "deepseek-ai/deepseek-r1-0528",
@@ -931,7 +932,6 @@ def flaky_tool() -> str:
     raise ValueError("Tool execution failed simulated error.")
 
 
-# Known failures: claude — does not invoke parameterless tools.
 @benchmark_test(
     exclude={
         "deepseek-ai/deepseek-r1-0528",
@@ -985,7 +985,7 @@ def test_multi_step_tool_chain(llm):
 
     kbench.assertions.assert_tool_was_invoked(lookup_city_population)
     kbench.assertions.assert_contains_regex(
-        r"14.000.000",
+        r"14,000,000",
         response,
         expectation="Response should contain the formatted population of Tokyo.",
     )

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -835,7 +835,7 @@ def run_simple_calculator(a: float, b: float, operator: str) -> float:
     raise ValueError(f"Unknown operator: {operator}")
 
 
-@benchmark_test()
+@benchmark_test(exclude={"google/gemma-3-12b", "deepseek-ai/deepseek-r1-0528"})
 @kbench.task()
 def test_simple_tool_use(llm):
     problem = "What is 50 plus 25?"
@@ -857,7 +857,7 @@ def increment_counter() -> int:
     return increment_counter.count
 
 
-@benchmark_test()
+@benchmark_test(exclude={"google/gemma-3-12b", "deepseek-ai/deepseek-r1-0528"})
 @kbench.task()
 def test_stateful_tool_double_execution(llm):
     increment_counter.count = 0  # Reset for each test run
@@ -882,7 +882,7 @@ def multiply_tool(a: float, b: float) -> float:
     return a * b
 
 
-@benchmark_test()
+@benchmark_test(exclude={"google/gemma-3-12b", "deepseek-ai/deepseek-r1-0528"})
 @kbench.task()
 def test_multiple_tool_selection(llm):
     add_tool.calls = 0
@@ -909,7 +909,7 @@ def get_user_profile(user_id: str) -> dict:
     return {"name": "Unknown", "role": "User", "skills": []}
 
 
-@benchmark_test()
+@benchmark_test(exclude={"google/gemma-3-12b", "deepseek-ai/deepseek-r1-0528"})
 @kbench.task()
 def test_complex_tool_return(llm):
     response = llm.prompt(
@@ -928,7 +928,7 @@ def flaky_tool() -> str:
     raise ValueError("Tool execution failed simulated error.")
 
 
-@benchmark_test()
+@benchmark_test(exclude={"google/gemma-3-12b", "deepseek-ai/deepseek-r1-0528"})
 @kbench.task()
 def test_tool_error_handling(llm):
     response = llm.prompt(

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -835,6 +835,13 @@ def run_simple_calculator(a: float, b: float, operator: str) -> float:
     raise ValueError(f"Unknown operator: {operator}")
 
 
+# TODO(tool-calling): Multi-turn tool calling via the GenAI backend has known
+# limitations on Model Proxy:
+#   - gemini-3-flash-preview / gemini-3.1-flash-lite-preview: Multi-turn tool
+#     calling is broken in the GenAI → Gemini 3 translation layer (single-turn
+#     works). Gemini 3 works fine through the OpenAI backend.
+#   - Non-Google models (Anthropic, DeepSeek, Qwen, GLM): Require function_call.id
+#     and function_response.id to be populated in GenAI Parts.
 @benchmark_test(exclude={"google/gemma-3-12b", "deepseek-ai/deepseek-r1-0528"})
 @kbench.task()
 def test_simple_tool_use(llm):

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -60,7 +60,7 @@ TEST_LLM_NAMES = {
     "openai/gpt-5.5-2026-04-23",
     "deepseek-ai/deepseek-r1-0528",
     "deepseek-ai/deepseek-v3.2",
-    "xai/grok-4.20-0309-non-reasoning",
+    # xai/grok-4.20 excluded: genai→xAI tool/reasoning routing is broken in MP.
     "google/gemini-3.1-flash-lite-preview",
 }
 
@@ -184,7 +184,8 @@ def test_assess_with_judge(llm_name, judge_llm_name):
 # --- Test Case: Structured Output (Integer Extraction) ---
 
 
-# Known failures (genai): gpt-5.5, grok-4.20 — MP sends empty json_schema.name.
+# Known failures (genai): gpt-5.5 — MP sends empty json_schema.name.
+# Known failures (openai): deepseek-r1 — nondeterministic on structured int extraction.
 @benchmark_test()
 @kbench.task()
 def test_extract_int(llm):
@@ -200,7 +201,7 @@ def test_extract_int(llm):
 # --- Test Case: Structured Output (Bool Extraction) ---
 
 
-# Known failures (genai): gpt-5.5, grok-4.20 — MP sends empty json_schema.name.
+# Known failures (genai): gpt-5.5 — MP sends empty json_schema.name.
 @benchmark_test()
 @kbench.task()
 def test_extract_bool(llm):
@@ -216,7 +217,7 @@ def test_extract_bool(llm):
 # --- Test Case: Structured Output (Dict Extraction) ---
 
 
-# Known failures (genai): gpt-5.5, grok-4.20 — MP sends empty json_schema.name.
+# Known failures (genai): gpt-5.5 — MP sends empty json_schema.name.
 @benchmark_test()
 @kbench.task()
 def test_extract_dict(llm):
@@ -249,7 +250,7 @@ class RPGCharacter:
     inventory: str
 
 
-# Known failures (genai): gpt-5.5, grok-4.20 — MP sends empty json_schema.name.
+# Known failures (genai): gpt-5.5 — MP sends empty json_schema.name.
 @benchmark_test()
 @kbench.task()
 def test_extract_dataclass(llm):
@@ -280,7 +281,7 @@ class Planet(BaseModel):
     moons: list[str] = Field(default_factory=list, description="List of major moons")
 
 
-# Known failures (genai): gpt-5.5, grok-4.20 — MP sends empty json_schema.name.
+# Known failures (genai): gpt-5.5 — MP sends empty json_schema.name.
 @benchmark_test()
 @kbench.task()
 def test_extract_pydantic(llm):
@@ -311,7 +312,7 @@ class Casting(BaseModel):
     actors: list[Actor]
 
 
-# Known failures (genai): gpt-5.5, grok-4.20 — MP sends empty json_schema.name.
+# Known failures (genai): gpt-5.5 — MP sends empty json_schema.name.
 @benchmark_test()
 @kbench.task()
 def test_extract_composite_pydantic(llm):
@@ -417,7 +418,7 @@ def test_image_url(llm):
 
 
 # Excluded: text-only models that don't support image inputs via Model Proxy.
-# Known failures: gpt-5.5, grok-4.20 — model reports "no image attached" for 1x1 pixel.
+# Known failures: gpt-5.5 — model reports "no image attached" for 1x1 pixel.
 @benchmark_test(
     exclude={
         "deepseek-ai/deepseek-r1-0528",
@@ -586,7 +587,7 @@ def test_audio_url(llm):
 # support it (not all models return traces).
 
 
-# Known failures: gemini-2.0-flash, gemma-4-31b, grok-4.20 — do not support reasoning.
+# Known failures: gemini-2.0-flash, gemma-4-31b — do not support reasoning.
 @benchmark_test()
 @kbench.task()
 def test_reasoning_param(llm):
@@ -610,6 +611,7 @@ def test_reasoning_param(llm):
 
 
 # Only Gemini models expose reasoning traces via the API.
+# Known failures: gemini-3-flash-preview — intermittently returns empty traces.
 @benchmark_test(
     include={
         "google/gemini-2.5-flash",
@@ -841,7 +843,7 @@ def increment_counter() -> int:
     return increment_counter.count
 
 
-# Known failures: claude, gpt-5.5, grok-4.20 — parameterless tool schema (MP to fix).
+# Known failures: claude — does not invoke parameterless tools.
 @benchmark_test(
     exclude={
         "deepseek-ai/deepseek-r1-0528",
@@ -928,7 +930,7 @@ def flaky_tool() -> str:
     raise ValueError("Tool execution failed simulated error.")
 
 
-# Known failures: claude, gpt-5.5, grok-4.20 — parameterless tool schema (MP to fix).
+# Known failures: claude — does not invoke parameterless tools.
 @benchmark_test(
     exclude={
         "deepseek-ai/deepseek-r1-0528",

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -187,6 +187,7 @@ def test_assess_with_judge(llm_name, judge_llm_name):
 @benchmark_test(
     exclude={
         "google/gemma-3-12b",
+        "zai/glm-5",
     }
 )
 @kbench.task()
@@ -206,6 +207,7 @@ def test_extract_int(llm):
 @benchmark_test(
     exclude={
         "google/gemma-3-12b",
+        "zai/glm-5",
     }
 )
 @kbench.task()
@@ -225,6 +227,7 @@ def test_extract_bool(llm):
 @benchmark_test(
     exclude={
         "google/gemma-3-12b",
+        "zai/glm-5",
     }
 )
 @kbench.task()
@@ -261,6 +264,7 @@ class RPGCharacter:
 @benchmark_test(
     exclude={
         "google/gemma-3-12b",
+        "zai/glm-5",
     }
 )
 @kbench.task()
@@ -295,6 +299,7 @@ class Planet(BaseModel):
 @benchmark_test(
     exclude={
         "google/gemma-3-12b",
+        "zai/glm-5",
     }
 )
 @kbench.task()
@@ -329,6 +334,7 @@ class Casting(BaseModel):
 @benchmark_test(
     exclude={
         "google/gemma-3-12b",
+        "zai/glm-5",
     }
 )
 @kbench.task()
@@ -378,7 +384,11 @@ def assert_multi_qa_result(run):
     assert run.result[1] == pytest.approx(0.0)
 
 
-@benchmark_test(df=df, verify_fn=assert_multi_qa_result)
+@benchmark_test(
+    df=df,
+    verify_fn=assert_multi_qa_result,
+    exclude={"google/gemma-3-12b"},
+)
 @kbench.task()
 def test_dataset_eval(llm, df) -> tuple[float, float]:
     with kbench.client.enable_cache():
@@ -405,6 +415,7 @@ def test_dataset_eval(llm, df) -> tuple[float, float]:
     exclude={
         "deepseek-ai/deepseek-r1-0528",
         "deepseek-ai/deepseek-v3.2",
+        "google/gemma-3-12b",
         "qwen/qwen3-235b-a22b-instruct-2507",
         "qwen/qwen3-next-80b-a3b-instruct",
         "zai/glm-5",
@@ -433,11 +444,12 @@ def test_image_url(llm):
 
 @benchmark_test(
     exclude={
+        "anthropic/claude-sonnet-4-5@20250929",
         "deepseek-ai/deepseek-r1-0528",
         "deepseek-ai/deepseek-v3.2",
+        "google/gemma-3-12b",
         "qwen/qwen3-235b-a22b-instruct-2507",
         "qwen/qwen3-next-80b-a3b-instruct",
-        "anthropic/claude-sonnet-4-5@20250929",
         "zai/glm-5",
     }
 )
@@ -469,6 +481,7 @@ def test_image_base64(llm):
     exclude={
         "deepseek-ai/deepseek-r1-0528",
         "deepseek-ai/deepseek-v3.2",
+        "google/gemma-3-12b",
         "qwen/qwen3-235b-a22b-instruct-2507",
         "qwen/qwen3-next-80b-a3b-instruct",
         "zai/glm-5",
@@ -861,7 +874,7 @@ def increment_counter() -> int:
     return increment_counter.count
 
 
-# Anthropic: fails on parameterless tools (Model Proxy bug, not SDK).
+# Anthropic: fails on parameterless tools (MP to fix).
 @benchmark_test(
     exclude={
         "google/gemma-3-12b",
@@ -893,7 +906,7 @@ def multiply_tool(a: float, b: float) -> float:
     return a * b
 
 
-# Gemini 2.x via OpenAI backend rejects multiple tool declarations (400).
+# Gemini 2.x via OpenAI backend rejects multiple tool declarations.
 # GenAI backend handles multiple tools correctly.
 @benchmark_test(
     exclude={
@@ -953,7 +966,7 @@ def flaky_tool() -> str:
     raise ValueError("Tool execution failed simulated error.")
 
 
-# Anthropic: fails on parameterless tools (Model Proxy bug, not SDK).
+# Anthropic: fails on parameterless tools (MP to fix).
 @benchmark_test(
     exclude={
         "google/gemma-3-12b",
@@ -1016,35 +1029,6 @@ def test_multi_step_tool_chain(llm):
 
 
 # %%
-# Anthropic works with parametered tools; parameterless failures are a
-# Model Proxy bug. This test verifies the distinction.
-
-ANTHROPIC_MODELS = {name for name in TEST_LLM_NAMES if "anthropic" in name.lower()}
-
-
-def celsius_to_fahrenheit(celsius: float) -> float:
-    """Converts a temperature from Celsius to Fahrenheit."""
-    return (celsius * 9 / 5) + 32
-
-
-@benchmark_test(include=ANTHROPIC_MODELS)
-@kbench.task()
-def test_anthropic_parametered_tool(llm):
-    """Verifies Anthropic models work with tools that have parameters."""
-    response = llm.prompt(
-        "Convert 100 degrees Celsius to Fahrenheit using the tool.",
-        tools=[celsius_to_fahrenheit],
-    )
-
-    kbench.assertions.assert_tool_was_invoked(celsius_to_fahrenheit)
-    kbench.assertions.assert_contains_regex(
-        r"212",
-        response,
-        expectation="Model should return 212 (100°C = 212°F).",
-    )
-
-
-# %%
 # --- Test Case: Tools with Structured Output ---
 
 
@@ -1069,7 +1053,6 @@ def get_city_data(city_name: str) -> dict:
 # - GenAI: tool loop passes schema= every round, causing the model to return
 #   tool_calls instead of schema-formatted content on intermediate rounds.
 # Fix: apply schema= only on the final (no tool_calls) round.
-@pytest.mark.xfail(reason="schema + tools not yet supported")
 @benchmark_test(
     exclude={
         "google/gemma-3-12b",

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -52,15 +52,15 @@ TEST_LLM_NAMES = {
     "google/gemini-2.5-flash",
     "google/gemini-2.5-pro",
     "google/gemini-3-flash-preview",
-    "google/gemma-3-12b",
+    "google/gemma-4-31b",
     "qwen/qwen3-235b-a22b-instruct-2507",
     "qwen/qwen3-next-80b-a3b-instruct",
-    "anthropic/claude-haiku-4-5@20251001",
-    "anthropic/claude-opus-4-5@20251101",
-    "anthropic/claude-sonnet-4-5@20250929",
+    "anthropic/claude-sonnet-4-6@default",
+    "anthropic/claude-opus-4-7@default",
+    "openai/gpt-5.5-2026-04-23",
     "deepseek-ai/deepseek-r1-0528",
     "deepseek-ai/deepseek-v3.2",
-    "zai/glm-5",
+    "xai/grok-4.20-0309-non-reasoning",
     "google/gemini-3.1-flash-lite-preview",
 }
 
@@ -184,12 +184,8 @@ def test_assess_with_judge(llm_name, judge_llm_name):
 # --- Test Case: Structured Output (Integer Extraction) ---
 
 
-@benchmark_test(
-    exclude={
-        "google/gemma-3-12b",
-        "zai/glm-5",
-    }
-)
+# Known failures (genai): gpt-5.5, grok-4.20 — MP sends empty json_schema.name.
+@benchmark_test()
 @kbench.task()
 def test_extract_int(llm):
     text = "The Apollo 11 mission landed on the Moon in 1969."
@@ -204,12 +200,8 @@ def test_extract_int(llm):
 # --- Test Case: Structured Output (Bool Extraction) ---
 
 
-@benchmark_test(
-    exclude={
-        "google/gemma-3-12b",
-        "zai/glm-5",
-    }
-)
+# Known failures (genai): gpt-5.5, grok-4.20 — MP sends empty json_schema.name.
+@benchmark_test()
 @kbench.task()
 def test_extract_bool(llm):
     text = "I absolutely loved this movie! It was fantastic."
@@ -224,12 +216,8 @@ def test_extract_bool(llm):
 # --- Test Case: Structured Output (Dict Extraction) ---
 
 
-@benchmark_test(
-    exclude={
-        "google/gemma-3-12b",
-        "zai/glm-5",
-    }
-)
+# Known failures (genai): gpt-5.5, grok-4.20 — MP sends empty json_schema.name.
+@benchmark_test()
 @kbench.task()
 def test_extract_dict(llm):
     text = "Contact info: John Doe, age 42, works as a Software Engineer."
@@ -261,12 +249,8 @@ class RPGCharacter:
     inventory: str
 
 
-@benchmark_test(
-    exclude={
-        "google/gemma-3-12b",
-        "zai/glm-5",
-    }
-)
+# Known failures (genai): gpt-5.5, grok-4.20 — MP sends empty json_schema.name.
+@benchmark_test()
 @kbench.task()
 def test_extract_dataclass(llm):
     character = llm.prompt(
@@ -296,12 +280,8 @@ class Planet(BaseModel):
     moons: list[str] = Field(default_factory=list, description="List of major moons")
 
 
-@benchmark_test(
-    exclude={
-        "google/gemma-3-12b",
-        "zai/glm-5",
-    }
-)
+# Known failures (genai): gpt-5.5, grok-4.20 — MP sends empty json_schema.name.
+@benchmark_test()
 @kbench.task()
 def test_extract_pydantic(llm):
     planet = llm.prompt("Provide information about the planet Jupiter.", schema=Planet)
@@ -331,12 +311,8 @@ class Casting(BaseModel):
     actors: list[Actor]
 
 
-@benchmark_test(
-    exclude={
-        "google/gemma-3-12b",
-        "zai/glm-5",
-    }
-)
+# Known failures (genai): gpt-5.5, grok-4.20 — MP sends empty json_schema.name.
+@benchmark_test()
 @kbench.task()
 def test_extract_composite_pydantic(llm):
     casting = llm.prompt("List the 6 main characters of Friends.", schema=Casting)
@@ -387,7 +363,6 @@ def assert_multi_qa_result(run):
 @benchmark_test(
     df=df,
     verify_fn=assert_multi_qa_result,
-    exclude={"google/gemma-3-12b"},
 )
 @kbench.task()
 def test_dataset_eval(llm, df) -> tuple[float, float]:
@@ -411,14 +386,13 @@ def test_dataset_eval(llm, df) -> tuple[float, float]:
 # --- Test Case: Image inputs (URL) ---
 
 
+# Excluded: text-only models that don't support image inputs via Model Proxy.
 @benchmark_test(
     exclude={
         "deepseek-ai/deepseek-r1-0528",
         "deepseek-ai/deepseek-v3.2",
-        "google/gemma-3-12b",
         "qwen/qwen3-235b-a22b-instruct-2507",
         "qwen/qwen3-next-80b-a3b-instruct",
-        "zai/glm-5",
     }
 )
 @kbench.task()
@@ -442,15 +416,14 @@ def test_image_url(llm):
 # --- Test Case: Image inputs (Base64) ---
 
 
+# Excluded: text-only models that don't support image inputs via Model Proxy.
+# Known failures: gpt-5.5, grok-4.20 — model reports "no image attached" for 1x1 pixel.
 @benchmark_test(
     exclude={
-        "anthropic/claude-sonnet-4-5@20250929",
         "deepseek-ai/deepseek-r1-0528",
         "deepseek-ai/deepseek-v3.2",
-        "google/gemma-3-12b",
         "qwen/qwen3-235b-a22b-instruct-2507",
         "qwen/qwen3-next-80b-a3b-instruct",
-        "zai/glm-5",
     }
 )
 @kbench.task()
@@ -477,14 +450,13 @@ def test_image_base64(llm):
 # --- Test Case: Image inputs (local file) ---
 
 
+# Excluded: text-only models that don't support image inputs via Model Proxy.
 @benchmark_test(
     exclude={
         "deepseek-ai/deepseek-r1-0528",
         "deepseek-ai/deepseek-v3.2",
-        "google/gemma-3-12b",
         "qwen/qwen3-235b-a22b-instruct-2507",
         "qwen/qwen3-next-80b-a3b-instruct",
-        "zai/glm-5",
     }
 )
 @kbench.task()
@@ -507,6 +479,7 @@ def test_image_local_file(llm):
 # --- Test Case: Video inputs (URL) ---
 
 
+# Only Gemini models support video input via Model Proxy.
 @benchmark_test(
     include={
         "google/gemini-2.5-flash",
@@ -613,12 +586,8 @@ def test_audio_url(llm):
 # support it (not all models return traces).
 
 
-@benchmark_test(
-    exclude={
-        "google/gemini-2.0-flash",
-        "google/gemma-3-12b",
-    },
-)
+# Known failures: gemini-2.0-flash, gemma-4-31b, grok-4.20 — do not support reasoning.
+@benchmark_test()
 @kbench.task()
 def test_reasoning_param(llm):
     """Tests that the unified reasoning parameter works across providers."""
@@ -640,11 +609,12 @@ def test_reasoning_param(llm):
 # when reasoning is enabled, accessible via message.reasoning_traces.
 
 
+# Only Gemini models expose reasoning traces via the API.
 @benchmark_test(
     include={
         "google/gemini-2.5-flash",
         "google/gemini-2.5-pro",
-        "anthropic/claude-sonnet-4-5@20250929",
+        "google/gemini-3-flash-preview",
     },
 )
 @kbench.task()
@@ -847,10 +817,7 @@ def run_simple_calculator(a: float, b: float, operator: str) -> float:
 
 @benchmark_test(
     exclude={
-        "google/gemma-3-12b",
-        "google/gemini-2.0-flash",
         "deepseek-ai/deepseek-r1-0528",
-        "deepseek-ai/deepseek-v3.2",
     }
 )
 @kbench.task()
@@ -874,11 +841,9 @@ def increment_counter() -> int:
     return increment_counter.count
 
 
-# Anthropic: fails on parameterless tools (MP to fix).
+# Known failures: claude, gpt-5.5, grok-4.20 — parameterless tool schema (MP to fix).
 @benchmark_test(
     exclude={
-        "google/gemma-3-12b",
-        "google/gemini-2.0-flash",
         "deepseek-ai/deepseek-r1-0528",
     }
 )
@@ -910,8 +875,6 @@ def multiply_tool(a: float, b: float) -> float:
 # GenAI backend handles multiple tools correctly.
 @benchmark_test(
     exclude={
-        "google/gemma-3-12b",
-        "google/gemini-2.0-flash",
         "deepseek-ai/deepseek-r1-0528",
     }
 )
@@ -941,10 +904,9 @@ def get_user_profile(user_id: str) -> dict:
     return {"name": "Unknown", "role": "User", "skills": []}
 
 
+# Known failures: gemini-2.0-flash returns incorrect role on both APIs.
 @benchmark_test(
     exclude={
-        "google/gemma-3-12b",
-        "google/gemini-2.0-flash",
         "deepseek-ai/deepseek-r1-0528",
     }
 )
@@ -966,11 +928,9 @@ def flaky_tool() -> str:
     raise ValueError("Tool execution failed simulated error.")
 
 
-# Anthropic: fails on parameterless tools (MP to fix).
+# Known failures: claude, gpt-5.5, grok-4.20 — parameterless tool schema (MP to fix).
 @benchmark_test(
     exclude={
-        "google/gemma-3-12b",
-        "google/gemini-2.0-flash",
         "deepseek-ai/deepseek-r1-0528",
     }
 )
@@ -1002,11 +962,10 @@ def format_population(population: int) -> str:
     return f"{population:,}"
 
 
+# Known failures (openai): Gemini 2.x rejects multiple tool declarations.
 @pytest.mark.slow
 @benchmark_test(
     exclude={
-        "google/gemma-3-12b",
-        "google/gemini-2.0-flash",
         "deepseek-ai/deepseek-r1-0528",
     }
 )
@@ -1053,11 +1012,11 @@ def get_city_data(city_name: str) -> dict:
 # - GenAI: tool loop passes schema= every round, causing the model to return
 #   tool_calls instead of schema-formatted content on intermediate rounds.
 # Fix: apply schema= only on the final (no tool_calls) round.
+# V3.2: returns plain text instead of structured JSON when both are combined.
 @benchmark_test(
     exclude={
-        "google/gemma-3-12b",
-        "google/gemini-2.0-flash",
         "deepseek-ai/deepseek-r1-0528",
+        "deepseek-ai/deepseek-v3.2",
     }
 )
 @kbench.task()

--- a/golden_tests/test_cookbook_examples_report.yaml
+++ b/golden_tests/test_cookbook_examples_report.yaml
@@ -1,17 +1,3 @@
-# Copyright 2026 Kaggle Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 genai://anthropic/claude-opus-4-7@default:
   config:
     structured_output: true

--- a/golden_tests/test_cookbook_examples_report.yaml
+++ b/golden_tests/test_cookbook_examples_report.yaml
@@ -1,8 +1,22 @@
-genai://anthropic/claude-haiku-4-5@20251001:
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+genai://anthropic/claude-opus-4-7@default:
   config:
     structured_output: true
   tests:
-    test_complex_tool_return: failed
+    test_complex_tool_return: passed
     test_dataset_eval: passed
     test_extract_bool: passed
     test_extract_composite_pydantic: passed
@@ -13,16 +27,18 @@ genai://anthropic/claude-haiku-4-5@20251001:
     test_image_base64: passed
     test_image_local_file: passed
     test_image_url: passed
-    test_multiple_tool_selection: failed
+    test_multi_step_tool_chain: passed
+    test_multiple_tool_selection: passed
     test_reasoning_param: passed
-    test_simple_tool_use: failed
+    test_simple_tool_use: passed
     test_stateful_tool_double_execution: failed
     test_tool_error_handling: failed
-genai://anthropic/claude-opus-4-5@20251101:
+    test_tool_with_schema_output: passed
+genai://anthropic/claude-sonnet-4-6@default:
   config:
     structured_output: true
   tests:
-    test_complex_tool_return: failed
+    test_complex_tool_return: passed
     test_dataset_eval: passed
     test_extract_bool: passed
     test_extract_composite_pydantic: passed
@@ -33,36 +49,17 @@ genai://anthropic/claude-opus-4-5@20251101:
     test_image_base64: passed
     test_image_local_file: passed
     test_image_url: passed
-    test_multiple_tool_selection: failed
+    test_multi_step_tool_chain: passed
+    test_multiple_tool_selection: passed
     test_reasoning_param: passed
-    test_simple_tool_use: failed
+    test_simple_tool_use: passed
     test_stateful_tool_double_execution: failed
     test_tool_error_handling: failed
-genai://anthropic/claude-sonnet-4-5@20250929:
-  config:
-    structured_output: true
-  tests:
-    test_complex_tool_return: failed
-    test_dataset_eval: passed
-    test_extract_bool: passed
-    test_extract_composite_pydantic: passed
-    test_extract_dataclass: passed
-    test_extract_dict: passed
-    test_extract_int: passed
-    test_extract_pydantic: passed
-    test_image_local_file: passed
-    test_image_url: passed
-    test_multiple_tool_selection: failed
-    test_reasoning_captures_traces: passed
-    test_reasoning_param: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
+    test_tool_with_schema_output: passed
 genai://deepseek-ai/deepseek-r1-0528:
   config:
     structured_output: false
   tests:
-    test_complex_tool_return: failed
     test_dataset_eval: passed
     test_extract_bool: passed
     test_extract_composite_pydantic: passed
@@ -70,16 +67,12 @@ genai://deepseek-ai/deepseek-r1-0528:
     test_extract_dict: passed
     test_extract_int: passed
     test_extract_pydantic: passed
-    test_multiple_tool_selection: failed
     test_reasoning_param: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
 genai://deepseek-ai/deepseek-v3.2:
   config:
     structured_output: false
   tests:
-    test_complex_tool_return: failed
+    test_complex_tool_return: passed
     test_dataset_eval: passed
     test_extract_bool: passed
     test_extract_composite_pydantic: passed
@@ -87,11 +80,12 @@ genai://deepseek-ai/deepseek-v3.2:
     test_extract_dict: passed
     test_extract_int: passed
     test_extract_pydantic: passed
-    test_multiple_tool_selection: failed
+    test_multi_step_tool_chain: passed
+    test_multiple_tool_selection: passed
     test_reasoning_param: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
+    test_simple_tool_use: passed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
 genai://google/gemini-2.0-flash:
   config:
     structured_output: true
@@ -110,10 +104,13 @@ genai://google/gemini-2.0-flash:
     test_image_base64: passed
     test_image_local_file: passed
     test_image_url: passed
+    test_multi_step_tool_chain: passed
     test_multiple_tool_selection: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
+    test_reasoning_param: failed
+    test_simple_tool_use: passed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
+    test_tool_with_schema_output: failed
 genai://google/gemini-2.5-flash:
   config:
     structured_output: true
@@ -132,12 +129,14 @@ genai://google/gemini-2.5-flash:
     test_image_base64: passed
     test_image_local_file: passed
     test_image_url: passed
+    test_multi_step_tool_chain: passed
     test_multiple_tool_selection: passed
     test_reasoning_captures_traces: passed
     test_reasoning_param: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
+    test_simple_tool_use: passed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
+    test_tool_with_schema_output: failed
     test_video_url: passed
 genai://google/gemini-2.5-pro:
   config:
@@ -157,12 +156,14 @@ genai://google/gemini-2.5-pro:
     test_image_base64: passed
     test_image_local_file: passed
     test_image_url: passed
+    test_multi_step_tool_chain: passed
     test_multiple_tool_selection: passed
     test_reasoning_captures_traces: passed
     test_reasoning_param: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
+    test_simple_tool_use: passed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
+    test_tool_with_schema_output: failed
     test_video_url: passed
 genai://google/gemini-3-flash-preview:
   config:
@@ -171,7 +172,7 @@ genai://google/gemini-3-flash-preview:
     test_audio_base64: passed
     test_audio_local_file: passed
     test_audio_url: passed
-    test_complex_tool_return: failed
+    test_complex_tool_return: passed
     test_dataset_eval: passed
     test_extra_api_params_max_tokens_genai: passed
     test_extract_bool: passed
@@ -184,11 +185,14 @@ genai://google/gemini-3-flash-preview:
     test_image_local_file: passed
     test_image_url: passed
     test_image_with_media_resolution: passed
-    test_multiple_tool_selection: failed
+    test_multi_step_tool_chain: passed
+    test_multiple_tool_selection: passed
+    test_reasoning_captures_traces: passed
     test_reasoning_param: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
+    test_simple_tool_use: passed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
+    test_tool_with_schema_output: failed
     test_video_url: passed
 genai://google/gemini-3.1-flash-lite-preview:
   config:
@@ -197,7 +201,7 @@ genai://google/gemini-3.1-flash-lite-preview:
     test_audio_base64: passed
     test_audio_local_file: passed
     test_audio_url: passed
-    test_complex_tool_return: failed
+    test_complex_tool_return: passed
     test_dataset_eval: passed
     test_extract_bool: passed
     test_extract_composite_pydantic: passed
@@ -208,63 +212,40 @@ genai://google/gemini-3.1-flash-lite-preview:
     test_image_base64: passed
     test_image_local_file: passed
     test_image_url: passed
-    test_multiple_tool_selection: failed
+    test_multi_step_tool_chain: passed
+    test_multiple_tool_selection: passed
     test_reasoning_param: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
-genai://google/gemma-3-12b:
+    test_simple_tool_use: passed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
+    test_tool_with_schema_output: failed
+genai://google/gemma-4-31b:
   config:
-    structured_output: true
+    structured_output: false
   tests:
-    test_complex_tool_return: failed
+    test_complex_tool_return: passed
     test_dataset_eval: passed
+    test_extract_bool: passed
+    test_extract_composite_pydantic: passed
+    test_extract_dataclass: passed
+    test_extract_dict: passed
+    test_extract_int: passed
+    test_extract_pydantic: passed
     test_image_base64: passed
     test_image_local_file: passed
     test_image_url: passed
-    test_multiple_tool_selection: failed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
-genai://qwen/qwen3-235b-a22b-instruct-2507:
-  config:
-    structured_output: false
-  tests:
-    test_complex_tool_return: failed
-    test_dataset_eval: passed
-    test_extract_bool: passed
-    test_extract_composite_pydantic: passed
-    test_extract_dataclass: passed
-    test_extract_dict: passed
-    test_extract_int: passed
-    test_extract_pydantic: passed
-    test_multiple_tool_selection: failed
-    test_reasoning_param: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
-genai://qwen/qwen3-next-80b-a3b-instruct:
-  config:
-    structured_output: false
-  tests:
-    test_complex_tool_return: failed
-    test_dataset_eval: passed
-    test_extract_bool: passed
-    test_extract_composite_pydantic: passed
-    test_extract_dataclass: passed
-    test_extract_dict: passed
-    test_extract_int: passed
-    test_extract_pydantic: passed
-    test_multiple_tool_selection: failed
-    test_reasoning_param: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
-genai://zai/glm-5:
+    test_multi_step_tool_chain: passed
+    test_multiple_tool_selection: passed
+    test_reasoning_param: failed
+    test_simple_tool_use: passed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
+    test_tool_with_schema_output: failed
+genai://openai/gpt-5.5-2026-04-23:
   config:
     structured_output: true
   tests:
-    test_complex_tool_return: failed
+    test_complex_tool_return: passed
     test_dataset_eval: passed
     test_extract_bool: failed
     test_extract_composite_pydantic: failed
@@ -272,16 +253,81 @@ genai://zai/glm-5:
     test_extract_dict: failed
     test_extract_int: failed
     test_extract_pydantic: failed
-    test_multiple_tool_selection: failed
+    test_image_base64: failed
+    test_image_local_file: passed
+    test_image_url: passed
+    test_multi_step_tool_chain: passed
+    test_multiple_tool_selection: passed
     test_reasoning_param: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
-openai://anthropic/claude-haiku-4-5@20251001:
+    test_simple_tool_use: passed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
+    test_tool_with_schema_output: failed
+genai://qwen/qwen3-235b-a22b-instruct-2507:
+  config:
+    structured_output: false
+  tests:
+    test_complex_tool_return: passed
+    test_dataset_eval: passed
+    test_extract_bool: passed
+    test_extract_composite_pydantic: passed
+    test_extract_dataclass: passed
+    test_extract_dict: passed
+    test_extract_int: passed
+    test_extract_pydantic: passed
+    test_multi_step_tool_chain: passed
+    test_multiple_tool_selection: passed
+    test_reasoning_param: passed
+    test_simple_tool_use: passed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
+    test_tool_with_schema_output: failed
+genai://qwen/qwen3-next-80b-a3b-instruct:
+  config:
+    structured_output: false
+  tests:
+    test_complex_tool_return: passed
+    test_dataset_eval: passed
+    test_extract_bool: passed
+    test_extract_composite_pydantic: passed
+    test_extract_dataclass: passed
+    test_extract_dict: passed
+    test_extract_int: passed
+    test_extract_pydantic: passed
+    test_multi_step_tool_chain: passed
+    test_multiple_tool_selection: passed
+    test_reasoning_param: passed
+    test_simple_tool_use: passed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
+    test_tool_with_schema_output: failed
+genai://xai/grok-4.20-0309-non-reasoning:
   config:
     structured_output: true
   tests:
     test_complex_tool_return: failed
+    test_dataset_eval: failed
+    test_extract_bool: failed
+    test_extract_composite_pydantic: failed
+    test_extract_dataclass: failed
+    test_extract_dict: failed
+    test_extract_int: failed
+    test_extract_pydantic: failed
+    test_image_base64: failed
+    test_image_local_file: passed
+    test_image_url: passed
+    test_multi_step_tool_chain: failed
+    test_multiple_tool_selection: failed
+    test_reasoning_param: failed
+    test_simple_tool_use: failed
+    test_stateful_tool_double_execution: failed
+    test_tool_error_handling: failed
+    test_tool_with_schema_output: failed
+openai://anthropic/claude-opus-4-7@default:
+  config:
+    structured_output: true
+  tests:
+    test_complex_tool_return: passed
     test_dataset_eval: passed
     test_extract_bool: passed
     test_extract_composite_pydantic: passed
@@ -292,16 +338,18 @@ openai://anthropic/claude-haiku-4-5@20251001:
     test_image_base64: passed
     test_image_local_file: passed
     test_image_url: passed
-    test_multiple_tool_selection: failed
+    test_multi_step_tool_chain: passed
+    test_multiple_tool_selection: passed
     test_reasoning_param: passed
-    test_simple_tool_use: failed
+    test_simple_tool_use: passed
     test_stateful_tool_double_execution: failed
     test_tool_error_handling: failed
-openai://anthropic/claude-opus-4-5@20251101:
+    test_tool_with_schema_output: failed
+openai://anthropic/claude-sonnet-4-6@default:
   config:
     structured_output: true
   tests:
-    test_complex_tool_return: failed
+    test_complex_tool_return: passed
     test_dataset_eval: passed
     test_extract_bool: passed
     test_extract_composite_pydantic: passed
@@ -312,36 +360,17 @@ openai://anthropic/claude-opus-4-5@20251101:
     test_image_base64: passed
     test_image_local_file: passed
     test_image_url: passed
-    test_multiple_tool_selection: failed
+    test_multi_step_tool_chain: passed
+    test_multiple_tool_selection: passed
     test_reasoning_param: passed
-    test_simple_tool_use: failed
+    test_simple_tool_use: passed
     test_stateful_tool_double_execution: failed
     test_tool_error_handling: failed
-openai://anthropic/claude-sonnet-4-5@20250929:
-  config:
-    structured_output: true
-  tests:
-    test_complex_tool_return: failed
-    test_dataset_eval: passed
-    test_extract_bool: passed
-    test_extract_composite_pydantic: passed
-    test_extract_dataclass: passed
-    test_extract_dict: passed
-    test_extract_int: passed
-    test_extract_pydantic: passed
-    test_image_local_file: passed
-    test_image_url: passed
-    test_multiple_tool_selection: failed
-    test_reasoning_captures_traces: passed
-    test_reasoning_param: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
+    test_tool_with_schema_output: failed
 openai://deepseek-ai/deepseek-r1-0528:
   config:
     structured_output: false
   tests:
-    test_complex_tool_return: failed
     test_dataset_eval: passed
     test_extract_bool: passed
     test_extract_composite_pydantic: passed
@@ -349,16 +378,12 @@ openai://deepseek-ai/deepseek-r1-0528:
     test_extract_dict: passed
     test_extract_int: passed
     test_extract_pydantic: passed
-    test_multiple_tool_selection: failed
     test_reasoning_param: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
 openai://deepseek-ai/deepseek-v3.2:
   config:
     structured_output: false
   tests:
-    test_complex_tool_return: failed
+    test_complex_tool_return: passed
     test_dataset_eval: passed
     test_extract_bool: passed
     test_extract_composite_pydantic: passed
@@ -366,11 +391,12 @@ openai://deepseek-ai/deepseek-v3.2:
     test_extract_dict: passed
     test_extract_int: passed
     test_extract_pydantic: passed
-    test_multiple_tool_selection: failed
+    test_multi_step_tool_chain: passed
+    test_multiple_tool_selection: passed
     test_reasoning_param: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
+    test_simple_tool_use: passed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
 openai://google/gemini-2.0-flash:
   config:
     structured_output: true
@@ -389,10 +415,13 @@ openai://google/gemini-2.0-flash:
     test_image_base64: passed
     test_image_local_file: passed
     test_image_url: passed
+    test_multi_step_tool_chain: failed
     test_multiple_tool_selection: failed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
+    test_reasoning_param: failed
+    test_simple_tool_use: passed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
+    test_tool_with_schema_output: failed
 openai://google/gemini-2.5-flash:
   config:
     structured_output: true
@@ -400,7 +429,7 @@ openai://google/gemini-2.5-flash:
     test_audio_base64: passed
     test_audio_local_file: passed
     test_audio_url: passed
-    test_complex_tool_return: failed
+    test_complex_tool_return: passed
     test_dataset_eval: passed
     test_extract_bool: passed
     test_extract_composite_pydantic: passed
@@ -411,12 +440,14 @@ openai://google/gemini-2.5-flash:
     test_image_base64: passed
     test_image_local_file: passed
     test_image_url: passed
+    test_multi_step_tool_chain: failed
     test_multiple_tool_selection: failed
     test_reasoning_captures_traces: passed
     test_reasoning_param: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
+    test_simple_tool_use: passed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
+    test_tool_with_schema_output: failed
     test_video_url: passed
 openai://google/gemini-2.5-pro:
   config:
@@ -425,7 +456,7 @@ openai://google/gemini-2.5-pro:
     test_audio_base64: passed
     test_audio_local_file: passed
     test_audio_url: passed
-    test_complex_tool_return: failed
+    test_complex_tool_return: passed
     test_dataset_eval: passed
     test_extract_bool: passed
     test_extract_composite_pydantic: passed
@@ -436,12 +467,14 @@ openai://google/gemini-2.5-pro:
     test_image_base64: passed
     test_image_local_file: passed
     test_image_url: passed
+    test_multi_step_tool_chain: failed
     test_multiple_tool_selection: failed
     test_reasoning_captures_traces: passed
     test_reasoning_param: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
+    test_simple_tool_use: passed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
+    test_tool_with_schema_output: failed
     test_video_url: passed
 openai://google/gemini-3-flash-preview:
   config:
@@ -450,7 +483,7 @@ openai://google/gemini-3-flash-preview:
     test_audio_base64: passed
     test_audio_local_file: passed
     test_audio_url: passed
-    test_complex_tool_return: failed
+    test_complex_tool_return: passed
     test_dataset_eval: passed
     test_extra_api_params_max_tokens_openai: passed
     test_extract_bool: passed
@@ -463,11 +496,14 @@ openai://google/gemini-3-flash-preview:
     test_image_local_file: passed
     test_image_url: passed
     test_image_with_detail: passed
-    test_multiple_tool_selection: failed
+    test_multi_step_tool_chain: passed
+    test_multiple_tool_selection: passed
+    test_reasoning_captures_traces: passed
     test_reasoning_param: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
+    test_simple_tool_use: passed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
+    test_tool_with_schema_output: failed
     test_video_url: passed
 openai://google/gemini-3.1-flash-lite-preview:
   config:
@@ -476,7 +512,7 @@ openai://google/gemini-3.1-flash-lite-preview:
     test_audio_base64: passed
     test_audio_local_file: passed
     test_audio_url: passed
-    test_complex_tool_return: failed
+    test_complex_tool_return: passed
     test_dataset_eval: passed
     test_extract_bool: passed
     test_extract_composite_pydantic: passed
@@ -487,29 +523,62 @@ openai://google/gemini-3.1-flash-lite-preview:
     test_image_base64: passed
     test_image_local_file: passed
     test_image_url: passed
-    test_multiple_tool_selection: failed
+    test_multi_step_tool_chain: passed
+    test_multiple_tool_selection: passed
     test_reasoning_param: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
-openai://google/gemma-3-12b:
+    test_simple_tool_use: passed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
+    test_tool_with_schema_output: failed
+openai://google/gemma-4-31b:
   config:
-    structured_output: true
+    structured_output: false
   tests:
-    test_complex_tool_return: failed
+    test_complex_tool_return: passed
     test_dataset_eval: passed
+    test_extract_bool: passed
+    test_extract_composite_pydantic: passed
+    test_extract_dataclass: passed
+    test_extract_dict: passed
+    test_extract_int: passed
+    test_extract_pydantic: passed
     test_image_base64: passed
     test_image_local_file: passed
     test_image_url: passed
-    test_multiple_tool_selection: failed
-    test_simple_tool_use: failed
+    test_multi_step_tool_chain: passed
+    test_multiple_tool_selection: passed
+    test_reasoning_param: failed
+    test_simple_tool_use: passed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
+    test_tool_with_schema_output: failed
+openai://openai/gpt-5.5-2026-04-23:
+  config:
+    structured_output: true
+  tests:
+    test_complex_tool_return: passed
+    test_dataset_eval: passed
+    test_extract_bool: passed
+    test_extract_composite_pydantic: passed
+    test_extract_dataclass: passed
+    test_extract_dict: passed
+    test_extract_int: passed
+    test_extract_pydantic: passed
+    test_image_base64: failed
+    test_image_local_file: passed
+    test_image_url: passed
+    test_multi_step_tool_chain: passed
+    test_multiple_tool_selection: passed
+    test_reasoning_param: passed
+    test_simple_tool_use: passed
     test_stateful_tool_double_execution: failed
     test_tool_error_handling: failed
+    test_tool_with_schema_output: failed
 openai://qwen/qwen3-235b-a22b-instruct-2507:
   config:
     structured_output: false
   tests:
-    test_complex_tool_return: failed
+    test_complex_tool_return: passed
     test_dataset_eval: passed
     test_extract_bool: passed
     test_extract_composite_pydantic: passed
@@ -517,16 +586,18 @@ openai://qwen/qwen3-235b-a22b-instruct-2507:
     test_extract_dict: passed
     test_extract_int: passed
     test_extract_pydantic: passed
-    test_multiple_tool_selection: failed
+    test_multi_step_tool_chain: passed
+    test_multiple_tool_selection: passed
     test_reasoning_param: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
+    test_simple_tool_use: passed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
+    test_tool_with_schema_output: failed
 openai://qwen/qwen3-next-80b-a3b-instruct:
   config:
     structured_output: false
   tests:
-    test_complex_tool_return: failed
+    test_complex_tool_return: passed
     test_dataset_eval: passed
     test_extract_bool: passed
     test_extract_composite_pydantic: passed
@@ -534,25 +605,32 @@ openai://qwen/qwen3-next-80b-a3b-instruct:
     test_extract_dict: passed
     test_extract_int: passed
     test_extract_pydantic: passed
-    test_multiple_tool_selection: failed
+    test_multi_step_tool_chain: passed
+    test_multiple_tool_selection: passed
     test_reasoning_param: passed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
-openai://zai/glm-5:
+    test_simple_tool_use: passed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
+    test_tool_with_schema_output: failed
+openai://xai/grok-4.20-0309-non-reasoning:
   config:
     structured_output: true
   tests:
-    test_complex_tool_return: failed
+    test_complex_tool_return: passed
     test_dataset_eval: passed
-    test_extract_bool: passed
+    test_extract_bool: failed
     test_extract_composite_pydantic: passed
     test_extract_dataclass: passed
     test_extract_dict: passed
     test_extract_int: passed
     test_extract_pydantic: passed
-    test_multiple_tool_selection: failed
-    test_reasoning_param: passed
-    test_simple_tool_use: failed
+    test_image_base64: failed
+    test_image_local_file: passed
+    test_image_url: passed
+    test_multi_step_tool_chain: passed
+    test_multiple_tool_selection: passed
+    test_reasoning_param: failed
+    test_simple_tool_use: passed
     test_stateful_tool_double_execution: failed
     test_tool_error_handling: failed
+    test_tool_with_schema_output: failed

--- a/golden_tests/test_cookbook_examples_report.yaml
+++ b/golden_tests/test_cookbook_examples_report.yaml
@@ -173,7 +173,7 @@ genai://google/gemini-3-flash-preview:
     test_image_with_media_resolution: passed
     test_multi_step_tool_chain: passed
     test_multiple_tool_selection: passed
-    test_reasoning_captures_traces: passed
+    test_reasoning_captures_traces: failed
     test_reasoning_param: passed
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: passed
@@ -287,28 +287,6 @@ genai://qwen/qwen3-next-80b-a3b-instruct:
     test_stateful_tool_double_execution: passed
     test_tool_error_handling: passed
     test_tool_with_schema_output: failed
-genai://xai/grok-4.20-0309-non-reasoning:
-  config:
-    structured_output: true
-  tests:
-    test_complex_tool_return: failed
-    test_dataset_eval: failed
-    test_extract_bool: failed
-    test_extract_composite_pydantic: failed
-    test_extract_dataclass: failed
-    test_extract_dict: failed
-    test_extract_int: failed
-    test_extract_pydantic: failed
-    test_image_base64: failed
-    test_image_local_file: passed
-    test_image_url: passed
-    test_multi_step_tool_chain: failed
-    test_multiple_tool_selection: failed
-    test_reasoning_param: failed
-    test_simple_tool_use: failed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
-    test_tool_with_schema_output: failed
 openai://anthropic/claude-opus-4-7@default:
   config:
     structured_output: true
@@ -362,7 +340,7 @@ openai://deepseek-ai/deepseek-r1-0528:
     test_extract_composite_pydantic: passed
     test_extract_dataclass: passed
     test_extract_dict: passed
-    test_extract_int: passed
+    test_extract_int: failed
     test_extract_pydantic: passed
     test_reasoning_param: passed
 openai://deepseek-ai/deepseek-v3.2:
@@ -557,8 +535,8 @@ openai://openai/gpt-5.5-2026-04-23:
     test_multiple_tool_selection: passed
     test_reasoning_param: passed
     test_simple_tool_use: passed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
     test_tool_with_schema_output: failed
 openai://qwen/qwen3-235b-a22b-instruct-2507:
   config:
@@ -597,26 +575,4 @@ openai://qwen/qwen3-next-80b-a3b-instruct:
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: passed
     test_tool_error_handling: passed
-    test_tool_with_schema_output: failed
-openai://xai/grok-4.20-0309-non-reasoning:
-  config:
-    structured_output: true
-  tests:
-    test_complex_tool_return: passed
-    test_dataset_eval: passed
-    test_extract_bool: failed
-    test_extract_composite_pydantic: passed
-    test_extract_dataclass: passed
-    test_extract_dict: passed
-    test_extract_int: passed
-    test_extract_pydantic: passed
-    test_image_base64: failed
-    test_image_local_file: passed
-    test_image_url: passed
-    test_multi_step_tool_chain: passed
-    test_multiple_tool_selection: passed
-    test_reasoning_param: failed
-    test_simple_tool_use: passed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
     test_tool_with_schema_output: failed

--- a/golden_tests/test_cookbook_examples_report.yaml
+++ b/golden_tests/test_cookbook_examples_report.yaml
@@ -17,8 +17,8 @@ genai://anthropic/claude-opus-4-7@default:
     test_multiple_tool_selection: passed
     test_reasoning_param: passed
     test_simple_tool_use: passed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
     test_tool_with_schema_output: passed
 genai://anthropic/claude-sonnet-4-6@default:
   config:
@@ -39,8 +39,8 @@ genai://anthropic/claude-sonnet-4-6@default:
     test_multiple_tool_selection: passed
     test_reasoning_param: passed
     test_simple_tool_use: passed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
     test_tool_with_schema_output: passed
 genai://deepseek-ai/deepseek-r1-0528:
   config:
@@ -66,7 +66,7 @@ genai://deepseek-ai/deepseek-v3.2:
     test_extract_dict: passed
     test_extract_int: passed
     test_extract_pydantic: passed
-    test_multi_step_tool_chain: failed
+    test_multi_step_tool_chain: passed
     test_multiple_tool_selection: passed
     test_reasoning_param: passed
     test_simple_tool_use: passed
@@ -306,8 +306,8 @@ openai://anthropic/claude-opus-4-7@default:
     test_multiple_tool_selection: passed
     test_reasoning_param: passed
     test_simple_tool_use: passed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
     test_tool_with_schema_output: passed
 openai://anthropic/claude-sonnet-4-6@default:
   config:
@@ -328,8 +328,8 @@ openai://anthropic/claude-sonnet-4-6@default:
     test_multiple_tool_selection: passed
     test_reasoning_param: passed
     test_simple_tool_use: passed
-    test_stateful_tool_double_execution: failed
-    test_tool_error_handling: failed
+    test_stateful_tool_double_execution: passed
+    test_tool_error_handling: passed
     test_tool_with_schema_output: passed
 openai://deepseek-ai/deepseek-r1-0528:
   config:

--- a/golden_tests/test_cookbook_examples_report.yaml
+++ b/golden_tests/test_cookbook_examples_report.yaml
@@ -66,7 +66,7 @@ genai://deepseek-ai/deepseek-v3.2:
     test_extract_dict: passed
     test_extract_int: passed
     test_extract_pydantic: passed
-    test_multi_step_tool_chain: passed
+    test_multi_step_tool_chain: failed
     test_multiple_tool_selection: passed
     test_reasoning_param: passed
     test_simple_tool_use: passed
@@ -122,7 +122,7 @@ genai://google/gemini-2.5-flash:
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: passed
     test_tool_error_handling: passed
-    test_tool_with_schema_output: failed
+    test_tool_with_schema_output: passed
     test_video_url: passed
 genai://google/gemini-2.5-pro:
   config:
@@ -173,12 +173,12 @@ genai://google/gemini-3-flash-preview:
     test_image_with_media_resolution: passed
     test_multi_step_tool_chain: passed
     test_multiple_tool_selection: passed
-    test_reasoning_captures_traces: failed
+    test_reasoning_captures_traces: passed
     test_reasoning_param: passed
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: passed
     test_tool_error_handling: passed
-    test_tool_with_schema_output: failed
+    test_tool_with_schema_output: passed
     test_video_url: passed
 genai://google/gemini-3.1-flash-lite-preview:
   config:
@@ -204,7 +204,7 @@ genai://google/gemini-3.1-flash-lite-preview:
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: passed
     test_tool_error_handling: passed
-    test_tool_with_schema_output: failed
+    test_tool_with_schema_output: passed
 genai://google/gemma-4-31b:
   config:
     structured_output: false
@@ -226,7 +226,7 @@ genai://google/gemma-4-31b:
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: passed
     test_tool_error_handling: passed
-    test_tool_with_schema_output: failed
+    test_tool_with_schema_output: passed
 genai://openai/gpt-5.5-2026-04-23:
   config:
     structured_output: true
@@ -267,7 +267,7 @@ genai://qwen/qwen3-235b-a22b-instruct-2507:
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: passed
     test_tool_error_handling: passed
-    test_tool_with_schema_output: failed
+    test_tool_with_schema_output: passed
 genai://qwen/qwen3-next-80b-a3b-instruct:
   config:
     structured_output: false
@@ -286,7 +286,7 @@ genai://qwen/qwen3-next-80b-a3b-instruct:
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: passed
     test_tool_error_handling: passed
-    test_tool_with_schema_output: failed
+    test_tool_with_schema_output: passed
 openai://anthropic/claude-opus-4-7@default:
   config:
     structured_output: true
@@ -308,7 +308,7 @@ openai://anthropic/claude-opus-4-7@default:
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: failed
     test_tool_error_handling: failed
-    test_tool_with_schema_output: failed
+    test_tool_with_schema_output: passed
 openai://anthropic/claude-sonnet-4-6@default:
   config:
     structured_output: true
@@ -330,7 +330,7 @@ openai://anthropic/claude-sonnet-4-6@default:
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: failed
     test_tool_error_handling: failed
-    test_tool_with_schema_output: failed
+    test_tool_with_schema_output: passed
 openai://deepseek-ai/deepseek-r1-0528:
   config:
     structured_output: false
@@ -340,7 +340,7 @@ openai://deepseek-ai/deepseek-r1-0528:
     test_extract_composite_pydantic: passed
     test_extract_dataclass: passed
     test_extract_dict: passed
-    test_extract_int: failed
+    test_extract_int: passed
     test_extract_pydantic: passed
     test_reasoning_param: passed
 openai://deepseek-ai/deepseek-v3.2:
@@ -385,7 +385,7 @@ openai://google/gemini-2.0-flash:
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: passed
     test_tool_error_handling: passed
-    test_tool_with_schema_output: failed
+    test_tool_with_schema_output: passed
 openai://google/gemini-2.5-flash:
   config:
     structured_output: true
@@ -411,7 +411,7 @@ openai://google/gemini-2.5-flash:
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: passed
     test_tool_error_handling: passed
-    test_tool_with_schema_output: failed
+    test_tool_with_schema_output: passed
     test_video_url: passed
 openai://google/gemini-2.5-pro:
   config:
@@ -467,7 +467,7 @@ openai://google/gemini-3-flash-preview:
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: passed
     test_tool_error_handling: passed
-    test_tool_with_schema_output: failed
+    test_tool_with_schema_output: passed
     test_video_url: passed
 openai://google/gemini-3.1-flash-lite-preview:
   config:
@@ -493,7 +493,7 @@ openai://google/gemini-3.1-flash-lite-preview:
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: passed
     test_tool_error_handling: passed
-    test_tool_with_schema_output: failed
+    test_tool_with_schema_output: passed
 openai://google/gemma-4-31b:
   config:
     structured_output: false
@@ -515,7 +515,7 @@ openai://google/gemma-4-31b:
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: passed
     test_tool_error_handling: passed
-    test_tool_with_schema_output: failed
+    test_tool_with_schema_output: passed
 openai://openai/gpt-5.5-2026-04-23:
   config:
     structured_output: true
@@ -537,7 +537,7 @@ openai://openai/gpt-5.5-2026-04-23:
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: passed
     test_tool_error_handling: passed
-    test_tool_with_schema_output: failed
+    test_tool_with_schema_output: passed
 openai://qwen/qwen3-235b-a22b-instruct-2507:
   config:
     structured_output: false
@@ -556,7 +556,7 @@ openai://qwen/qwen3-235b-a22b-instruct-2507:
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: passed
     test_tool_error_handling: passed
-    test_tool_with_schema_output: failed
+    test_tool_with_schema_output: passed
 openai://qwen/qwen3-next-80b-a3b-instruct:
   config:
     structured_output: false
@@ -575,4 +575,4 @@ openai://qwen/qwen3-next-80b-a3b-instruct:
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: passed
     test_tool_error_handling: passed
-    test_tool_with_schema_output: failed
+    test_tool_with_schema_output: passed

--- a/quick_start.md
+++ b/quick_start.md
@@ -12,6 +12,7 @@
   - [Using Multiple LLMs](#using-multiple-llms)
   - [Using Tools: The Python Script
     Runner](#using-tools-the-python-script-runner)
+  - [Using Custom Tools](#using-custom-tools)
 - [6. Creative and Robust Assertions](#6-creative-and-robust-assertions)
   - [Using External Libraries](#using-external-libraries)
 - [7. Evaluating on a Dataset](#7-evaluating-on-a-dataset)
@@ -310,6 +311,37 @@ def solve_with_python(llm):
 
 
 solve_with_python.run(llm=kbench.llm)
+```
+
+### Using Custom Tools
+
+You can give models access to your own Python functions as tools. The
+library handles the multi-turn tool calling loop automatically —
+converting functions to tool schemas, executing calls, and feeding
+results back until the model produces a final answer.
+
+``` python
+def lookup_city_population(city: str) -> int:
+    """Looks up the population of a city."""
+    populations = {"Tokyo": 14_000_000, "Paris": 2_100_000}
+    return populations.get(city, 0)
+
+
+@kbench.task(name="city_population")
+def city_population(llm):
+    response = llm.prompt(
+        "What is the population of Tokyo?",
+        tools=[lookup_city_population],
+    )
+
+    # Verify the tool was actually called
+    kbench.assertions.assert_tool_was_invoked(lookup_city_population)
+    kbench.assertions.assert_contains_regex(
+        r"14,000,000", response, expectation="Should contain Tokyo's population."
+    )
+
+
+city_population.run(llm=kbench.llm)
 ```
 
 ## 6. Creative and Robust Assertions

--- a/skills/kaggle-benchmarks/SKILL.md
+++ b/skills/kaggle-benchmarks/SKILL.md
@@ -841,7 +841,7 @@ def error_handling_task(llm):
 > **Tool calling behavior:** When you pass `tools=` to `prompt()`, the library
 > automatically handles the tool invocation loop: it sends the tool schemas to the LLM,
 > executes any requested tool calls, feeds results back, and repeats until the LLM
-> returns a final text answer (up to `max_tool_calls=5` rounds by default).
+> returns a final text answer (up to `max_tool_rounds=10` rounds by default).
 > This works on both `genai` and `openai` API backends.
 >
 > **Verifying tool usage:** Use `kbench.assertions.assert_tool_was_invoked(fn)`

--- a/skills/kaggle-benchmarks/SKILL.md
+++ b/skills/kaggle-benchmarks/SKILL.md
@@ -838,11 +838,14 @@ def error_handling_task(llm):
     kbench.assertions.assert_contains_regex(r"(?i)error|failed", response)
 ```
 
-> **Note:** Automatic tool calling is currently only supported via the `genai` API.
-> For `openai` API, tools must be called manually (see `use_calculator_tool.py`).
+> **Tool calling behavior:** When you pass `tools=` to `prompt()`, the library
+> automatically handles the tool invocation loop: it sends the tool schemas to the LLM,
+> executes any requested tool calls, feeds results back, and repeats until the LLM
+> returns a final text answer (up to `max_tool_calls=5` rounds by default).
+> This works on both `genai` and `openai` API backends.
 >
-> **Note:** `kbench.assertions.assert_tool_was_invoked(fn)` appears in golden tests
-> but may not be available in all versions of the library. Check before using.
+> **Verifying tool usage:** Use `kbench.assertions.assert_tool_was_invoked(fn)`
+> to assert that a specific tool was called during the task.
 
 ---
 

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -164,12 +164,6 @@ def _parse_tool_call(call_data: dict) -> ToolInvocation:
     )
 
 
-class ToolInvocationLimitExhausted(Exception):
-    """Raised when the tool invocation loop exceeds max_tool_calls."""
-
-    pass
-
-
 class LLMChat(actors.Actor):
     """A chat agent that interacts with a Large Language Model (LLM)."""
 
@@ -209,7 +203,6 @@ class LLMChat(actors.Actor):
         audio: audios.AudioContent | None = None,
         reasoning: ReasoningLevel | None = None,
         extra_api_params: dict[str, Any] | None = None,
-        max_tool_calls: int = 5,
     ) -> T:
         """Sends a message to the LLM and returns the parsed response.
 
@@ -218,9 +211,6 @@ class LLMChat(actors.Actor):
                 (e.g. top_p, max_tokens, max_output_tokens). Cannot include
                 parameters already on prompt() or respond() signatures
                 (seed, temperature, schema, system, etc.).
-            max_tool_calls: Maximum number of tool invocation round-trips
-                before stopping the loop. Only relevant when tools are
-                provided.
         """
         if image is not None:
             match image:
@@ -268,9 +258,8 @@ class LLMChat(actors.Actor):
         # Tool invocation loop: fork the chat to isolate tool-calling
         # round-trips from the main conversation, matching PR #12's design.
         if tools:
-            exhausted = False
             with chats.fork(name="Tool loop") as _subchat:
-                for _ in range(max_tool_calls):
+                while True:
                     response = self.respond(schema=schema, **kwargs, **extra)
 
                     tool_calls = response._meta.get("tool_calls")
@@ -281,13 +270,6 @@ class LLMChat(actors.Actor):
                         invocation = _parse_tool_call(call_data)
                         result = invoke_tool(invocation, tools)
                         actors.Tool(name=invocation.name).send(result)
-                else:
-                    exhausted = True
-
-            if exhausted:
-                raise ToolInvocationLimitExhausted(
-                    f"Exceeded {max_tool_calls} tool invocation rounds."
-                )
         else:
             response = self.respond(schema=schema, **kwargs, **extra)
 
@@ -452,7 +434,9 @@ class OpenAI(LLMChat):
             # inner one arrives at Model Proxy as a top-level field where it
             # reads google.thinking_config.  Without include_thoughts, the
             # frontend drops thinking traces from the response.
-            if kwargs["reasoning_effort"] != "none" and self.model.startswith("google/"):
+            if kwargs["reasoning_effort"] != "none" and self.model.startswith(
+                "google/"
+            ):
                 kwargs.setdefault("extra_body", {})
                 kwargs["extra_body"].setdefault("extra_body", {})
                 kwargs["extra_body"]["extra_body"].setdefault("google", {})

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -106,7 +106,7 @@ from kaggle_benchmarks.tools.functions import (
     function_to_genai_tool,
     function_to_openai_tool,
 )
-from kaggle_benchmarks.tools.native import native_agent
+from kaggle_benchmarks.tools.native import native_tool_agent
 
 if TYPE_CHECKING:
     from kaggle_benchmarks import llm_messages
@@ -241,7 +241,7 @@ class LLMChat(actors.Actor):
         }
 
         if tools:
-            response = native_agent(self, tools, schema=schema, **kwargs, **extra)
+            response = native_tool_agent(self, tools, schema=schema, **kwargs, **extra)
         else:
             response = self.respond(schema=schema, **kwargs, **extra)
 

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -164,6 +164,12 @@ def _parse_tool_call(call_data: dict) -> ToolInvocation:
     )
 
 
+class ToolInvocationLimitExhausted(Exception):
+    """Raised when the tool invocation loop exceeds max_tool_calls."""
+
+    pass
+
+
 class LLMChat(actors.Actor):
     """A chat agent that interacts with a Large Language Model (LLM)."""
 
@@ -259,22 +265,27 @@ class LLMChat(actors.Actor):
         if tools:
             kwargs["tools"] = tools
 
-        response = self.respond(schema=schema, **kwargs, **extra)
-
-        # Tool invocation loop: if the LLM returns tool calls, invoke each
-        # tool, send the results back into the chat, and ask the LLM again.
+        # Tool invocation loop: fork the chat to isolate tool-calling
+        # round-trips from the main conversation, matching PR #12's design.
         if tools:
-            for _ in range(max_tool_calls):
-                tool_calls = response._meta.get("tool_calls")
-                if not tool_calls:
-                    break
-                for call_data in tool_calls:
-                    invocation = _parse_tool_call(call_data)
-                    result = invoke_tool(invocation, tools)
-                    # Send the tool result as a message from a Tool actor so
-                    # serializers can dispatch on ToolInvocationResult content.
-                    actors.Tool(name=invocation.name).send(result)
-                response = self.respond(schema=schema, **kwargs, **extra)
+            with chats.fork(name="Tool loop") as _subchat:
+                for _ in range(max_tool_calls):
+                    response = self.respond(schema=schema, **kwargs, **extra)
+
+                    tool_calls = response._meta.get("tool_calls")
+                    if not tool_calls:
+                        break
+
+                    for call_data in tool_calls:
+                        invocation = _parse_tool_call(call_data)
+                        result = invoke_tool(invocation, tools)
+                        actors.Tool(name=invocation.name).send(result)
+                else:
+                    raise ToolInvocationLimitExhausted(
+                        f"Exceeded {max_tool_calls} tool invocation rounds."
+                    )
+        else:
+            response = self.respond(schema=schema, **kwargs, **extra)
 
         return response.content
 

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -299,8 +299,6 @@ class LLMChat(actors.Actor):
         if isinstance(invoke_response, LLMResponse):
             # A response can have either content, tool_calls, or both in some cases.
             response.content = invoke_response.content or ""
-            # TODO: Move tool_calls to a typed field on Message once all
-            # invoke() impls return LLMResponse instead of LLMMessage.
             response._meta["tool_calls"] = invoke_response.tool_calls
             response._meta.update(invoke_response.meta)
             response._meta["reasoning_traces"] = invoke_response.reasoning_traces
@@ -392,7 +390,7 @@ class OpenAI(LLMChat):
 
         raw_messages = list(self.serializer.dump_messages(messages))
 
-        # Convert callables to OpenAI-format tool schemas.
+        # Convert callables to OpenAI tool schemas.
         if tools:
             kwargs["tools"] = [function_to_openai_tool(t) for t in tools]
 
@@ -650,15 +648,15 @@ class GoogleGenAI(LLMChat):
 
             content, thinking = self._split_response(response)
 
-            # Extract function calls from response parts and normalise them
-            # to the OpenAI-style dict format so the tool loop in prompt()
-            # can use ToolInvocation.from_api_dict() uniformly for both providers.
-            tool_calls = None
+            # Extract function calls from response parts and normalise to
+            # OpenAI-style dicts so native_tool_agent() can use
+            # ToolInvocation.from_api_dict() uniformly for both backends.
             parts = response.candidates[0].content.parts or []
             fn_parts = [p for p in parts if p.function_call]
+            tool_calls = None
             if fn_parts:
                 tool_calls = []
-                for i, part in enumerate(fn_parts):
+                for part in fn_parts:
                     fc = part.function_call
                     tc: dict[str, Any] = {
                         "id": fc.id or f"call_{uuid.uuid4().hex[:8]}",
@@ -668,9 +666,9 @@ class GoogleGenAI(LLMChat):
                             "arguments": dict(fc.args) if fc.args else {},
                         },
                     }
-                    # TODO(genai-sdk): thought_signature is an SDK-internal
-                    # field required for Gemini 3.x round-tripping. Revisit
-                    # once the GenAI SDK stabilises the thought API.
+                    # TODO(genai-sdk): thought_signature is SDK-internal,
+                    # required for Gemini 3.x round-tripping. Revisit once
+                    # the GenAI SDK stabilises the thought API.
                     if getattr(part, "thought_signature", None):
                         tc["_thought_signature"] = part.thought_signature
                     if getattr(part, "thought", None):

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -648,7 +648,7 @@ class GoogleGenAI(LLMChat):
 
             content, thinking = self._split_response(response)
 
-            # Extract function calls from response parts and normalise to
+            # Extract function calls from response parts and normalize to
             # OpenAI-style dicts so native_tool_agent() can use
             # ToolInvocation.from_api_dict() uniformly for both backends.
             parts = response.candidates[0].content.parts or []

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -102,11 +102,11 @@ from kaggle_benchmarks._config import config
 from kaggle_benchmarks.content_types import audios, images, videos
 from kaggle_benchmarks.serializers import genai as genai_serializer
 from kaggle_benchmarks.serializers import openai as openai_serializer
-from kaggle_benchmarks.tools.base import ToolInvocation, invoke_tool
 from kaggle_benchmarks.tools.functions import (
     function_to_genai_tool,
     function_to_openai_tool,
 )
+from kaggle_benchmarks.tools.native import native_agent
 
 if TYPE_CHECKING:
     from kaggle_benchmarks import llm_messages
@@ -149,19 +149,6 @@ class LLMResponse:
     reasoning_traces: str | None = None
     tool_calls: list[Any] | None = None
     meta: dict[str, Any] = dataclasses.field(default_factory=dict)
-
-
-def _parse_tool_call(call_data: dict) -> ToolInvocation:
-    """Converts an OpenAI-format tool call dict to a ToolInvocation."""
-    func = call_data["function"]
-    arguments = func["arguments"]
-    if isinstance(arguments, str):
-        arguments = json.loads(arguments)
-    return ToolInvocation(
-        name=func["name"],
-        arguments=arguments,
-        call_id=call_data.get("id"),
-    )
 
 
 class LLMChat(actors.Actor):
@@ -252,24 +239,9 @@ class LLMChat(actors.Actor):
             "temperature": temperature if self.support_temperature else None,
             "reasoning": reasoning,
         }
+
         if tools:
-            kwargs["tools"] = tools
-
-        # Tool invocation loop: fork the chat to isolate tool-calling
-        # round-trips from the main conversation, matching PR #12's design.
-        if tools:
-            with chats.fork(name="Tool loop") as _subchat:
-                while True:
-                    response = self.respond(schema=schema, **kwargs, **extra)
-
-                    tool_calls = response._meta.get("tool_calls")
-                    if not tool_calls:
-                        break
-
-                    for call_data in tool_calls:
-                        invocation = _parse_tool_call(call_data)
-                        result = invoke_tool(invocation, tools)
-                        actors.Tool(name=invocation.name).send(result)
+            response = native_agent(self, tools, schema=schema, **kwargs, **extra)
         else:
             response = self.respond(schema=schema, **kwargs, **extra)
 

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -91,6 +91,7 @@ import inspect
 import json
 import re
 import typing
+import uuid
 from typing import TYPE_CHECKING, Any, Iterator, Literal, TypeVar
 
 import openai
@@ -173,6 +174,7 @@ class LLMChat(actors.Actor):
         messages: list[messages.Message],
         system: str | None,
         reasoning: ReasoningLevel | None = None,
+        tools: list[Any] | None = None,
         **kwargs,
     ) -> LLMResponse | Iterator[LLMResponse] | "llm_messages.LLMMessage[str]":
         """Invokes the LLM with the given messages and system instructions."""
@@ -297,6 +299,8 @@ class LLMChat(actors.Actor):
         if isinstance(invoke_response, LLMResponse):
             # A response can have either content, tool_calls, or both in some cases.
             response.content = invoke_response.content or ""
+            # TODO: Move tool_calls to a typed field on Message once all
+            # invoke() impls return LLMResponse instead of LLMMessage.
             response._meta["tool_calls"] = invoke_response.tool_calls
             response._meta.update(invoke_response.meta)
             response._meta["reasoning_traces"] = invoke_response.reasoning_traces
@@ -378,6 +382,7 @@ class OpenAI(LLMChat):
         messages: list[messages.Message],
         system: str | None,
         reasoning: ReasoningLevel | None = None,
+        tools: list[Any] | None = None,
         **kwargs,
     ) -> LLMResponse | Iterator[LLMResponse]:
         if system:
@@ -387,10 +392,9 @@ class OpenAI(LLMChat):
 
         raw_messages = list(self.serializer.dump_messages(messages))
 
-        # Convert Python callables to OpenAI-format tool schema dicts.
-        raw_tools = kwargs.pop("tools", [])
-        if raw_tools:
-            kwargs["tools"] = [function_to_openai_tool(t) for t in raw_tools]
+        # Convert callables to OpenAI-format tool schemas.
+        if tools:
+            kwargs["tools"] = [function_to_openai_tool(t) for t in tools]
 
         if self._should_remove_seed():
             # TODO(b/430112500): Remove once model proxy supports it for AIS backends.
@@ -577,6 +581,7 @@ class GoogleGenAI(LLMChat):
         messages: list[messages.Message],
         system: str | None,
         reasoning: ReasoningLevel | None = None,
+        tools: list[Any] | None = None,
         **kwargs,
     ) -> LLMResponse | Iterator[LLMResponse]:
         raw_messages = list(self.serializer.dump_messages(messages))
@@ -585,17 +590,11 @@ class GoogleGenAI(LLMChat):
         if system:
             config_params["system_instruction"] = system
 
-        # Convert Python callables to GenAI FunctionDeclarations.
-        # The GenAI SDK accepts callables natively via
-        # FunctionDeclaration.from_callable_with_api_option, so we convert
-        # each function and wrap them in a types.Tool.
-        tools_list = kwargs.pop("tools", [])
-        if tools_list:
+        # Convert callables to GenAI FunctionDeclarations.
+        if tools:
             config_params["tools"] = [
                 types.Tool(
-                    function_declarations=[
-                        function_to_genai_tool(t) for t in tools_list
-                    ]
+                    function_declarations=[function_to_genai_tool(t) for t in tools]
                 )
             ]
 
@@ -653,7 +652,7 @@ class GoogleGenAI(LLMChat):
 
             # Extract function calls from response parts and normalise them
             # to the OpenAI-style dict format so the tool loop in prompt()
-            # can use _parse_tool_call() uniformly for both providers.
+            # can use ToolInvocation.from_api_dict() uniformly for both providers.
             tool_calls = None
             parts = response.candidates[0].content.parts or []
             fn_parts = [p for p in parts if p.function_call]
@@ -662,16 +661,16 @@ class GoogleGenAI(LLMChat):
                 for i, part in enumerate(fn_parts):
                     fc = part.function_call
                     tc: dict[str, Any] = {
-                        "id": fc.id or f"call_{i}",
+                        "id": fc.id or f"call_{uuid.uuid4().hex[:8]}",
                         "type": "function",
                         "function": {
                             "name": fc.name,
                             "arguments": dict(fc.args) if fc.args else {},
                         },
                     }
-                    # Preserve Part-level fields required for GenAI
-                    # round-tripping (e.g. Gemini 3.x models require
-                    # thought_signature on function_call Parts).
+                    # TODO(genai-sdk): thought_signature is an SDK-internal
+                    # field required for Gemini 3.x round-tripping. Revisit
+                    # once the GenAI SDK stabilises the thought API.
                     if getattr(part, "thought_signature", None):
                         tc["_thought_signature"] = part.thought_signature
                     if getattr(part, "thought", None):

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -476,6 +476,14 @@ class OpenAI(LLMChat):
         if isinstance(response, openai.Stream):
             return self._get_stream_response(response)
         else:
+            # Handle cases where the API returns no choices (e.g.
+            # Anthropic models proxied through the OpenAI endpoint can
+            # return choices=None on multi-turn tool conversations).
+            if not response.choices:
+                return LLMResponse(
+                    content="",
+                    meta=self._get_usage_meta(response.usage),
+                )
             message = response.choices[0].message
             tool_calls = message.tool_calls
             content = message.content or ""
@@ -648,19 +656,27 @@ class GoogleGenAI(LLMChat):
             # can use _parse_tool_call() uniformly for both providers.
             tool_calls = None
             parts = response.candidates[0].content.parts or []
-            fn_calls = [p.function_call for p in parts if p.function_call]
-            if fn_calls:
-                tool_calls = [
-                    {
-                        "id": f"call_{i}",
+            fn_parts = [p for p in parts if p.function_call]
+            if fn_parts:
+                tool_calls = []
+                for i, part in enumerate(fn_parts):
+                    fc = part.function_call
+                    tc: dict[str, Any] = {
+                        "id": fc.id or f"call_{i}",
                         "type": "function",
                         "function": {
                             "name": fc.name,
                             "arguments": dict(fc.args) if fc.args else {},
                         },
                     }
-                    for i, fc in enumerate(fn_calls)
-                ]
+                    # Preserve Part-level fields required for GenAI
+                    # round-tripping (e.g. Gemini 3.x models require
+                    # thought_signature on function_call Parts).
+                    if getattr(part, "thought_signature", None):
+                        tc["_thought_signature"] = part.thought_signature
+                    if getattr(part, "thought", None):
+                        tc["_thought"] = part.thought
+                    tool_calls.append(tc)
 
             return LLMResponse(
                 content=content,

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -92,7 +92,7 @@ import json
 import re
 import typing
 import uuid
-from typing import TYPE_CHECKING, Any, Iterator, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, TypeVar
 
 import openai
 from google import genai
@@ -103,11 +103,7 @@ from kaggle_benchmarks._config import config
 from kaggle_benchmarks.content_types import audios, images, videos
 from kaggle_benchmarks.serializers import genai as genai_serializer
 from kaggle_benchmarks.serializers import openai as openai_serializer
-from kaggle_benchmarks.tools.functions import (
-    function_to_genai_tool,
-    function_to_openai_tool,
-)
-from kaggle_benchmarks.tools.native import native_tool_agent
+from kaggle_benchmarks.tools import functions, native
 
 if TYPE_CHECKING:
     from kaggle_benchmarks import llm_messages
@@ -174,7 +170,7 @@ class LLMChat(actors.Actor):
         messages: list[messages.Message],
         system: str | None,
         reasoning: ReasoningLevel | None = None,
-        tools: list[Any] | None = None,
+        tools: list[Callable] | None = None,
         **kwargs,
     ) -> LLMResponse | Iterator[LLMResponse] | "llm_messages.LLMMessage[str]":
         """Invokes the LLM with the given messages and system instructions."""
@@ -186,7 +182,7 @@ class LLMChat(actors.Actor):
         schema: type[T] = str,
         seed: int = 0,
         temperature: float = 0,
-        tools: list[Any] | None = None,
+        tools: list[Callable] | None = None,
         image: images.ImageContent | None = None,
         video: videos.VideoContent | None = None,
         audio: audios.AudioContent | None = None,
@@ -243,7 +239,9 @@ class LLMChat(actors.Actor):
         }
 
         if tools:
-            response = native_tool_agent(self, tools, schema=schema, **kwargs, **extra)
+            response = native.native_tool_agent(
+                self, tools, schema=schema, **kwargs, **extra
+            )
         else:
             response = self.respond(schema=schema, **kwargs, **extra)
 
@@ -380,7 +378,7 @@ class OpenAI(LLMChat):
         messages: list[messages.Message],
         system: str | None,
         reasoning: ReasoningLevel | None = None,
-        tools: list[Any] | None = None,
+        tools: list[Callable] | None = None,
         **kwargs,
     ) -> LLMResponse | Iterator[LLMResponse]:
         if system:
@@ -392,7 +390,7 @@ class OpenAI(LLMChat):
 
         # Convert callables to OpenAI tool schemas.
         if tools:
-            kwargs["tools"] = [function_to_openai_tool(t) for t in tools]
+            kwargs["tools"] = [functions.function_to_openai_tool(t) for t in tools]
 
         if self._should_remove_seed():
             # TODO(b/430112500): Remove once model proxy supports it for AIS backends.
@@ -579,7 +577,7 @@ class GoogleGenAI(LLMChat):
         messages: list[messages.Message],
         system: str | None,
         reasoning: ReasoningLevel | None = None,
-        tools: list[Any] | None = None,
+        tools: list[Callable] | None = None,
         **kwargs,
     ) -> LLMResponse | Iterator[LLMResponse]:
         raw_messages = list(self.serializer.dump_messages(messages))
@@ -592,7 +590,9 @@ class GoogleGenAI(LLMChat):
         if tools:
             config_params["tools"] = [
                 types.Tool(
-                    function_declarations=[function_to_genai_tool(t) for t in tools]
+                    function_declarations=[
+                        functions.function_to_genai_tool(t) for t in tools
+                    ]
                 )
             ]
 

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -668,7 +668,7 @@ class GoogleGenAI(LLMChat):
                     }
                     # TODO(genai-sdk): thought_signature is SDK-internal,
                     # required for Gemini 3.x round-tripping. Revisit once
-                    # the GenAI SDK stabilises the thought API.
+                    # the GenAI SDK stabilizes the thought API.
                     if getattr(part, "thought_signature", None):
                         tc["_thought_signature"] = part.thought_signature
                     if getattr(part, "thought", None):

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -268,6 +268,7 @@ class LLMChat(actors.Actor):
         # Tool invocation loop: fork the chat to isolate tool-calling
         # round-trips from the main conversation, matching PR #12's design.
         if tools:
+            exhausted = False
             with chats.fork(name="Tool loop") as _subchat:
                 for _ in range(max_tool_calls):
                     response = self.respond(schema=schema, **kwargs, **extra)
@@ -281,9 +282,12 @@ class LLMChat(actors.Actor):
                         result = invoke_tool(invocation, tools)
                         actors.Tool(name=invocation.name).send(result)
                 else:
-                    raise ToolInvocationLimitExhausted(
-                        f"Exceeded {max_tool_calls} tool invocation rounds."
-                    )
+                    exhausted = True
+
+            if exhausted:
+                raise ToolInvocationLimitExhausted(
+                    f"Exceeded {max_tool_calls} tool invocation rounds."
+                )
         else:
             response = self.respond(schema=schema, **kwargs, **extra)
 

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -102,6 +102,11 @@ from kaggle_benchmarks._config import config
 from kaggle_benchmarks.content_types import audios, images, videos
 from kaggle_benchmarks.serializers import genai as genai_serializer
 from kaggle_benchmarks.serializers import openai as openai_serializer
+from kaggle_benchmarks.tools.base import ToolInvocation, invoke_tool
+from kaggle_benchmarks.tools.functions import (
+    function_to_genai_tool,
+    function_to_openai_tool,
+)
 
 if TYPE_CHECKING:
     from kaggle_benchmarks import llm_messages
@@ -146,6 +151,19 @@ class LLMResponse:
     meta: dict[str, Any] = dataclasses.field(default_factory=dict)
 
 
+def _parse_tool_call(call_data: dict) -> ToolInvocation:
+    """Converts an OpenAI-format tool call dict to a ToolInvocation."""
+    func = call_data["function"]
+    arguments = func["arguments"]
+    if isinstance(arguments, str):
+        arguments = json.loads(arguments)
+    return ToolInvocation(
+        name=func["name"],
+        arguments=arguments,
+        call_id=call_data.get("id"),
+    )
+
+
 class LLMChat(actors.Actor):
     """A chat agent that interacts with a Large Language Model (LLM)."""
 
@@ -185,6 +203,7 @@ class LLMChat(actors.Actor):
         audio: audios.AudioContent | None = None,
         reasoning: ReasoningLevel | None = None,
         extra_api_params: dict[str, Any] | None = None,
+        max_tool_calls: int = 5,
     ) -> T:
         """Sends a message to the LLM and returns the parsed response.
 
@@ -193,6 +212,9 @@ class LLMChat(actors.Actor):
                 (e.g. top_p, max_tokens, max_output_tokens). Cannot include
                 parameters already on prompt() or respond() signatures
                 (seed, temperature, schema, system, etc.).
+            max_tool_calls: Maximum number of tool invocation round-trips
+                before stopping the loop. Only relevant when tools are
+                provided.
         """
         if image is not None:
             match image:
@@ -232,11 +254,29 @@ class LLMChat(actors.Actor):
         kwargs = {
             "seed": seed,
             "temperature": temperature if self.support_temperature else None,
-            "tools": tools if tools is not None else [],
             "reasoning": reasoning,
         }
+        if tools:
+            kwargs["tools"] = tools
 
-        return self.respond(schema=schema, **kwargs, **extra).content
+        response = self.respond(schema=schema, **kwargs, **extra)
+
+        # Tool invocation loop: if the LLM returns tool calls, invoke each
+        # tool, send the results back into the chat, and ask the LLM again.
+        if tools:
+            for _ in range(max_tool_calls):
+                tool_calls = response._meta.get("tool_calls")
+                if not tool_calls:
+                    break
+                for call_data in tool_calls:
+                    invocation = _parse_tool_call(call_data)
+                    result = invoke_tool(invocation, tools)
+                    # Send the tool result as a message from a Tool actor so
+                    # serializers can dispatch on ToolInvocationResult content.
+                    actors.Tool(name=invocation.name).send(result)
+                response = self.respond(schema=schema, **kwargs, **extra)
+
+        return response.content
 
     @chats.emits_message
     def respond(
@@ -377,6 +417,11 @@ class OpenAI(LLMChat):
             messages = [Message(sender=actors.system, content=system)] + messages
 
         raw_messages = list(self.serializer.dump_messages(messages))
+
+        # Convert Python callables to OpenAI-format tool schema dicts.
+        raw_tools = kwargs.pop("tools", [])
+        if raw_tools:
+            kwargs["tools"] = [function_to_openai_tool(t) for t in raw_tools]
 
         if self._should_remove_seed():
             # TODO(b/430112500): Remove once model proxy supports it for AIS backends.
@@ -561,6 +606,20 @@ class GoogleGenAI(LLMChat):
         if system:
             config_params["system_instruction"] = system
 
+        # Convert Python callables to GenAI FunctionDeclarations.
+        # The GenAI SDK accepts callables natively via
+        # FunctionDeclaration.from_callable_with_api_option, so we convert
+        # each function and wrap them in a types.Tool.
+        tools_list = kwargs.pop("tools", [])
+        if tools_list:
+            config_params["tools"] = [
+                types.Tool(
+                    function_declarations=[
+                        function_to_genai_tool(t) for t in tools_list
+                    ]
+                )
+            ]
+
         if reasoning is not None and "thinking_config" not in kwargs:
             # Only set thinking_config if not already overwritten by the caller.
             level = self._REASONING_LEVEL_MAP[reasoning]
@@ -612,8 +671,29 @@ class GoogleGenAI(LLMChat):
                 )
 
             content, thinking = self._split_response(response)
+
+            # Extract function calls from response parts and normalise them
+            # to the OpenAI-style dict format so the tool loop in prompt()
+            # can use _parse_tool_call() uniformly for both providers.
+            tool_calls = None
+            parts = response.candidates[0].content.parts or []
+            fn_calls = [p.function_call for p in parts if p.function_call]
+            if fn_calls:
+                tool_calls = [
+                    {
+                        "id": f"call_{i}",
+                        "type": "function",
+                        "function": {
+                            "name": fc.name,
+                            "arguments": dict(fc.args) if fc.args else {},
+                        },
+                    }
+                    for i, fc in enumerate(fn_calls)
+                ]
+
             return LLMResponse(
                 content=content,
                 reasoning_traces=thinking,
+                tool_calls=tool_calls,
                 meta=self._get_usage_meta(response.usage_metadata),
             )

--- a/src/kaggle_benchmarks/assertions.py
+++ b/src/kaggle_benchmarks/assertions.py
@@ -25,6 +25,7 @@ from typing import Any, Callable, Iterable, Type
 import pydantic
 
 from kaggle_benchmarks import chats
+from kaggle_benchmarks import tools as tool_utils
 
 
 @dataclasses.dataclass
@@ -513,3 +514,29 @@ def assess_response_with_judge(
         assess_report = None
 
     return assess_report
+
+
+@assertion_handler()
+def assert_tool_was_invoked(
+    tool: str | Callable, expectation: str | None = None
+) -> AssertionResult:
+    """Asserts that a specific tool was invoked during the current task.
+
+    Scans the current chat history for a ``ToolInvocationResult`` whose name
+    matches the given tool (either a callable or a string name).
+
+    Args:
+        tool: The tool function or its name as a string.
+        expectation: An optional message summarizing the assertion.
+    """
+    tool_name = tool if isinstance(tool, str) else tool.__name__
+    chat = chats.get_current_chat()
+    passed = any(
+        isinstance(msg.content, tool_utils.ToolInvocationResult)
+        and msg.content.name == tool_name
+        for msg in chat.messages
+    )
+    return AssertionResult(
+        passed=passed,
+        expectation=expectation or f"Expected tool `{tool_name}` to be invoked",
+    )

--- a/src/kaggle_benchmarks/assertions.py
+++ b/src/kaggle_benchmarks/assertions.py
@@ -522,8 +522,8 @@ def assert_tool_was_invoked(
 ) -> AssertionResult:
     """Asserts that a specific tool was invoked during the current task.
 
-    Scans the current chat history for a ``ToolInvocationResult`` whose name
-    matches the given tool (either a callable or a string name).
+    Scans the current chat history (including nested forked chats) for a
+    ``ToolInvocationResult`` whose name matches the given tool.
 
     Args:
         tool: The tool function or its name as a string.
@@ -531,12 +531,20 @@ def assert_tool_was_invoked(
     """
     tool_name = tool if isinstance(tool, str) else tool.__name__
     chat = chats.get_current_chat()
-    passed = any(
-        isinstance(msg.content, tool_utils.ToolInvocationResult)
-        and msg.content.name == tool_name
-        for msg in chat.messages
-    )
+
+    def _find_in_chat(c: chats.Chat) -> bool:
+        for item in c.history:
+            if isinstance(item, chats.Chat):
+                if _find_in_chat(item):
+                    return True
+            elif (
+                isinstance(item.content, tool_utils.ToolInvocationResult)
+                and item.content.name == tool_name
+            ):
+                return True
+        return False
+
     return AssertionResult(
-        passed=passed,
+        passed=_find_in_chat(chat),
         expectation=expectation or f"Expected tool `{tool_name}` to be invoked",
     )

--- a/src/kaggle_benchmarks/content_types/audios.py
+++ b/src/kaggle_benchmarks/content_types/audios.py
@@ -102,7 +102,9 @@ def from_url(
 
 
 def from_path(
-    path: str, caption: str | None = None, extra_api_params: dict[str, Any] | None = None
+    path: str,
+    caption: str | None = None,
+    extra_api_params: dict[str, Any] | None = None,
 ) -> AudioContent:
     """Creates AudioContent from a local audio file path."""
     with open(path, "rb") as audio_file:
@@ -128,5 +130,8 @@ def from_base64(
     except ValueError as e:
         raise ValueError(f"Invalid base64 audio data: {e}") from e
     return AudioContent(
-        b64_string, mime_type=f"audio/{format}", caption=caption, extra_api_params=extra_api_params
+        b64_string,
+        mime_type=f"audio/{format}",
+        caption=caption,
+        extra_api_params=extra_api_params,
     )

--- a/src/kaggle_benchmarks/content_types/images.py
+++ b/src/kaggle_benchmarks/content_types/images.py
@@ -152,7 +152,10 @@ def from_base64(
         base64 = base64.decode("utf-8")
 
     return ImageBase64(
-        base64, mime_type=f"image/{format}", caption=caption, extra_api_params=extra_api_params
+        base64,
+        mime_type=f"image/{format}",
+        caption=caption,
+        extra_api_params=extra_api_params,
     )
 
 

--- a/src/kaggle_benchmarks/kaggle/model_proxy.py
+++ b/src/kaggle_benchmarks/kaggle/model_proxy.py
@@ -77,7 +77,10 @@ class ModelProxy:
         # Qwen and DeepSeek models support response_format, but the schema must be under 64 characters.
         kwargs.setdefault(
             "support_structured_outputs",
-            "meta" not in model and "qwen" not in model and "deepseek" not in model,
+            "meta" not in model
+            and "qwen" not in model
+            and "deepseek" not in model
+            and "gemma" not in model,
         )
 
         if api == "genai":

--- a/src/kaggle_benchmarks/messages.py
+++ b/src/kaggle_benchmarks/messages.py
@@ -54,8 +54,9 @@ class Message(Generic[T]):
 
     @property
     def reasoning_traces(self):
-        # TODO: Remove this _meta workaround once respond() creates LLMMessage
-        # instead of Message. LLMMessage.reasoning_traces will be the canonical field.
+        # TODO: Remove this _meta workaround once invoke() returns LLMMessage
+        # directly (PR #115 added this path). LLMMessage.reasoning_traces
+        # will be the canonical field.
         return self._meta.get("reasoning_traces")
 
     @property

--- a/src/kaggle_benchmarks/serializers/genai.py
+++ b/src/kaggle_benchmarks/serializers/genai.py
@@ -61,9 +61,29 @@ class GenAISerializer(BaseSerializer):
 
     def dump_text_message(self, message: messages.Message[str]):
         """Serializes a standard textual payload into a Part object."""
-        yield types.Content(
-            role=self.get_role(message.sender), parts=[types.Part(text=message.content)]
-        )
+        parts = []
+        if message.content:
+            parts.append(types.Part(text=message.content))
+
+        # When an assistant message carried tool calls, include them as
+        # function_call Parts so the GenAI API sees the model's tool call
+        # decisions in the conversation history.
+        tool_calls = message._meta.get("tool_calls")
+        if tool_calls and self.get_role(message.sender) == "model":
+            for tc in tool_calls:
+                func = tc.get("function", {})
+                parts.append(
+                    types.Part.from_function_call(
+                        name=func.get("name", ""),
+                        args=func.get("arguments", {}),
+                    )
+                )
+
+        # Ensure at least one part is present to avoid empty Content objects.
+        if not parts:
+            parts.append(types.Part(text=""))
+
+        yield types.Content(role=self.get_role(message.sender), parts=parts)
 
     def dump_image(self, message: messages.Message[images.ImageContent]):
         """Serializes images natively as inline data Blobs for the GenAI client."""

--- a/src/kaggle_benchmarks/serializers/genai.py
+++ b/src/kaggle_benchmarks/serializers/genai.py
@@ -68,7 +68,7 @@ class GenAISerializer(BaseSerializer):
         # When an assistant message carried tool calls, include them as
         # function_call Parts so the GenAI API sees the model's tool call
         # decisions in the conversation history.
-        tool_calls = message._meta.get("tool_calls")
+        tool_calls = message.tool_calls
         if tool_calls and self.get_role(message.sender) == "model":
             for tc in tool_calls:
                 func = tc.get("function", {})

--- a/src/kaggle_benchmarks/serializers/genai.py
+++ b/src/kaggle_benchmarks/serializers/genai.py
@@ -77,9 +77,10 @@ class GenAISerializer(BaseSerializer):
                     args=func.get("arguments", {}),
                 )
                 part.function_call.id = tc.get("id")
-                # Restore Part-level fields preserved during normalisation
-                # (e.g. Gemini 3.x requires thought_signature on
-                # function_call Parts in multi-turn conversations).
+                # Round-trip thought_signature/thought back onto the Part.
+                # Gemini 3.x requires these on function_call Parts in
+                # multi-turn conversations; without them the API rejects
+                # the follow-up request.
                 if "_thought_signature" in tc:
                     part.thought_signature = tc["_thought_signature"]
                 if "_thought" in tc:

--- a/src/kaggle_benchmarks/serializers/genai.py
+++ b/src/kaggle_benchmarks/serializers/genai.py
@@ -77,6 +77,13 @@ class GenAISerializer(BaseSerializer):
                     args=func.get("arguments", {}),
                 )
                 part.function_call.id = tc.get("id")
+                # Restore Part-level fields preserved during normalisation
+                # (e.g. Gemini 3.x requires thought_signature on
+                # function_call Parts in multi-turn conversations).
+                if "_thought_signature" in tc:
+                    part.thought_signature = tc["_thought_signature"]
+                if "_thought" in tc:
+                    part.thought = tc["_thought"]
                 parts.append(part)
 
         # Ensure at least one part is present to avoid empty Content objects.

--- a/src/kaggle_benchmarks/serializers/genai.py
+++ b/src/kaggle_benchmarks/serializers/genai.py
@@ -72,12 +72,12 @@ class GenAISerializer(BaseSerializer):
         if tool_calls and self.get_role(message.sender) == "model":
             for tc in tool_calls:
                 func = tc.get("function", {})
-                parts.append(
-                    types.Part.from_function_call(
-                        name=func.get("name", ""),
-                        args=func.get("arguments", {}),
-                    )
+                part = types.Part.from_function_call(
+                    name=func.get("name", ""),
+                    args=func.get("arguments", {}),
                 )
+                part.function_call.id = tc.get("id")
+                parts.append(part)
 
         # Ensure at least one part is present to avoid empty Content objects.
         if not parts:
@@ -177,10 +177,14 @@ class GenAISerializer(BaseSerializer):
         self, call: tool_utils.ToolInvocationResult | tool_utils.ToolInvocation
     ):
         if isinstance(call, tool_utils.ToolInvocationResult):
-            yield types.Part.from_function_response(
+            part = types.Part.from_function_response(
                 name=call.name, response={"result": call.output}
             )
+            part.function_response.id = call.call_id
+            yield part
 
         else:
             args = call.arguments
-            yield types.Part.from_function_call(name=call.name, args=args)
+            part = types.Part.from_function_call(name=call.name, args=args)
+            part.function_call.id = call.call_id
+            yield part

--- a/src/kaggle_benchmarks/serializers/genai.py
+++ b/src/kaggle_benchmarks/serializers/genai.py
@@ -185,7 +185,7 @@ class GenAISerializer(BaseSerializer):
     ):
         if isinstance(call, tool_utils.ToolInvocationResult):
             part = types.Part.from_function_response(
-                name=call.name, response={"result": call.output}
+                name=call.name, response={"result": call.text}
             )
             part.function_response.id = call.call_id
             yield part

--- a/src/kaggle_benchmarks/serializers/openai.py
+++ b/src/kaggle_benchmarks/serializers/openai.py
@@ -118,7 +118,7 @@ class OpenAICompletionSerializer(BaseSerializer):
         if isinstance(call, tool_utils.ToolInvocationResult):
             yield {
                 "type": "function_call_output",
-                "output": str(call.output),
+                "output": call.text,
                 "call_id": str(call.call_id),
             }
 
@@ -173,6 +173,6 @@ class ModelProxyOpenAISerializer(OpenAICompletionSerializer):
         result = message.content
         yield {
             "role": "tool",
-            "content": str(result.output),
+            "content": result.text,
             "tool_call_id": str(result.call_id) if result.call_id else "",
         }

--- a/src/kaggle_benchmarks/serializers/openai.py
+++ b/src/kaggle_benchmarks/serializers/openai.py
@@ -53,8 +53,8 @@ class OpenAICompletionSerializer(BaseSerializer):
         """Extracts tool calls and results, injecting them into the sequence before standard text output."""
         # This path handles LLMMessage objects in the chat history.
         # Currently only MockedChat (tests/mocks.py) returns LLMMessage from
-        # invoke(). Once respond() migrates to create LLMMessage instead of
-        # plain Message (see TODO in messages.py), this becomes the primary
+        # invoke(). Once built-in LLMs also return LLMMessage from invoke()
+        # (PR #115 added this path to respond()), this becomes the primary
         # serialization path for assistant messages.
         #
         # NOTE: _dump_invocation emits a separate assistant message per tool

--- a/src/kaggle_benchmarks/serializers/openai.py
+++ b/src/kaggle_benchmarks/serializers/openai.py
@@ -51,18 +51,36 @@ class OpenAICompletionSerializer(BaseSerializer):
 
     def dump_llm_message(self, message: llm_messages.LLMMessage):
         """Extracts tool calls and results, injecting them into the sequence before standard text output."""
-        # This path handles LLMMessage objects in the chat history.
-        # Currently only MockedChat (tests/mocks.py) returns LLMMessage from
-        # invoke(). Once built-in LLMs also return LLMMessage from invoke()
-        # (PR #115 added this path to respond()), this becomes the primary
-        # serialization path for assistant messages.
-        #
-        # NOTE: _dump_invocation emits a separate assistant message per tool
-        # call. For multi-tool scenarios, these should be batched into a
-        # single {"role": "assistant", "tool_calls": [...]} message. Fix
-        # when the LLMMessage migration happens.
-        for call in message.tool_calls or []:
-            yield from self._dump_invocation(call)
+        if message.tool_calls:
+            tool_calls_payload = []
+            tool_results = []
+            for call in message.tool_calls:
+                tool_calls_payload.append(
+                    {
+                        "id": str(call.call_id),
+                        "type": "function",
+                        "function": {
+                            "name": call.name,
+                            "arguments": json.dumps(call.arguments)
+                            if not isinstance(call.arguments, str)
+                            else call.arguments,
+                        },
+                    }
+                )
+                if isinstance(call, tool_utils.ToolInvocationResult):
+                    tool_results.append(
+                        {
+                            "role": "tool",
+                            "content": call.text,
+                            "tool_call_id": str(call.call_id),
+                        }
+                    )
+            yield {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": tool_calls_payload,
+            }
+            yield from tool_results
 
         if message.content is not None and message.content != "":
             yield from self.dump_message(
@@ -75,12 +93,16 @@ class OpenAICompletionSerializer(BaseSerializer):
             "role": self.get_role(message.sender),
             "content": message.content or None,
         }
-        # When an assistant message carried tool calls, include them in
-        # the serialized payload so the API can match subsequent tool
-        # result messages by their call IDs.
-        tool_calls = message._meta.get("tool_calls")
+
+        # TODO: Remove once respond() returns LLMMessage for assistant
+        # messages. Today, assistant messages with tool calls arrive here as
+        # plain Message (not LLMMessage), so we must attach tool_calls
+        # manually. After the migration, they'll route to dump_llm_message
+        # instead and these lines become unnecessary.
+        tool_calls = message.tool_calls
         if tool_calls and self.get_role(message.sender) == "assistant":
             msg["tool_calls"] = tool_calls
+
         yield msg
 
     def dump_tool_invocation(
@@ -119,34 +141,6 @@ class OpenAICompletionSerializer(BaseSerializer):
             "role": self.get_role(message.sender),
             "content": caption + [{"type": "input_audio", "input_audio": input_audio}],
         }
-
-    def _dump_invocation(
-        self, call: tool_utils.ToolInvocationResult | tool_utils.ToolInvocation
-    ):
-        """Serializes tool calls/results for the LLMMessage path."""
-        # Emit the function call as a Chat Completions tool_call.
-        yield {
-            "role": "assistant",
-            "content": None,
-            "tool_calls": [
-                {
-                    "id": str(call.call_id),
-                    "type": "function",
-                    "function": {
-                        "name": call.name,
-                        "arguments": json.dumps(call.arguments)
-                        if not isinstance(call.arguments, str)
-                        else call.arguments,
-                    },
-                }
-            ],
-        }
-        if isinstance(call, tool_utils.ToolInvocationResult):
-            yield {
-                "role": "tool",
-                "content": call.text,
-                "tool_call_id": str(call.call_id),
-            }
 
 
 class ModelProxyOpenAISerializer(OpenAICompletionSerializer):

--- a/src/kaggle_benchmarks/serializers/openai.py
+++ b/src/kaggle_benchmarks/serializers/openai.py
@@ -123,7 +123,7 @@ class OpenAICompletionSerializer(BaseSerializer):
     def _dump_invocation(
         self, call: tool_utils.ToolInvocationResult | tool_utils.ToolInvocation
     ):
-        """Serializes tool calls/results for the legacy LLMMessage path."""
+        """Serializes tool calls/results for the LLMMessage path."""
         # Emit the function call as a Chat Completions tool_call.
         yield {
             "role": "assistant",

--- a/src/kaggle_benchmarks/serializers/openai.py
+++ b/src/kaggle_benchmarks/serializers/openai.py
@@ -61,10 +61,17 @@ class OpenAICompletionSerializer(BaseSerializer):
 
     def dump_text_message(self, message: messages.Message):
         """Serializes a standard textual payload."""
-        yield {
+        msg = {
             "role": self.get_role(message.sender),
-            "content": message.content,
+            "content": message.content or None,
         }
+        # When an assistant message carried tool calls, include them in
+        # the serialized payload so the API can match subsequent tool
+        # result messages by their call IDs.
+        tool_calls = message._meta.get("tool_calls")
+        if tool_calls and self.get_role(message.sender) == "assistant":
+            msg["tool_calls"] = tool_calls
+        yield msg
 
     def dump_tool_invocation(
         self, message: messages.Message[tool_utils.ToolInvocationResult]
@@ -154,3 +161,18 @@ class ModelProxyOpenAISerializer(OpenAICompletionSerializer):
         yield from self.dump_text_message(
             messages.Message(sender=message.sender, content=str(message.content))
         )
+
+    def dump_tool_invocation(
+        self, message: messages.Message[tool_utils.ToolInvocationResult]
+    ):
+        """Serializes a tool result using the Chat Completions format.
+
+        Model Proxy uses the Chat Completions API, which expects tool results
+        as {"role": "tool", "content": "...", "tool_call_id": "..."}.
+        """
+        result = message.content
+        yield {
+            "role": "tool",
+            "content": str(result.output),
+            "tool_call_id": str(result.call_id) if result.call_id else "",
+        }

--- a/src/kaggle_benchmarks/serializers/openai.py
+++ b/src/kaggle_benchmarks/serializers/openai.py
@@ -51,6 +51,16 @@ class OpenAICompletionSerializer(BaseSerializer):
 
     def dump_llm_message(self, message: llm_messages.LLMMessage):
         """Extracts tool calls and results, injecting them into the sequence before standard text output."""
+        # This path handles LLMMessage objects in the chat history.
+        # Currently only MockedChat (tests/mocks.py) returns LLMMessage from
+        # invoke(). Once respond() migrates to create LLMMessage instead of
+        # plain Message (see TODO in messages.py), this becomes the primary
+        # serialization path for assistant messages.
+        #
+        # NOTE: _dump_invocation emits a separate assistant message per tool
+        # call. For multi-tool scenarios, these should be batched into a
+        # single {"role": "assistant", "tool_calls": [...]} message. Fix
+        # when the LLMMessage migration happens.
         for call in message.tool_calls or []:
             yield from self._dump_invocation(call)
 
@@ -76,7 +86,13 @@ class OpenAICompletionSerializer(BaseSerializer):
     def dump_tool_invocation(
         self, message: messages.Message[tool_utils.ToolInvocationResult]
     ):
-        yield from self._dump_invocation(message.content)
+        """Serializes a tool result as a Chat Completions tool message."""
+        result = message.content
+        yield {
+            "role": "tool",
+            "content": result.text,
+            "tool_call_id": str(result.call_id) if result.call_id else "",
+        }
 
     _SUPPORTED_AUDIO_FORMATS = {"mp3", "wav"}
 
@@ -107,19 +123,29 @@ class OpenAICompletionSerializer(BaseSerializer):
     def _dump_invocation(
         self, call: tool_utils.ToolInvocationResult | tool_utils.ToolInvocation
     ):
+        """Serializes tool calls/results for the legacy LLMMessage path."""
+        # Emit the function call as a Chat Completions tool_call.
         yield {
-            "call_id": call.call_id,
-            "arguments": json.dumps(call.arguments)
-            if not isinstance(call.arguments, str)
-            else call.arguments,
-            "name": call.name,
-            "type": "function_call",
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": str(call.call_id),
+                    "type": "function",
+                    "function": {
+                        "name": call.name,
+                        "arguments": json.dumps(call.arguments)
+                        if not isinstance(call.arguments, str)
+                        else call.arguments,
+                    },
+                }
+            ],
         }
         if isinstance(call, tool_utils.ToolInvocationResult):
             yield {
-                "type": "function_call_output",
-                "output": call.text,
-                "call_id": str(call.call_id),
+                "role": "tool",
+                "content": call.text,
+                "tool_call_id": str(call.call_id),
             }
 
 
@@ -161,18 +187,3 @@ class ModelProxyOpenAISerializer(OpenAICompletionSerializer):
         yield from self.dump_text_message(
             messages.Message(sender=message.sender, content=str(message.content))
         )
-
-    def dump_tool_invocation(
-        self, message: messages.Message[tool_utils.ToolInvocationResult]
-    ):
-        """Serializes a tool result using the Chat Completions format.
-
-        Model Proxy uses the Chat Completions API, which expects tool results
-        as {"role": "tool", "content": "...", "tool_call_id": "..."}.
-        """
-        result = message.content
-        yield {
-            "role": "tool",
-            "content": result.text,
-            "tool_call_id": str(result.call_id) if result.call_id else "",
-        }

--- a/src/kaggle_benchmarks/tools/__init__.py
+++ b/src/kaggle_benchmarks/tools/__init__.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kaggle_benchmarks.tools import container, functions, python, search, web
+from kaggle_benchmarks.tools import container, functions, native, python, search, web
 from kaggle_benchmarks.tools.base import (
     ModelResponse,
     ToolCallModel,
     ToolInvocation,
+    ToolInvocationLimitExhausted,
     ToolInvocationResult,
     describe_tools,
     invoke_tool,
+    parse_tool_call,
 )

--- a/src/kaggle_benchmarks/tools/__init__.py
+++ b/src/kaggle_benchmarks/tools/__init__.py
@@ -21,5 +21,4 @@ from kaggle_benchmarks.tools.base import (
     ToolInvocationResult,
     describe_tools,
     invoke_tool,
-    parse_tool_call,
 )

--- a/src/kaggle_benchmarks/tools/base.py
+++ b/src/kaggle_benchmarks/tools/base.py
@@ -14,11 +14,16 @@
 
 import dataclasses
 import inspect
+import json
 from typing import Any, Callable, Generic, TypeVar
 
 import pydantic
 
 T = TypeVar("T")
+
+
+class ToolInvocationLimitExhausted(Exception):
+    """Raised when the tool invocation loop exceeds the maximum number of rounds."""
 
 
 @dataclasses.dataclass
@@ -138,3 +143,16 @@ def invoke_tool(call: ToolInvocation, tools: list[Callable]) -> ToolInvocationRe
             output=error_message,
             call_id=call.call_id,
         )
+
+
+def parse_tool_call(call_data: dict) -> ToolInvocation:
+    """Converts an OpenAI-format tool call dict to a ToolInvocation."""
+    func = call_data["function"]
+    arguments = func["arguments"]
+    if isinstance(arguments, str):
+        arguments = json.loads(arguments)
+    return ToolInvocation(
+        name=func["name"],
+        arguments=arguments,
+        call_id=call_data.get("id"),
+    )

--- a/src/kaggle_benchmarks/tools/base.py
+++ b/src/kaggle_benchmarks/tools/base.py
@@ -34,6 +34,29 @@ class ToolInvocation:
     arguments: dict[str, Any]
     call_id: str | None = None
 
+    @classmethod
+    def from_api_dict(cls, call_data: dict) -> "ToolInvocation":
+        """Creates a ToolInvocation from a normalised tool call dict.
+
+        Both backends normalise their tool call responses to the same
+        dict schema::
+
+            {"id": ..., "function": {"name": ..., "arguments": ...}}
+
+        The OpenAI backend produces this natively from the Chat
+        Completions response, while the GenAI backend converts
+        ``function_call`` Parts to this format in ``GoogleGenAI._call_api``.
+        """
+        func = call_data["function"]
+        arguments = func["arguments"]
+        if isinstance(arguments, str):
+            arguments = json.loads(arguments)
+        return cls(
+            name=func["name"],
+            arguments=arguments,
+            call_id=call_data.get("id"),
+        )
+
 
 @dataclasses.dataclass
 class ToolInvocationResult:
@@ -120,6 +143,8 @@ def invoke_tool(call: ToolInvocation, tools: list[Callable]) -> ToolInvocationRe
         has_var_keyword = any(
             p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
         )
+        # Guard against None arguments: some models return arguments=null
+        # instead of arguments={} for tools that take no parameters.
         args = call.arguments or {}
         if has_var_keyword:
             filtered_args = args
@@ -147,13 +172,8 @@ def invoke_tool(call: ToolInvocation, tools: list[Callable]) -> ToolInvocationRe
 
 
 def parse_tool_call(call_data: dict) -> ToolInvocation:
-    """Converts an OpenAI-format tool call dict to a ToolInvocation."""
-    func = call_data["function"]
-    arguments = func["arguments"]
-    if isinstance(arguments, str):
-        arguments = json.loads(arguments)
-    return ToolInvocation(
-        name=func["name"],
-        arguments=arguments,
-        call_id=call_data.get("id"),
-    )
+    """Converts a normalised tool call dict to a ToolInvocation.
+
+    Convenience wrapper around :meth:`ToolInvocation.from_api_dict`.
+    """
+    return ToolInvocation.from_api_dict(call_data)

--- a/src/kaggle_benchmarks/tools/base.py
+++ b/src/kaggle_benchmarks/tools/base.py
@@ -120,11 +120,12 @@ def invoke_tool(call: ToolInvocation, tools: list[Callable]) -> ToolInvocationRe
         has_var_keyword = any(
             p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
         )
+        args = call.arguments or {}
         if has_var_keyword:
-            filtered_args = call.arguments
+            filtered_args = args
         else:
             accepted = set(sig.parameters.keys())
-            filtered_args = {k: v for k, v in call.arguments.items() if k in accepted}
+            filtered_args = {k: v for k, v in args.items() if k in accepted}
 
         output = tool(**filtered_args)
         return ToolInvocationResult(

--- a/src/kaggle_benchmarks/tools/base.py
+++ b/src/kaggle_benchmarks/tools/base.py
@@ -46,9 +46,13 @@ class ToolInvocation:
         The OpenAI backend produces this natively from the Chat
         Completions response, while the GenAI backend converts
         ``function_call`` Parts to this format in ``GoogleGenAI._call_api``.
+
+        Handles edge cases from various backends:
+        - ``arguments`` may be a JSON string (OpenAI) or a dict (GenAI).
+        - ``arguments`` may be ``None`` for parameterless tools.
         """
         func = call_data["function"]
-        arguments = func["arguments"]
+        arguments = func.get("arguments") or {}
         if isinstance(arguments, str):
             arguments = json.loads(arguments)
         return cls(
@@ -66,8 +70,18 @@ class ToolInvocationResult:
     arguments: dict[str, Any]
     call_id: str | None = None
     output: Any = None
+    error: str | None = None
+
+    @property
+    def text(self) -> str:
+        """Returns a string representation of the result or error."""
+        if self.error:
+            return self.error
+        return str(self.output)
 
     def describe(self):
+        if self.error:
+            return f"{self.name}({self.arguments}): Error: {self.error}"
         return f"{self.name}({self.arguments}) -> {self.output}"
 
 
@@ -127,11 +141,10 @@ def invoke_tool(call: ToolInvocation, tools: list[Callable]) -> ToolInvocationRe
     """Invokes a tool and returns the result."""
     tool = next((t for t in tools if t.__name__ == call.name), None)
     if tool is None:
-        error_message = f"Error: Tool '{call.name}' not found."
         return ToolInvocationResult(
             name=call.name,
             arguments=call.arguments,
-            output=error_message,
+            error=f"Error: Tool '{call.name}' not found.",
             call_id=call.call_id,
         )
     try:
@@ -143,8 +156,6 @@ def invoke_tool(call: ToolInvocation, tools: list[Callable]) -> ToolInvocationRe
         has_var_keyword = any(
             p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
         )
-        # Guard against None arguments: some models return arguments=null
-        # instead of arguments={} for tools that take no parameters.
         args = call.arguments or {}
         if has_var_keyword:
             filtered_args = args
@@ -162,18 +173,9 @@ def invoke_tool(call: ToolInvocation, tools: list[Callable]) -> ToolInvocationRe
     except KeyboardInterrupt:
         raise
     except Exception as e:
-        error_message = f"Error invoking tool '{call.name}': {e}"
         return ToolInvocationResult(
             name=call.name,
             arguments=call.arguments,
-            output=error_message,
+            error=f"Error invoking tool '{call.name}': {e}",
             call_id=call.call_id,
         )
-
-
-def parse_tool_call(call_data: dict) -> ToolInvocation:
-    """Converts a normalised tool call dict to a ToolInvocation.
-
-    Convenience wrapper around :meth:`ToolInvocation.from_api_dict`.
-    """
-    return ToolInvocation.from_api_dict(call_data)

--- a/src/kaggle_benchmarks/tools/base.py
+++ b/src/kaggle_benchmarks/tools/base.py
@@ -15,7 +15,7 @@
 import dataclasses
 import inspect
 import json
-from typing import Any, Callable, Generic, TypeVar
+from typing import Any, Callable, Generic, Self, TypeVar
 
 import pydantic
 
@@ -35,7 +35,7 @@ class ToolInvocation:
     call_id: str | None = None
 
     @classmethod
-    def from_api_dict(cls, call_data: dict) -> "ToolInvocation":
+    def from_api_dict(cls, call_data: dict) -> Self:
         """Creates a ToolInvocation from a normalized tool call dict.
 
         Both backends normalize their tool call responses to the same
@@ -141,31 +141,28 @@ def invoke_tool(call: ToolInvocation, tools: list[Callable]) -> ToolInvocationRe
     """Invokes a tool and returns the result."""
     tool = next((t for t in tools if t.__name__ == call.name), None)
     if tool is None:
+        error_message = f"Error: Tool '{call.name}' not found."
         return ToolInvocationResult(
             name=call.name,
             arguments=call.arguments,
-            error=f"Error: Tool '{call.name}' not found.",
+            error=error_message,
             call_id=call.call_id,
         )
     try:
-        # Filter arguments to only those the function accepts.
+        # Strip known infrastructure fields injected by intermediaries.
         # Model Proxy injects a 'signature' field (opaque base64 blob) into
         # tool call arguments for Google models (gemini-2.5-*, gemini-3-*)
         # routed through the OpenAI-compatible endpoint. This field is not
         # part of the function schema and would cause a TypeError if passed
         # through. GenAI backend and non-Google models are not affected.
-        sig = inspect.signature(tool)
-        has_var_keyword = any(
-            p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
-        )
-        args = call.arguments or {}
-        if has_var_keyword:
-            filtered_args = args
-        else:
-            accepted = set(sig.parameters.keys())
-            filtered_args = {k: v for k, v in args.items() if k in accepted}
+        _INFRASTRUCTURE_FIELDS = {"signature"}
+        args = {
+            k: v
+            for k, v in (call.arguments or {}).items()
+            if k not in _INFRASTRUCTURE_FIELDS
+        }
 
-        output = tool(**filtered_args)
+        output = tool(**args)
         return ToolInvocationResult(
             name=call.name,
             arguments=call.arguments,
@@ -175,9 +172,10 @@ def invoke_tool(call: ToolInvocation, tools: list[Callable]) -> ToolInvocationRe
     except KeyboardInterrupt:
         raise
     except Exception as e:
+        error_message = f"Error invoking tool '{call.name}': {e}"
         return ToolInvocationResult(
             name=call.name,
             arguments=call.arguments,
-            error=f"Error invoking tool '{call.name}': {e}",
+            error=error_message,
             call_id=call.call_id,
         )

--- a/src/kaggle_benchmarks/tools/base.py
+++ b/src/kaggle_benchmarks/tools/base.py
@@ -36,9 +36,9 @@ class ToolInvocation:
 
     @classmethod
     def from_api_dict(cls, call_data: dict) -> "ToolInvocation":
-        """Creates a ToolInvocation from a normalised tool call dict.
+        """Creates a ToolInvocation from a normalized tool call dict.
 
-        Both backends normalise their tool call responses to the same
+        Both backends normalize their tool call responses to the same
         dict schema::
 
             {"id": ..., "function": {"name": ..., "arguments": ...}}
@@ -149,9 +149,11 @@ def invoke_tool(call: ToolInvocation, tools: list[Callable]) -> ToolInvocationRe
         )
     try:
         # Filter arguments to only those the function accepts.
-        # Some backends (e.g. Model Proxy) inject extra fields like
-        # 'signature' into tool call arguments that the actual function
-        # does not expect.
+        # Model Proxy injects a 'signature' field (opaque base64 blob) into
+        # tool call arguments for Google models (gemini-2.5-*, gemini-3-*)
+        # routed through the OpenAI-compatible endpoint. This field is not
+        # part of the function schema and would cause a TypeError if passed
+        # through. GenAI backend and non-Google models are not affected.
         sig = inspect.signature(tool)
         has_var_keyword = any(
             p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()

--- a/src/kaggle_benchmarks/tools/base.py
+++ b/src/kaggle_benchmarks/tools/base.py
@@ -107,7 +107,21 @@ def invoke_tool(call: ToolInvocation, tools: list[Callable]) -> ToolInvocationRe
             call_id=call.call_id,
         )
     try:
-        output = tool(**call.arguments)
+        # Filter arguments to only those the function accepts.
+        # Some backends (e.g. Model Proxy) inject extra fields like
+        # 'signature' into tool call arguments that the actual function
+        # does not expect.
+        sig = inspect.signature(tool)
+        has_var_keyword = any(
+            p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+        )
+        if has_var_keyword:
+            filtered_args = call.arguments
+        else:
+            accepted = set(sig.parameters.keys())
+            filtered_args = {k: v for k, v in call.arguments.items() if k in accepted}
+
+        output = tool(**filtered_args)
         return ToolInvocationResult(
             name=call.name,
             arguments=call.arguments,

--- a/src/kaggle_benchmarks/tools/functions.py
+++ b/src/kaggle_benchmarks/tools/functions.py
@@ -59,9 +59,11 @@ def function_to_openai_tool(func: Callable) -> dict:
 
     return {
         "type": "function",
-        "name": func.__name__,
-        "description": (func.__doc__ or "").strip(),
-        "parameters": parameters,
+        "function": {
+            "name": func.__name__,
+            "description": (func.__doc__ or "").strip(),
+            "parameters": parameters,
+        },
     }
 
 

--- a/src/kaggle_benchmarks/tools/functions.py
+++ b/src/kaggle_benchmarks/tools/functions.py
@@ -49,22 +49,31 @@ def function_to_openai_tool(func: Callable) -> dict:
     """Converts a Python function into an OpenAI-compatible tool definition."""
     schema = get_function_schema(func)
 
-    parameters = {
-        "type": "object",
-        "properties": schema.get("properties", {}),
-        "required": schema.get("required", []),
-    }
-    if "$defs" in schema:
-        parameters["$defs"] = schema["$defs"]
+    # Omit 'parameters' entirely for parameterless functions.
+    # GPT-5.5 rejects empty properties objects (`{"properties": {}}`)
+    # with 400: "object schema missing properties".
+    properties = schema.get("properties", {})
+    if properties:
+        parameters: dict = {
+            "type": "object",
+            "properties": properties,
+            "required": schema.get("required", []),
+        }
+        if "$defs" in schema:
+            parameters["$defs"] = schema["$defs"]
+    else:
+        parameters = None
 
-    return {
+    tool_def = {
         "type": "function",
         "function": {
             "name": func.__name__,
             "description": (func.__doc__ or "").strip(),
-            "parameters": parameters,
         },
     }
+    if parameters:
+        tool_def["function"]["parameters"] = parameters
+    return tool_def
 
 
 def function_to_genai_tool(

--- a/src/kaggle_benchmarks/tools/native.py
+++ b/src/kaggle_benchmarks/tools/native.py
@@ -45,9 +45,17 @@ def native_tool_agent(
     """Runs a multi-turn tool calling loop.
 
     Forks the chat to isolate tool-calling round-trips from the main
-    conversation, then loops: call ``llm.respond()`` → check for tool_calls
-    → invoke tools → send results → repeat until the LLM responds without
-    tool calls or ``max_tool_rounds`` is exhausted.
+    conversation. The loop runs in two phases:
+
+    1. **Tool rounds** — calls ``llm.respond(tools=…)`` without ``schema=``
+       to avoid backend conflicts (OpenAI requires ``strict=True`` on tools
+       when ``response_format`` is set; GenAI models return tool_calls instead
+       of schema-formatted content). Repeats until the model stops requesting
+       tools or ``max_tool_rounds`` is exhausted.
+
+    2. **Schema formatting** — if ``schema`` is not ``str``, makes one final
+       ``llm.respond(schema=…)`` call (no tools) so the response conforms to
+       the requested output type.
 
     Args:
         llm: The LLM chat actor to use.
@@ -65,26 +73,39 @@ def native_tool_agent(
         ToolInvocationLimitExhausted: If the LLM keeps requesting tool calls
             beyond ``max_tool_rounds`` iterations.
     """
-    # Lazy imports to avoid circular dependencies (actors → tools → actors).
     from kaggle_benchmarks import actors, chats
+
+    response = None
+    exhausted = True
 
     with chats.fork(name="Tool loop"):
         for _ in range(max_tool_rounds):
-            # TODO: Pass schema= only on a final call without tools, not on
-            # every round. Use a two-phase loop: tools-only rounds, then a
-            # schema-only call once the model stops requesting tool calls.
-            response = llm.respond(schema=schema, tools=tools, **respond_kwargs)
+            response = llm.respond(tools=tools, **respond_kwargs)
 
             # TODO: Use response.tool_calls once respond() returns LLMMessage.
             tool_calls = response._meta.get("tool_calls")
             if not tool_calls:
-                return response
+                exhausted = False
+                break
 
             for call_data in tool_calls:
                 invocation = ToolInvocation.from_api_dict(call_data)
                 result = invoke_tool(invocation, tools)
                 actors.Tool(name=invocation.name).send(result)
 
-    raise ToolInvocationLimitExhausted(
-        f"Tool invocation limit of {max_tool_rounds} rounds exhausted"
-    )
+        if not exhausted and schema is not str:
+            # User message required: some models (e.g. Claude) reject requests
+            # where the conversation ends with an assistant message.
+            actors.user.send(
+                "Now format your previous answer using the requested schema."
+            )
+            response = llm.respond(schema=schema, **respond_kwargs)
+
+    # Raised outside `with chats.fork()` because the context manager may
+    # swallow exceptions when no parent run is active (see contexts.enter).
+    if exhausted:
+        raise ToolInvocationLimitExhausted(
+            f"Tool invocation limit of {max_tool_rounds} rounds exhausted"
+        )
+
+    return response

--- a/src/kaggle_benchmarks/tools/native.py
+++ b/src/kaggle_benchmarks/tools/native.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Native tool calling agent for models with API-level function calling support.
+
+This module provides a tool invocation loop for models that support function
+calling natively (e.g., Gemini, GPT, Claude).  It complements the simulated
+tool calling in ``tools/simulate.py`` (PR #12), which uses structured output
+to emulate tool calling for models that lack native support.
+"""
+
+from typing import Any, Callable, TypeVar
+
+from kaggle_benchmarks.tools.base import (
+    ToolInvocationLimitExhausted,
+    invoke_tool,
+    parse_tool_call,
+)
+
+T = TypeVar("T")
+
+DEFAULT_MAX_TOOL_ROUNDS = 10
+
+
+def native_agent(
+    llm,
+    tools: list[Callable],
+    schema: type[T] = str,
+    max_tool_rounds: int = DEFAULT_MAX_TOOL_ROUNDS,
+    **respond_kwargs: Any,
+):
+    """Runs a native tool calling loop for models that support function calling.
+
+    Forks the chat to isolate tool-calling round-trips from the main
+    conversation, then loops: call ``llm.respond()`` → check for tool_calls
+    → invoke tools → send results → repeat until the LLM responds without
+    tool calls or ``max_tool_rounds`` is exhausted.
+
+    Args:
+        llm: The LLM chat actor to use.
+        tools: List of Python callables available as tools.
+        schema: The output schema for the final response.
+        max_tool_rounds: Maximum number of tool-calling rounds before raising
+            ``ToolInvocationLimitExhausted``.
+        **respond_kwargs: Additional keyword arguments forwarded to
+            ``llm.respond()`` (e.g. ``seed``, ``temperature``, ``reasoning``).
+
+    Returns:
+        The final response message from the LLM (a ``messages.Message``).
+
+    Raises:
+        ToolInvocationLimitExhausted: If the LLM keeps requesting tool calls
+            beyond ``max_tool_rounds`` iterations.
+    """
+    # Lazy imports to avoid circular dependencies (actors → tools → actors).
+    from kaggle_benchmarks import actors, chats
+
+    with chats.fork(name="Tool loop") as _subchat:
+        for _ in range(max_tool_rounds):
+            response = llm.respond(schema=schema, tools=tools, **respond_kwargs)
+
+            tool_calls = response._meta.get("tool_calls")
+            if not tool_calls:
+                return response
+
+            for call_data in tool_calls:
+                invocation = parse_tool_call(call_data)
+                result = invoke_tool(invocation, tools)
+                actors.Tool(name=invocation.name).send(result)
+
+    raise ToolInvocationLimitExhausted(
+        f"Tool invocation limit of {max_tool_rounds} rounds exhausted"
+    )

--- a/src/kaggle_benchmarks/tools/native.py
+++ b/src/kaggle_benchmarks/tools/native.py
@@ -33,7 +33,7 @@ T = TypeVar("T")
 DEFAULT_MAX_TOOL_ROUNDS = 10
 
 
-def native_agent(
+def native_tool_agent(
     llm,
     tools: list[Callable],
     schema: type[T] = str,
@@ -46,6 +46,10 @@ def native_agent(
     conversation, then loops: call ``llm.respond()`` → check for tool_calls
     → invoke tools → send results → repeat until the LLM responds without
     tool calls or ``max_tool_rounds`` is exhausted.
+
+    This is the counterpart of ``tools.simulate.simulate_agent`` (PR #12),
+    which uses structured output to emulate tool calling for models that
+    lack native support.
 
     Args:
         llm: The LLM chat actor to use.

--- a/src/kaggle_benchmarks/tools/native.py
+++ b/src/kaggle_benchmarks/tools/native.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Native tool calling agent for models with API-level function calling support.
+"""Native tool calling agent for multi-turn function calling.
 
-This module provides a tool invocation loop for models that support function
-calling natively (e.g., Gemini, GPT, Claude).  It complements the simulated
-tool calling in ``tools/simulate.py`` (PR #12), which uses structured output
-to emulate tool calling for models that lack native support.
+Provides a tool invocation loop for models that support native function
+calling (e.g., Gemini, GPT, Claude).
 """
 
-from typing import Any, Callable, TypeVar
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from kaggle_benchmarks.tools.base import (
     ToolInvocation,
@@ -28,28 +28,28 @@ from kaggle_benchmarks.tools.base import (
     invoke_tool,
 )
 
+if TYPE_CHECKING:
+    from kaggle_benchmarks.actors.llms import LLMChat
+    from kaggle_benchmarks.messages import Message
+
 T = TypeVar("T")
 
 DEFAULT_MAX_TOOL_ROUNDS = 10
 
 
 def native_tool_agent(
-    llm,
+    llm: LLMChat,
     tools: list[Callable],
     schema: type[T] = str,
     max_tool_rounds: int = DEFAULT_MAX_TOOL_ROUNDS,
     **respond_kwargs: Any,
-):
-    """Runs a native tool calling loop for models that support function calling.
+) -> Message:
+    """Runs a multi-turn tool calling loop.
 
     Forks the chat to isolate tool-calling round-trips from the main
     conversation, then loops: call ``llm.respond()`` → check for tool_calls
     → invoke tools → send results → repeat until the LLM responds without
     tool calls or ``max_tool_rounds`` is exhausted.
-
-    This is the counterpart of ``tools.simulate.simulate_agent`` (PR #12),
-    which uses structured output to emulate tool calling for models that
-    lack native support.
 
     Args:
         llm: The LLM chat actor to use.
@@ -70,7 +70,9 @@ def native_tool_agent(
     # Lazy imports to avoid circular dependencies (actors → tools → actors).
     from kaggle_benchmarks import actors, chats
 
-    with chats.fork(name="Tool loop") as _subchat:
+    # TODO: Read tool_calls from a typed field once all invoke() impls
+    # return LLMResponse instead of LLMMessage.
+    with chats.fork(name="Tool loop"):
         for _ in range(max_tool_rounds):
             response = llm.respond(schema=schema, tools=tools, **respond_kwargs)
 

--- a/src/kaggle_benchmarks/tools/native.py
+++ b/src/kaggle_benchmarks/tools/native.py
@@ -23,9 +23,9 @@ to emulate tool calling for models that lack native support.
 from typing import Any, Callable, TypeVar
 
 from kaggle_benchmarks.tools.base import (
+    ToolInvocation,
     ToolInvocationLimitExhausted,
     invoke_tool,
-    parse_tool_call,
 )
 
 T = TypeVar("T")
@@ -79,7 +79,7 @@ def native_tool_agent(
                 return response
 
             for call_data in tool_calls:
-                invocation = parse_tool_call(call_data)
+                invocation = ToolInvocation.from_api_dict(call_data)
                 result = invoke_tool(invocation, tools)
                 actors.Tool(name=invocation.name).send(result)
 

--- a/src/kaggle_benchmarks/tools/native.py
+++ b/src/kaggle_benchmarks/tools/native.py
@@ -75,6 +75,9 @@ def native_tool_agent(
     # response.tool_calls.
     with chats.fork(name="Tool loop"):
         for _ in range(max_tool_rounds):
+            # TODO: schema= is applied on every round, including intermediate
+            # rounds where the model returns tool calls. This can confuse some
+            # backends. Apply schema= only on the final (no tool_calls) round.
             response = llm.respond(schema=schema, tools=tools, **respond_kwargs)
 
             tool_calls = response._meta.get("tool_calls")  # TODO: response.tool_calls

--- a/src/kaggle_benchmarks/tools/native.py
+++ b/src/kaggle_benchmarks/tools/native.py
@@ -68,19 +68,15 @@ def native_tool_agent(
     # Lazy imports to avoid circular dependencies (actors → tools → actors).
     from kaggle_benchmarks import actors, chats
 
-    # TODO: invoke() currently returns LLMResponse, so respond() creates a
-    # plain Message and stuffs tool_calls into response._meta (an untyped
-    # dict). Once invoke() returns LLMMessage directly (PR #115 added this
-    # path to respond()), replace the _meta lookup below with
-    # response.tool_calls.
     with chats.fork(name="Tool loop"):
         for _ in range(max_tool_rounds):
-            # TODO: schema= is applied on every round, including intermediate
-            # rounds where the model returns tool calls. This can confuse some
-            # backends. Apply schema= only on the final (no tool_calls) round.
+            # TODO: Pass schema= only on a final call without tools, not on
+            # every round. Use a two-phase loop: tools-only rounds, then a
+            # schema-only call once the model stops requesting tool calls.
             response = llm.respond(schema=schema, tools=tools, **respond_kwargs)
 
-            tool_calls = response._meta.get("tool_calls")  # TODO: response.tool_calls
+            # TODO: Use response.tool_calls once respond() returns LLMMessage.
+            tool_calls = response._meta.get("tool_calls")
             if not tool_calls:
                 return response
 

--- a/src/kaggle_benchmarks/tools/native.py
+++ b/src/kaggle_benchmarks/tools/native.py
@@ -34,14 +34,12 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 
-DEFAULT_MAX_TOOL_ROUNDS = 10
-
 
 def native_tool_agent(
     llm: LLMChat,
     tools: list[Callable],
     schema: type[T] = str,
-    max_tool_rounds: int = DEFAULT_MAX_TOOL_ROUNDS,
+    max_tool_rounds: int = 10,
     **respond_kwargs: Any,
 ) -> Message:
     """Runs a multi-turn tool calling loop.
@@ -70,13 +68,16 @@ def native_tool_agent(
     # Lazy imports to avoid circular dependencies (actors → tools → actors).
     from kaggle_benchmarks import actors, chats
 
-    # TODO: Read tool_calls from a typed field once all invoke() impls
-    # return LLMResponse instead of LLMMessage.
+    # TODO: invoke() currently returns LLMResponse, so respond() creates a
+    # plain Message and stuffs tool_calls into response._meta (an untyped
+    # dict). Once invoke() returns LLMMessage directly (PR #115 added this
+    # path to respond()), replace the _meta lookup below with
+    # response.tool_calls.
     with chats.fork(name="Tool loop"):
         for _ in range(max_tool_rounds):
             response = llm.respond(schema=schema, tools=tools, **respond_kwargs)
 
-            tool_calls = response._meta.get("tool_calls")
+            tool_calls = response._meta.get("tool_calls")  # TODO: response.tool_calls
             if not tool_calls:
                 return response
 

--- a/tests/contents/test_audio.py
+++ b/tests/contents/test_audio.py
@@ -120,7 +120,9 @@ def test_from_base64_invalid():
 
 
 def test_extra_api_params_stored():
-    a = audios.from_base64(B64_STRING, format="mp3", extra_api_params={"some_param": "value"})
+    a = audios.from_base64(
+        B64_STRING, format="mp3", extra_api_params={"some_param": "value"}
+    )
     assert a.extra_api_params == {"some_param": "value"}
 
 

--- a/tests/contents/test_images.py
+++ b/tests/contents/test_images.py
@@ -107,7 +107,9 @@ def test_from_image_url(mocker):
 
 
 def test_extra_api_params_stored():
-    img = images.from_base64(B64_STRING, format="png", extra_api_params={"detail": "low"})
+    img = images.from_base64(
+        B64_STRING, format="png", extra_api_params={"detail": "low"}
+    )
     assert img.extra_api_params == {"detail": "low"}
 
     img_url = images.from_url(

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -20,6 +20,12 @@ from kaggle_benchmarks.llm_messages import LLMMessage
 
 
 class MockedChat(actors.LLMChat):
+    """A mock LLMChat that returns pre-configured responses.
+
+    Note: invoke() returns LLMMessage (not LLMResponse), exercising a
+    different branch in LLMChat.respond() than real backends.
+    """
+
     def __init__(
         self, responses: list[LLMMessage[str]], name="MockedChat", cycle=False, **kwargs
     ):
@@ -48,7 +54,28 @@ class MockedChat(actors.LLMChat):
             **kwargs,
         )
 
-    def invoke(self, messages, **kwargs):
+    @staticmethod
+    def make_tool_call_response(
+        name: str,
+        arguments: dict | None = None,
+        call_id: str = "call_1",
+    ) -> LLMMessage[str]:
+        """Creates an LLMMessage that simulates a tool call from the LLM.
+
+        Sets tool_calls in _meta to match the dict format that real
+        backends produce (normalised to OpenAI-style dicts).
+        """
+        msg = LLMMessage(sender=None, content="")
+        msg._meta["tool_calls"] = [
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {"name": name, "arguments": arguments},
+            }
+        ]
+        return msg
+
+    def invoke(self, messages, tools=None, **kwargs):
         self.invocations.append((messages, kwargs))
         try:
             response = next(self.response)

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -63,7 +63,7 @@ class MockedChat(actors.LLMChat):
         """Creates an LLMMessage that simulates a tool call from the LLM.
 
         Sets tool_calls in _meta to match the dict format that real
-        backends produce (normalised to OpenAI-style dicts).
+        backends produce (normalized to OpenAI-style dicts).
         """
         msg = LLMMessage(sender=None, content="")
         msg._meta["tool_calls"] = [

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -54,27 +54,6 @@ class MockedChat(actors.LLMChat):
             **kwargs,
         )
 
-    @staticmethod
-    def make_tool_call_response(
-        name: str,
-        arguments: dict | None = None,
-        call_id: str = "call_1",
-    ) -> LLMMessage[str]:
-        """Creates an LLMMessage that simulates a tool call from the LLM.
-
-        Sets tool_calls in _meta to match the dict format that real
-        backends produce (normalized to OpenAI-style dicts).
-        """
-        msg = LLMMessage(sender=None, content="")
-        msg._meta["tool_calls"] = [
-            {
-                "id": call_id,
-                "type": "function",
-                "function": {"name": name, "arguments": arguments},
-            }
-        ]
-        return msg
-
     def invoke(self, messages, tools=None, **kwargs):
         self.invocations.append((messages, kwargs))
         try:

--- a/tests/serializers/test_genai_serializer.py
+++ b/tests/serializers/test_genai_serializer.py
@@ -41,6 +41,22 @@ class DummyPydantic(pydantic.BaseModel):
 B64_STRING = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
 
 # A shared set of message formats and their expected outputs.
+
+
+def _make_function_call_part(name: str, args: dict, call_id: str) -> types.Part:
+    """Builds a function_call Part with the id field set."""
+    part = types.Part.from_function_call(name=name, args=args)
+    part.function_call.id = call_id
+    return part
+
+
+def _make_function_response_part(name: str, response: dict, call_id: str) -> types.Part:
+    """Builds a function_response Part with the id field set."""
+    part = types.Part.from_function_response(name=name, response=response)
+    part.function_response.id = call_id
+    return part
+
+
 MESSAGE_FORMATS = [
     pytest.param(
         messages.Message(content="Hello", sender=actors.user),
@@ -134,7 +150,7 @@ MESSAGE_FORMATS = [
             types.Content(
                 role="system",
                 parts=[
-                    types.Part.from_function_call(name="test_tool", args={}),
+                    _make_function_call_part("test_tool", {}, "123"),
                 ],
             )
         ],
@@ -154,8 +170,8 @@ MESSAGE_FORMATS = [
             types.Content(
                 role="system",
                 parts=[
-                    types.Part.from_function_response(
-                        name="test_tool", response={"result": "result"}
+                    _make_function_response_part(
+                        "test_tool", {"result": "result"}, "123"
                     ),
                 ],
             )
@@ -203,8 +219,8 @@ MESSAGE_FORMATS = [
             types.Content(
                 role="user",
                 parts=[
-                    types.Part.from_function_response(
-                        name="test_tool", response={"result": "result"}
+                    _make_function_response_part(
+                        "test_tool", {"result": "result"}, "123"
                     ),
                 ],
             )

--- a/tests/serializers/test_openai_serializer.py
+++ b/tests/serializers/test_openai_serializer.py
@@ -71,10 +71,18 @@ MESSAGE_FORMATS = [
         ),
         [
             {
-                "call_id": "123",
-                "arguments": "{}",
-                "name": "test_tool",
-                "type": "function_call",
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "123",
+                        "type": "function",
+                        "function": {
+                            "name": "test_tool",
+                            "arguments": "{}",
+                        },
+                    }
+                ],
             },
         ],
         id="llm_message_with_tool_calls",
@@ -91,15 +99,23 @@ MESSAGE_FORMATS = [
         ),
         [
             {
-                "call_id": "123",
-                "arguments": "{}",
-                "name": "test_tool",
-                "type": "function_call",
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "123",
+                        "type": "function",
+                        "function": {
+                            "name": "test_tool",
+                            "arguments": "{}",
+                        },
+                    }
+                ],
             },
             {
-                "call_id": "123",
-                "output": "result",
-                "type": "function_call_output",
+                "role": "tool",
+                "content": "result",
+                "tool_call_id": "123",
             },
         ],
         id="llm_message_with_tool_invocation_result",
@@ -139,15 +155,9 @@ MESSAGE_FORMATS = [
         ),
         [
             {
-                "call_id": "123",
-                "arguments": "{}",
-                "name": "test_tool",
-                "type": "function_call",
-            },
-            {
-                "call_id": "123",
-                "output": "result",
-                "type": "function_call_output",
+                "role": "tool",
+                "content": "result",
+                "tool_call_id": "123",
             },
         ],
         id="message_with_tool_invocation_result",

--- a/tests/serializers/test_openai_serializer.py
+++ b/tests/serializers/test_openai_serializer.py
@@ -335,7 +335,9 @@ def test_dump_audio_message_with_extra_api_params_model_proxy():
     serializer = openai_serializer.ModelProxyOpenAISerializer(roles_mapping={})
     message = messages.Message(
         content=audios.AudioContent(
-            b64_string="abc123", mime_type="audio/wav", extra_api_params={"language": "en"}
+            b64_string="abc123",
+            mime_type="audio/wav",
+            extra_api_params={"language": "en"},
         ),
         sender=actors.user,
     )

--- a/tests/test_genai_client.py
+++ b/tests/test_genai_client.py
@@ -275,7 +275,11 @@ def test_invoke_with_tools():
 
     assert llm.config.tools is not None
     assert len(llm.config.tools) == 1
-    assert llm.config.tools[0] == multiply
+    # Tools are now converted to types.Tool with FunctionDeclarations
+    tool_wrapper = llm.config.tools[0]
+    assert isinstance(tool_wrapper, types.Tool)
+    assert len(tool_wrapper.function_declarations) == 1
+    assert tool_wrapper.function_declarations[0].name == "multiply"
 
 
 def test_invoke_with_structured_output():

--- a/tests/test_tool_loop.py
+++ b/tests/test_tool_loop.py
@@ -14,10 +14,7 @@
 
 """Tests for the tool invocation loop in LLMChat.prompt()."""
 
-import pytest
-
 from kaggle_benchmarks import assertions, chats
-from kaggle_benchmarks.actors.llms import ToolInvocationLimitExhausted
 from kaggle_benchmarks.llm_messages import LLMMessage
 from tests.mocks import MockedChat
 
@@ -79,18 +76,6 @@ class TestToolInvocationLoop:
         result = llm.prompt("Call the tool.", tools=[_always_fails])
 
         assert result == "The tool failed."
-
-    def test_tool_invocation_limit_exhausted(self):
-        """Raises ToolInvocationLimitExhausted when max_tool_calls is exceeded."""
-        # Create a mock that always returns tool calls (never a final answer).
-        tool_response = _make_tool_call_response("_add", {"a": 1, "b": 2})
-        llm = MockedChat(
-            responses=[tool_response],
-            cycle=True,
-        )
-
-        with pytest.raises(ToolInvocationLimitExhausted):
-            llm.prompt("What is 1 + 2?", tools=[_add], max_tool_calls=3)
 
     def test_extra_arguments_filtered(self):
         """Extra arguments from the API (like 'signature') are filtered out."""

--- a/tests/test_tool_loop.py
+++ b/tests/test_tool_loop.py
@@ -45,6 +45,11 @@ def _always_fails() -> str:
     raise ValueError("Simulated error")
 
 
+def _no_args() -> str:
+    """A tool that takes no arguments."""
+    return "ok"
+
+
 class TestToolInvocationLoop:
     """Tests for the prompt() tool invocation loop."""
 
@@ -126,3 +131,13 @@ class TestToolInvocationLoop:
 
         with pytest.raises(ToolInvocationLimitExhausted):
             llm.prompt("Keep calling tools.", tools=[_add])
+
+    def test_none_arguments_handled(self):
+        """When the model returns None arguments, the tool still executes."""
+        tool_response = _make_tool_call_response("_no_args", None)
+        final_response = LLMMessage(sender=None, content="done")
+
+        llm = MockedChat(responses=[tool_response, final_response])
+        result = llm.prompt("Call the tool.", tools=[_no_args])
+
+        assert result == "done"

--- a/tests/test_tool_loop.py
+++ b/tests/test_tool_loop.py
@@ -18,26 +18,27 @@ import pytest
 
 from kaggle_benchmarks import assertions, chats
 from kaggle_benchmarks.llm_messages import LLMMessage
-from kaggle_benchmarks.tools.base import ToolInvocationLimitExhausted
+from kaggle_benchmarks.tools.base import (
+    ToolInvocation,
+    ToolInvocationLimitExhausted,
+    ToolInvocationResult,
+    invoke_tool,
+)
 from tests.mocks import MockedChat
 
-
-def _make_tool_call_response(name: str, arguments: dict, call_id: str = "call_1"):
-    """Creates an LLMMessage that simulates a tool call from the LLM."""
-    msg = LLMMessage(sender=None, content="")
-    msg._meta["tool_calls"] = [
-        {
-            "id": call_id,
-            "type": "function",
-            "function": {"name": name, "arguments": arguments},
-        }
-    ]
-    return msg
+# ---------------------------------------------------------------------------
+# Test tool functions
+# ---------------------------------------------------------------------------
 
 
 def _add(a: float, b: float) -> float:
     """Adds two numbers."""
     return a + b
+
+
+def _multiply(a: float, b: float) -> float:
+    """Multiplies two numbers."""
+    return a * b
 
 
 def _always_fails() -> str:
@@ -50,15 +51,140 @@ def _no_args() -> str:
     return "ok"
 
 
+# ---------------------------------------------------------------------------
+# ToolInvocation.from_api_dict unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolInvocationFromApiDict:
+    """Tests for ToolInvocation.from_api_dict() edge cases."""
+
+    def test_dict_arguments(self):
+        """Normal case: arguments as a dict."""
+        invocation = ToolInvocation.from_api_dict(
+            {"id": "c1", "function": {"name": "add", "arguments": {"a": 1, "b": 2}}}
+        )
+        assert invocation.name == "add"
+        assert invocation.arguments == {"a": 1, "b": 2}
+        assert invocation.call_id == "c1"
+
+    def test_string_arguments(self):
+        """OpenAI returns arguments as a JSON string."""
+        invocation = ToolInvocation.from_api_dict(
+            {
+                "id": "c2",
+                "function": {
+                    "name": "add",
+                    "arguments": '{"a": 1, "b": 2}',
+                },
+            }
+        )
+        assert invocation.arguments == {"a": 1, "b": 2}
+
+    def test_none_arguments(self):
+        """Some models return arguments=null for parameterless tools."""
+        invocation = ToolInvocation.from_api_dict(
+            {"id": "c3", "function": {"name": "noop", "arguments": None}}
+        )
+        assert invocation.arguments == {}
+
+    def test_missing_arguments(self):
+        """Some models omit the arguments key entirely."""
+        invocation = ToolInvocation.from_api_dict(
+            {"id": "c4", "function": {"name": "noop"}}
+        )
+        assert invocation.arguments == {}
+
+    def test_missing_id(self):
+        """call_id should be None when id is not provided."""
+        invocation = ToolInvocation.from_api_dict(
+            {"function": {"name": "add", "arguments": {"a": 1}}}
+        )
+        assert invocation.call_id is None
+
+
+# ---------------------------------------------------------------------------
+# ToolInvocationResult tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolInvocationResult:
+    """Tests for ToolInvocationResult fields and methods."""
+
+    def test_text_returns_output(self):
+        result = ToolInvocationResult(name="f", arguments={}, output=42)
+        assert result.text == "42"
+
+    def test_text_returns_error(self):
+        result = ToolInvocationResult(
+            name="f", arguments={}, error="Something went wrong"
+        )
+        assert result.text == "Something went wrong"
+
+    def test_error_takes_precedence_in_text(self):
+        result = ToolInvocationResult(name="f", arguments={}, output=42, error="oops")
+        assert result.text == "oops"
+
+    def test_describe_success(self):
+        result = ToolInvocationResult(name="add", arguments={"a": 1}, output=2)
+        assert "add" in result.describe()
+        assert "2" in result.describe()
+        assert "Error" not in result.describe()
+
+    def test_describe_error(self):
+        result = ToolInvocationResult(name="add", arguments={}, error="Error: boom")
+        desc = result.describe()
+        assert "Error" in desc
+        assert "boom" in desc
+
+
+# ---------------------------------------------------------------------------
+# invoke_tool tests
+# ---------------------------------------------------------------------------
+
+
+class TestInvokeTool:
+    """Tests for invoke_tool with error field separation."""
+
+    def test_tool_not_found_sets_error(self):
+        """When tool is not found, error field should be set (not output)."""
+        invocation = ToolInvocation(name="nonexistent", arguments={})
+        result = invoke_tool(invocation, [_add])
+
+        assert result.error is not None
+        assert "not found" in result.error
+        assert result.output is None
+
+    def test_tool_exception_sets_error(self):
+        """When tool raises, error field should be set (not output)."""
+        invocation = ToolInvocation(name="_always_fails", arguments={})
+        result = invoke_tool(invocation, [_always_fails])
+
+        assert result.error is not None
+        assert "Simulated error" in result.error
+        assert result.output is None
+
+    def test_tool_success_sets_output(self):
+        """Successful tool call sets output, not error."""
+        invocation = ToolInvocation(name="_add", arguments={"a": 3, "b": 4})
+        result = invoke_tool(invocation, [_add])
+
+        assert result.output == 7.0
+        assert result.error is None
+
+
+# ---------------------------------------------------------------------------
+# Tool invocation loop tests
+# ---------------------------------------------------------------------------
+
+
 class TestToolInvocationLoop:
     """Tests for the prompt() tool invocation loop."""
 
     def test_tool_called_and_result_returned(self):
         """The LLM requests a tool call, the tool runs, and the final answer
         uses the result."""
-        # First response: LLM requests tool call.
-        # Second response: LLM gives final answer using tool result.
-        tool_response = _make_tool_call_response("_add", {"a": 3, "b": 4})
+        tool_response = MockedChat.make_tool_call_response("_add", {"a": 3, "b": 4})
         final_response = LLMMessage(sender=None, content="The answer is 7.")
 
         llm = MockedChat(responses=[tool_response, final_response])
@@ -77,7 +203,7 @@ class TestToolInvocationLoop:
 
     def test_tool_error_sent_back_to_llm(self):
         """When a tool raises an exception, the error message is sent back."""
-        tool_response = _make_tool_call_response("_always_fails", {})
+        tool_response = MockedChat.make_tool_call_response("_always_fails", {})
         final_response = LLMMessage(sender=None, content="The tool failed.")
 
         llm = MockedChat(responses=[tool_response, final_response])
@@ -87,7 +213,7 @@ class TestToolInvocationLoop:
 
     def test_extra_arguments_filtered(self):
         """Extra arguments from the API (like 'signature') are filtered out."""
-        tool_response = _make_tool_call_response(
+        tool_response = MockedChat.make_tool_call_response(
             "_add", {"a": 5, "b": 10, "signature": "extra_field"}
         )
         final_response = LLMMessage(sender=None, content="15")
@@ -100,7 +226,7 @@ class TestToolInvocationLoop:
 
     def test_assert_tool_was_invoked_in_forked_chat(self):
         """assert_tool_was_invoked finds tools in the forked subchat."""
-        tool_response = _make_tool_call_response("_add", {"a": 1, "b": 2})
+        tool_response = MockedChat.make_tool_call_response("_add", {"a": 1, "b": 2})
         final_response = LLMMessage(sender=None, content="3")
 
         llm = MockedChat(responses=[tool_response, final_response])
@@ -109,6 +235,17 @@ class TestToolInvocationLoop:
         # The assertion should find the tool result in the nested fork.
         result = assertions.assert_tool_was_invoked(_add)
         assert result.passed
+
+    def test_assert_tool_was_invoked_by_name(self):
+        """assert_tool_was_invoked accepts a string tool name."""
+        tool_response = MockedChat.make_tool_call_response("_add", {"a": 1, "b": 2})
+        final_response = LLMMessage(sender=None, content="3")
+
+        llm = MockedChat(responses=[tool_response, final_response])
+        llm.prompt("1+2?", tools=[_add])
+
+        assert assertions.assert_tool_was_invoked("_add").passed
+        assert not assertions.assert_tool_was_invoked("_multiply").passed
 
     def test_no_fork_without_tools(self):
         """When no tools are provided, prompt() doesn't fork the chat."""
@@ -125,19 +262,69 @@ class TestToolInvocationLoop:
 
     def test_tool_invocation_limit_exhausted(self):
         """ToolInvocationLimitExhausted is raised when max rounds are exceeded."""
-        # Create a cycling response that always requests a tool call.
-        tool_response = _make_tool_call_response("_add", {"a": 1, "b": 2})
+        tool_response = MockedChat.make_tool_call_response("_add", {"a": 1, "b": 2})
         llm = MockedChat(responses=[tool_response], cycle=True)
 
         with pytest.raises(ToolInvocationLimitExhausted):
             llm.prompt("Keep calling tools.", tools=[_add])
 
+    def test_max_tool_rounds_parameter(self):
+        """max_tool_rounds can be set to 1 to limit iterations."""
+        tool_response = MockedChat.make_tool_call_response("_add", {"a": 1, "b": 2})
+        llm = MockedChat(responses=[tool_response], cycle=True)
+
+        with pytest.raises(ToolInvocationLimitExhausted):
+            llm.prompt(
+                "Keep calling tools.",
+                tools=[_add],
+                extra_api_params={"max_tool_rounds": 1},
+            )
+        # With max_tool_rounds=1, only 1 invocation should have been made.
+        assert len(llm.invocations) == 1
+
     def test_none_arguments_handled(self):
         """When the model returns None arguments, the tool still executes."""
-        tool_response = _make_tool_call_response("_no_args", None)
+        tool_response = MockedChat.make_tool_call_response("_no_args", None)
         final_response = LLMMessage(sender=None, content="done")
 
         llm = MockedChat(responses=[tool_response, final_response])
         result = llm.prompt("Call the tool.", tools=[_no_args])
 
         assert result == "done"
+
+    def test_multiple_tool_calls_in_single_response(self):
+        """When the LLM requests multiple tools at once, all are invoked."""
+        msg = LLMMessage(sender=None, content="")
+        msg._meta["tool_calls"] = [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "_add", "arguments": {"a": 1, "b": 2}},
+            },
+            {
+                "id": "call_2",
+                "type": "function",
+                "function": {
+                    "name": "_multiply",
+                    "arguments": {"a": 3, "b": 4},
+                },
+            },
+        ]
+        final_response = LLMMessage(sender=None, content="1+2=3, 3*4=12")
+
+        llm = MockedChat(responses=[msg, final_response])
+        result = llm.prompt("Calculate both.", tools=[_add, _multiply])
+
+        assert result == "1+2=3, 3*4=12"
+        # 2 invocations: first with tool calls, second with final answer.
+        assert len(llm.invocations) == 2
+
+    def test_tool_not_found_through_loop(self):
+        """When the LLM calls a nonexistent tool, the error is sent back."""
+        tool_response = MockedChat.make_tool_call_response("nonexistent_tool", {"x": 1})
+        final_response = LLMMessage(sender=None, content="That tool doesn't exist.")
+
+        llm = MockedChat(responses=[tool_response, final_response])
+        result = llm.prompt("Call the tool.", tools=[_add])
+
+        assert result == "That tool doesn't exist."

--- a/tests/test_tool_loop.py
+++ b/tests/test_tool_loop.py
@@ -14,8 +14,11 @@
 
 """Tests for the tool invocation loop in LLMChat.prompt()."""
 
+import pytest
+
 from kaggle_benchmarks import assertions, chats
 from kaggle_benchmarks.llm_messages import LLMMessage
+from kaggle_benchmarks.tools.base import ToolInvocationLimitExhausted
 from tests.mocks import MockedChat
 
 
@@ -114,3 +117,12 @@ class TestToolInvocationLoop:
         chat = chats.get_current_chat()
         nested = [item for item in chat.history if isinstance(item, chats.Chat)]
         assert len(nested) == 0
+
+    def test_tool_invocation_limit_exhausted(self):
+        """ToolInvocationLimitExhausted is raised when max rounds are exceeded."""
+        # Create a cycling response that always requests a tool call.
+        tool_response = _make_tool_call_response("_add", {"a": 1, "b": 2})
+        llm = MockedChat(responses=[tool_response], cycle=True)
+
+        with pytest.raises(ToolInvocationLimitExhausted):
+            llm.prompt("Keep calling tools.", tools=[_add])

--- a/tests/test_tool_loop.py
+++ b/tests/test_tool_loop.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the tool invocation loop in LLMChat.prompt()."""
+
+import pytest
+
+from kaggle_benchmarks import assertions, chats
+from kaggle_benchmarks.actors.llms import ToolInvocationLimitExhausted
+from kaggle_benchmarks.llm_messages import LLMMessage
+from tests.mocks import MockedChat
+
+
+def _make_tool_call_response(name: str, arguments: dict, call_id: str = "call_1"):
+    """Creates an LLMMessage that simulates a tool call from the LLM."""
+    msg = LLMMessage(sender=None, content="")
+    msg._meta["tool_calls"] = [
+        {
+            "id": call_id,
+            "type": "function",
+            "function": {"name": name, "arguments": arguments},
+        }
+    ]
+    return msg
+
+
+def _add(a: float, b: float) -> float:
+    """Adds two numbers."""
+    return a + b
+
+
+def _always_fails() -> str:
+    """This tool always fails."""
+    raise ValueError("Simulated error")
+
+
+class TestToolInvocationLoop:
+    """Tests for the prompt() tool invocation loop."""
+
+    def test_tool_called_and_result_returned(self):
+        """The LLM requests a tool call, the tool runs, and the final answer
+        uses the result."""
+        # First response: LLM requests tool call.
+        # Second response: LLM gives final answer using tool result.
+        tool_response = _make_tool_call_response("_add", {"a": 3, "b": 4})
+        final_response = LLMMessage(sender=None, content="The answer is 7.")
+
+        llm = MockedChat(responses=[tool_response, final_response])
+        result = llm.prompt("What is 3 + 4?", tools=[_add])
+
+        assert result == "The answer is 7."
+
+    def test_tool_not_called_when_no_tool_calls(self):
+        """When the LLM doesn't request any tools, prompt() returns directly."""
+        response = LLMMessage(sender=None, content="The answer is 42.")
+        llm = MockedChat(responses=[response])
+
+        result = llm.prompt("What is 42?", tools=[_add])
+        assert result == "The answer is 42."
+        assert len(llm.invocations) == 1  # Only one call, no loop
+
+    def test_tool_error_sent_back_to_llm(self):
+        """When a tool raises an exception, the error message is sent back."""
+        tool_response = _make_tool_call_response("_always_fails", {})
+        final_response = LLMMessage(sender=None, content="The tool failed.")
+
+        llm = MockedChat(responses=[tool_response, final_response])
+        result = llm.prompt("Call the tool.", tools=[_always_fails])
+
+        assert result == "The tool failed."
+
+    def test_tool_invocation_limit_exhausted(self):
+        """Raises ToolInvocationLimitExhausted when max_tool_calls is exceeded."""
+        # Create a mock that always returns tool calls (never a final answer).
+        tool_response = _make_tool_call_response("_add", {"a": 1, "b": 2})
+        llm = MockedChat(
+            responses=[tool_response],
+            cycle=True,
+        )
+
+        with pytest.raises(ToolInvocationLimitExhausted):
+            llm.prompt("What is 1 + 2?", tools=[_add], max_tool_calls=3)
+
+    def test_extra_arguments_filtered(self):
+        """Extra arguments from the API (like 'signature') are filtered out."""
+        tool_response = _make_tool_call_response(
+            "_add", {"a": 5, "b": 10, "signature": "extra_field"}
+        )
+        final_response = LLMMessage(sender=None, content="15")
+
+        llm = MockedChat(responses=[tool_response, final_response])
+        result = llm.prompt("5 + 10?", tools=[_add])
+
+        # Should succeed despite the extra 'signature' argument.
+        assert result == "15"
+
+    def test_assert_tool_was_invoked_in_forked_chat(self):
+        """assert_tool_was_invoked finds tools in the forked subchat."""
+        tool_response = _make_tool_call_response("_add", {"a": 1, "b": 2})
+        final_response = LLMMessage(sender=None, content="3")
+
+        llm = MockedChat(responses=[tool_response, final_response])
+        llm.prompt("1+2?", tools=[_add])
+
+        # The assertion should find the tool result in the nested fork.
+        result = assertions.assert_tool_was_invoked(_add)
+        assert result.passed
+
+    def test_no_fork_without_tools(self):
+        """When no tools are provided, prompt() doesn't fork the chat."""
+        response = LLMMessage(sender=None, content="Hello.")
+        llm = MockedChat(responses=[response])
+
+        result = llm.prompt("Hi")
+        assert result == "Hello."
+
+        # No nested chats in history.
+        chat = chats.get_current_chat()
+        nested = [item for item in chat.history if isinstance(item, chats.Chat)]
+        assert len(nested) == 0

--- a/tests/test_tool_loop.py
+++ b/tests/test_tool_loop.py
@@ -51,56 +51,78 @@ def _no_args() -> str:
     return "ok"
 
 
+def _make_tool_call_response(
+    name: str,
+    arguments: dict | None = None,
+    call_id: str = "call_1",
+) -> LLMMessage[str]:
+    """Creates an LLMMessage that simulates a tool call from the LLM.
+
+    Populates _meta["tool_calls"] with the OpenAI-style dict format that
+    native_tool_agent expects.
+    """
+    msg = LLMMessage(sender=None, content="")
+    msg._meta["tool_calls"] = [
+        {
+            "id": call_id,
+            "type": "function",
+            "function": {"name": name, "arguments": arguments},
+        }
+    ]
+    return msg
+
+
 # ---------------------------------------------------------------------------
-# ToolInvocation.from_api_dict unit tests
+# ToolInvocation.from_api_dict tests
 # ---------------------------------------------------------------------------
 
 
-class TestToolInvocationFromApiDict:
-    """Tests for ToolInvocation.from_api_dict() edge cases."""
-
-    def test_dict_arguments(self):
-        """Normal case: arguments as a dict."""
-        invocation = ToolInvocation.from_api_dict(
-            {"id": "c1", "function": {"name": "add", "arguments": {"a": 1, "b": 2}}}
-        )
-        assert invocation.name == "add"
-        assert invocation.arguments == {"a": 1, "b": 2}
-        assert invocation.call_id == "c1"
-
-    def test_string_arguments(self):
-        """OpenAI returns arguments as a JSON string."""
-        invocation = ToolInvocation.from_api_dict(
-            {
-                "id": "c2",
-                "function": {
-                    "name": "add",
-                    "arguments": '{"a": 1, "b": 2}',
-                },
-            }
-        )
-        assert invocation.arguments == {"a": 1, "b": 2}
-
-    def test_none_arguments(self):
-        """Some models return arguments=null for parameterless tools."""
-        invocation = ToolInvocation.from_api_dict(
-            {"id": "c3", "function": {"name": "noop", "arguments": None}}
-        )
-        assert invocation.arguments == {}
-
-    def test_missing_arguments(self):
-        """Some models omit the arguments key entirely."""
-        invocation = ToolInvocation.from_api_dict(
-            {"id": "c4", "function": {"name": "noop"}}
-        )
-        assert invocation.arguments == {}
-
-    def test_missing_id(self):
-        """call_id should be None when id is not provided."""
-        invocation = ToolInvocation.from_api_dict(
-            {"function": {"name": "add", "arguments": {"a": 1}}}
-        )
-        assert invocation.call_id is None
+@pytest.mark.parametrize(
+    "api_dict, expected_name, expected_args, expected_id",
+    [
+        pytest.param(
+            {"id": "c1", "function": {"name": "add", "arguments": {"a": 1, "b": 2}}},
+            "add",
+            {"a": 1, "b": 2},
+            "c1",
+            id="dict_arguments",
+        ),
+        pytest.param(
+            {"id": "c2", "function": {"name": "add", "arguments": '{"a": 1, "b": 2}'}},
+            "add",
+            {"a": 1, "b": 2},
+            "c2",
+            id="string_arguments",
+        ),
+        pytest.param(
+            {"id": "c3", "function": {"name": "noop", "arguments": None}},
+            "noop",
+            {},
+            "c3",
+            id="none_arguments",
+        ),
+        pytest.param(
+            {"id": "c4", "function": {"name": "noop"}},
+            "noop",
+            {},
+            "c4",
+            id="missing_arguments",
+        ),
+        pytest.param(
+            {"function": {"name": "add", "arguments": {"a": 1}}},
+            "add",
+            {"a": 1},
+            None,
+            id="missing_id",
+        ),
+    ],
+)
+def test_from_api_dict(api_dict, expected_name, expected_args, expected_id):
+    """ToolInvocation.from_api_dict handles various argument formats."""
+    invocation = ToolInvocation.from_api_dict(api_dict)
+    assert invocation.name == expected_name
+    assert invocation.arguments == expected_args
+    assert invocation.call_id == expected_id
 
 
 # ---------------------------------------------------------------------------
@@ -108,34 +130,33 @@ class TestToolInvocationFromApiDict:
 # ---------------------------------------------------------------------------
 
 
-class TestToolInvocationResult:
-    """Tests for ToolInvocationResult fields and methods."""
+def test_result_text_returns_output():
+    result = ToolInvocationResult(name="f", arguments={}, output=42)
+    assert result.text == "42"
 
-    def test_text_returns_output(self):
-        result = ToolInvocationResult(name="f", arguments={}, output=42)
-        assert result.text == "42"
 
-    def test_text_returns_error(self):
-        result = ToolInvocationResult(
-            name="f", arguments={}, error="Something went wrong"
-        )
-        assert result.text == "Something went wrong"
+def test_result_text_returns_error():
+    result = ToolInvocationResult(name="f", arguments={}, error="Something went wrong")
+    assert result.text == "Something went wrong"
 
-    def test_error_takes_precedence_in_text(self):
-        result = ToolInvocationResult(name="f", arguments={}, output=42, error="oops")
-        assert result.text == "oops"
 
-    def test_describe_success(self):
-        result = ToolInvocationResult(name="add", arguments={"a": 1}, output=2)
-        assert "add" in result.describe()
-        assert "2" in result.describe()
-        assert "Error" not in result.describe()
+def test_result_error_takes_precedence_in_text():
+    result = ToolInvocationResult(name="f", arguments={}, output=42, error="oops")
+    assert result.text == "oops"
 
-    def test_describe_error(self):
-        result = ToolInvocationResult(name="add", arguments={}, error="Error: boom")
-        desc = result.describe()
-        assert "Error" in desc
-        assert "boom" in desc
+
+def test_result_describe_success():
+    result = ToolInvocationResult(name="add", arguments={"a": 1}, output=2)
+    assert "add" in result.describe()
+    assert "2" in result.describe()
+    assert "Error" not in result.describe()
+
+
+def test_result_describe_error():
+    result = ToolInvocationResult(name="add", arguments={}, error="Error: boom")
+    desc = result.describe()
+    assert "Error" in desc
+    assert "boom" in desc
 
 
 # ---------------------------------------------------------------------------
@@ -143,34 +164,33 @@ class TestToolInvocationResult:
 # ---------------------------------------------------------------------------
 
 
-class TestInvokeTool:
-    """Tests for invoke_tool with error field separation."""
+def test_invoke_tool_not_found_sets_error():
+    """When tool is not found, error field should be set (not output)."""
+    invocation = ToolInvocation(name="nonexistent", arguments={})
+    result = invoke_tool(invocation, [_add])
 
-    def test_tool_not_found_sets_error(self):
-        """When tool is not found, error field should be set (not output)."""
-        invocation = ToolInvocation(name="nonexistent", arguments={})
-        result = invoke_tool(invocation, [_add])
+    assert result.error is not None
+    assert "not found" in result.error
+    assert result.output is None
 
-        assert result.error is not None
-        assert "not found" in result.error
-        assert result.output is None
 
-    def test_tool_exception_sets_error(self):
-        """When tool raises, error field should be set (not output)."""
-        invocation = ToolInvocation(name="_always_fails", arguments={})
-        result = invoke_tool(invocation, [_always_fails])
+def test_invoke_tool_exception_sets_error():
+    """When tool raises, error field should be set (not output)."""
+    invocation = ToolInvocation(name="_always_fails", arguments={})
+    result = invoke_tool(invocation, [_always_fails])
 
-        assert result.error is not None
-        assert "Simulated error" in result.error
-        assert result.output is None
+    assert result.error is not None
+    assert "Simulated error" in result.error
+    assert result.output is None
 
-    def test_tool_success_sets_output(self):
-        """Successful tool call sets output, not error."""
-        invocation = ToolInvocation(name="_add", arguments={"a": 3, "b": 4})
-        result = invoke_tool(invocation, [_add])
 
-        assert result.output == 7.0
-        assert result.error is None
+def test_invoke_tool_success_sets_output():
+    """Successful tool call sets output, not error."""
+    invocation = ToolInvocation(name="_add", arguments={"a": 3, "b": 4})
+    result = invoke_tool(invocation, [_add])
+
+    assert result.output == 7.0
+    assert result.error is None
 
 
 # ---------------------------------------------------------------------------
@@ -178,153 +198,161 @@ class TestInvokeTool:
 # ---------------------------------------------------------------------------
 
 
-class TestToolInvocationLoop:
-    """Tests for the prompt() tool invocation loop."""
+def test_tool_called_and_result_returned():
+    """The LLM requests a tool call, the tool runs, and the final answer
+    uses the result."""
+    tool_response = _make_tool_call_response("_add", {"a": 3, "b": 4})
+    final_response = LLMMessage(sender=None, content="The answer is 7.")
 
-    def test_tool_called_and_result_returned(self):
-        """The LLM requests a tool call, the tool runs, and the final answer
-        uses the result."""
-        tool_response = MockedChat.make_tool_call_response("_add", {"a": 3, "b": 4})
-        final_response = LLMMessage(sender=None, content="The answer is 7.")
+    llm = MockedChat(responses=[tool_response, final_response])
+    result = llm.prompt("What is 3 + 4?", tools=[_add])
 
-        llm = MockedChat(responses=[tool_response, final_response])
-        result = llm.prompt("What is 3 + 4?", tools=[_add])
+    assert result == "The answer is 7."
 
-        assert result == "The answer is 7."
 
-    def test_tool_not_called_when_no_tool_calls(self):
-        """When the LLM doesn't request any tools, prompt() returns directly."""
-        response = LLMMessage(sender=None, content="The answer is 42.")
-        llm = MockedChat(responses=[response])
+def test_tool_not_called_when_no_tool_calls():
+    """When the LLM doesn't request any tools, prompt() returns directly."""
+    response = LLMMessage(sender=None, content="The answer is 42.")
+    llm = MockedChat(responses=[response])
 
-        result = llm.prompt("What is 42?", tools=[_add])
-        assert result == "The answer is 42."
-        assert len(llm.invocations) == 1  # Only one call, no loop
+    result = llm.prompt("What is 42?", tools=[_add])
+    assert result == "The answer is 42."
+    assert len(llm.invocations) == 1  # Only one call, no loop
 
-    def test_tool_error_sent_back_to_llm(self):
-        """When a tool raises an exception, the error message is sent back."""
-        tool_response = MockedChat.make_tool_call_response("_always_fails", {})
-        final_response = LLMMessage(sender=None, content="The tool failed.")
 
-        llm = MockedChat(responses=[tool_response, final_response])
-        result = llm.prompt("Call the tool.", tools=[_always_fails])
+def test_tool_error_sent_back_to_llm():
+    """When a tool raises an exception, the error message is sent back."""
+    tool_response = _make_tool_call_response("_always_fails", {})
+    final_response = LLMMessage(sender=None, content="The tool failed.")
 
-        assert result == "The tool failed."
+    llm = MockedChat(responses=[tool_response, final_response])
+    result = llm.prompt("Call the tool.", tools=[_always_fails])
 
-    def test_extra_arguments_filtered(self):
-        """Extra arguments from the API (like 'signature') are filtered out."""
-        tool_response = MockedChat.make_tool_call_response(
-            "_add", {"a": 5, "b": 10, "signature": "extra_field"}
+    assert result == "The tool failed."
+
+
+def test_extra_arguments_filtered():
+    """Extra arguments from the API (like 'signature') are filtered out."""
+    tool_response = _make_tool_call_response(
+        "_add", {"a": 5, "b": 10, "signature": "extra_field"}
+    )
+    final_response = LLMMessage(sender=None, content="15")
+
+    llm = MockedChat(responses=[tool_response, final_response])
+    result = llm.prompt("5 + 10?", tools=[_add])
+
+    # Should succeed despite the extra 'signature' argument.
+    assert result == "15"
+
+
+def test_assert_tool_was_invoked_in_forked_chat():
+    """assert_tool_was_invoked finds tools in the forked subchat."""
+    tool_response = _make_tool_call_response("_add", {"a": 1, "b": 2})
+    final_response = LLMMessage(sender=None, content="3")
+
+    llm = MockedChat(responses=[tool_response, final_response])
+    llm.prompt("1+2?", tools=[_add])
+
+    # The assertion should find the tool result in the nested fork.
+    result = assertions.assert_tool_was_invoked(_add)
+    assert result.passed
+
+
+def test_assert_tool_was_invoked_by_name():
+    """assert_tool_was_invoked accepts a string tool name."""
+    tool_response = _make_tool_call_response("_add", {"a": 1, "b": 2})
+    final_response = LLMMessage(sender=None, content="3")
+
+    llm = MockedChat(responses=[tool_response, final_response])
+    llm.prompt("1+2?", tools=[_add])
+
+    assert assertions.assert_tool_was_invoked("_add").passed
+    assert not assertions.assert_tool_was_invoked("_multiply").passed
+
+
+def test_no_fork_without_tools():
+    """When no tools are provided, prompt() doesn't fork the chat."""
+    response = LLMMessage(sender=None, content="Hello.")
+    llm = MockedChat(responses=[response])
+
+    result = llm.prompt("Hi")
+    assert result == "Hello."
+
+    # No nested chats in history.
+    chat = chats.get_current_chat()
+    nested = [item for item in chat.history if isinstance(item, chats.Chat)]
+    assert len(nested) == 0
+
+
+def test_tool_invocation_limit_exhausted():
+    """ToolInvocationLimitExhausted is raised when max rounds are exceeded."""
+    tool_response = _make_tool_call_response("_add", {"a": 1, "b": 2})
+    llm = MockedChat(responses=[tool_response], cycle=True)
+
+    with pytest.raises(ToolInvocationLimitExhausted):
+        llm.prompt("Keep calling tools.", tools=[_add])
+
+
+def test_max_tool_rounds_parameter():
+    """max_tool_rounds can be set to 1 to limit iterations."""
+    tool_response = _make_tool_call_response("_add", {"a": 1, "b": 2})
+    llm = MockedChat(responses=[tool_response], cycle=True)
+
+    with pytest.raises(ToolInvocationLimitExhausted):
+        llm.prompt(
+            "Keep calling tools.",
+            tools=[_add],
+            extra_api_params={"max_tool_rounds": 1},
         )
-        final_response = LLMMessage(sender=None, content="15")
+    # With max_tool_rounds=1, only 1 invocation should have been made.
+    assert len(llm.invocations) == 1
 
-        llm = MockedChat(responses=[tool_response, final_response])
-        result = llm.prompt("5 + 10?", tools=[_add])
 
-        # Should succeed despite the extra 'signature' argument.
-        assert result == "15"
+def test_none_arguments_handled():
+    """When the model returns None arguments, the tool still executes."""
+    tool_response = _make_tool_call_response("_no_args", None)
+    final_response = LLMMessage(sender=None, content="done")
 
-    def test_assert_tool_was_invoked_in_forked_chat(self):
-        """assert_tool_was_invoked finds tools in the forked subchat."""
-        tool_response = MockedChat.make_tool_call_response("_add", {"a": 1, "b": 2})
-        final_response = LLMMessage(sender=None, content="3")
+    llm = MockedChat(responses=[tool_response, final_response])
+    result = llm.prompt("Call the tool.", tools=[_no_args])
 
-        llm = MockedChat(responses=[tool_response, final_response])
-        llm.prompt("1+2?", tools=[_add])
+    assert result == "done"
 
-        # The assertion should find the tool result in the nested fork.
-        result = assertions.assert_tool_was_invoked(_add)
-        assert result.passed
 
-    def test_assert_tool_was_invoked_by_name(self):
-        """assert_tool_was_invoked accepts a string tool name."""
-        tool_response = MockedChat.make_tool_call_response("_add", {"a": 1, "b": 2})
-        final_response = LLMMessage(sender=None, content="3")
-
-        llm = MockedChat(responses=[tool_response, final_response])
-        llm.prompt("1+2?", tools=[_add])
-
-        assert assertions.assert_tool_was_invoked("_add").passed
-        assert not assertions.assert_tool_was_invoked("_multiply").passed
-
-    def test_no_fork_without_tools(self):
-        """When no tools are provided, prompt() doesn't fork the chat."""
-        response = LLMMessage(sender=None, content="Hello.")
-        llm = MockedChat(responses=[response])
-
-        result = llm.prompt("Hi")
-        assert result == "Hello."
-
-        # No nested chats in history.
-        chat = chats.get_current_chat()
-        nested = [item for item in chat.history if isinstance(item, chats.Chat)]
-        assert len(nested) == 0
-
-    def test_tool_invocation_limit_exhausted(self):
-        """ToolInvocationLimitExhausted is raised when max rounds are exceeded."""
-        tool_response = MockedChat.make_tool_call_response("_add", {"a": 1, "b": 2})
-        llm = MockedChat(responses=[tool_response], cycle=True)
-
-        with pytest.raises(ToolInvocationLimitExhausted):
-            llm.prompt("Keep calling tools.", tools=[_add])
-
-    def test_max_tool_rounds_parameter(self):
-        """max_tool_rounds can be set to 1 to limit iterations."""
-        tool_response = MockedChat.make_tool_call_response("_add", {"a": 1, "b": 2})
-        llm = MockedChat(responses=[tool_response], cycle=True)
-
-        with pytest.raises(ToolInvocationLimitExhausted):
-            llm.prompt(
-                "Keep calling tools.",
-                tools=[_add],
-                extra_api_params={"max_tool_rounds": 1},
-            )
-        # With max_tool_rounds=1, only 1 invocation should have been made.
-        assert len(llm.invocations) == 1
-
-    def test_none_arguments_handled(self):
-        """When the model returns None arguments, the tool still executes."""
-        tool_response = MockedChat.make_tool_call_response("_no_args", None)
-        final_response = LLMMessage(sender=None, content="done")
-
-        llm = MockedChat(responses=[tool_response, final_response])
-        result = llm.prompt("Call the tool.", tools=[_no_args])
-
-        assert result == "done"
-
-    def test_multiple_tool_calls_in_single_response(self):
-        """When the LLM requests multiple tools at once, all are invoked."""
-        msg = LLMMessage(sender=None, content="")
-        msg._meta["tool_calls"] = [
-            {
-                "id": "call_1",
-                "type": "function",
-                "function": {"name": "_add", "arguments": {"a": 1, "b": 2}},
+def test_multiple_tool_calls_in_single_response():
+    """When the LLM requests multiple tools at once, all are invoked."""
+    msg = LLMMessage(sender=None, content="")
+    msg._meta["tool_calls"] = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "_add", "arguments": {"a": 1, "b": 2}},
+        },
+        {
+            "id": "call_2",
+            "type": "function",
+            "function": {
+                "name": "_multiply",
+                "arguments": {"a": 3, "b": 4},
             },
-            {
-                "id": "call_2",
-                "type": "function",
-                "function": {
-                    "name": "_multiply",
-                    "arguments": {"a": 3, "b": 4},
-                },
-            },
-        ]
-        final_response = LLMMessage(sender=None, content="1+2=3, 3*4=12")
+        },
+    ]
+    final_response = LLMMessage(sender=None, content="1+2=3, 3*4=12")
 
-        llm = MockedChat(responses=[msg, final_response])
-        result = llm.prompt("Calculate both.", tools=[_add, _multiply])
+    llm = MockedChat(responses=[msg, final_response])
+    result = llm.prompt("Calculate both.", tools=[_add, _multiply])
 
-        assert result == "1+2=3, 3*4=12"
-        # 2 invocations: first with tool calls, second with final answer.
-        assert len(llm.invocations) == 2
+    assert result == "1+2=3, 3*4=12"
+    # 2 invocations: first with tool calls, second with final answer.
+    assert len(llm.invocations) == 2
 
-    def test_tool_not_found_through_loop(self):
-        """When the LLM calls a nonexistent tool, the error is sent back."""
-        tool_response = MockedChat.make_tool_call_response("nonexistent_tool", {"x": 1})
-        final_response = LLMMessage(sender=None, content="That tool doesn't exist.")
 
-        llm = MockedChat(responses=[tool_response, final_response])
-        result = llm.prompt("Call the tool.", tools=[_add])
+def test_tool_not_found_through_loop():
+    """When the LLM calls a nonexistent tool, the error is sent back."""
+    tool_response = _make_tool_call_response("nonexistent_tool", {"x": 1})
+    final_response = LLMMessage(sender=None, content="That tool doesn't exist.")
 
-        assert result == "That tool doesn't exist."
+    llm = MockedChat(responses=[tool_response, final_response])
+    result = llm.prompt("Call the tool.", tools=[_add])
+
+    assert result == "That tool doesn't exist."

--- a/tests/test_tool_loop.py
+++ b/tests/test_tool_loop.py
@@ -14,6 +14,7 @@
 
 """Tests for the tool invocation loop in LLMChat.prompt()."""
 
+import pydantic
 import pytest
 
 from kaggle_benchmarks import assertions, chats
@@ -356,3 +357,88 @@ def test_tool_not_found_through_loop():
     result = llm.prompt("Call the tool.", tools=[_add])
 
     assert result == "That tool doesn't exist."
+
+
+# ---------------------------------------------------------------------------
+# Two-phase tool loop tests (schema + tools)
+# ---------------------------------------------------------------------------
+
+
+class _CityInfo(pydantic.BaseModel):
+    """Test schema for structured output."""
+
+    name: str
+    population: int
+
+
+def _get_city(city_name: str) -> dict:
+    """Returns city data."""
+    return {"name": city_name, "population": 1_000_000}
+
+
+def test_schema_not_passed_during_tool_rounds():
+    """During tool rounds, respond() should NOT receive schema=.
+    The schema-only call happens as a separate final invocation."""
+    tool_response = _make_tool_call_response("_get_city", {"city_name": "Berlin"})
+    text_response = LLMMessage(sender=None, content="Berlin has 1M people.")
+    schema_response = LLMMessage(
+        sender=None, content='{"name": "Berlin", "population": 1000000}'
+    )
+
+    llm = MockedChat(
+        responses=[tool_response, text_response, schema_response],
+        support_structured_outputs=True,
+    )
+    result = llm.prompt("Look up Berlin.", tools=[_get_city], schema=_CityInfo)
+
+    assert isinstance(result, _CityInfo)
+    # 3 invocations: tool call, text answer (no schema), schema-only call.
+    assert len(llm.invocations) == 3
+
+    # Tool rounds (invocations 0 and 1): should NOT have response_format.
+    _, kwargs_round1 = llm.invocations[0]
+    assert "response_format" not in kwargs_round1
+
+    _, kwargs_round2 = llm.invocations[1]
+    assert "response_format" not in kwargs_round2
+
+    # Final call (invocation 2): should have response_format for the schema.
+    _, kwargs_round3 = llm.invocations[2]
+    assert "response_format" in kwargs_round3
+    assert kwargs_round3["response_format"] == _CityInfo
+
+
+def test_no_extra_call_when_schema_is_str():
+    """When schema=str (default), no extra schema-only call is made."""
+    tool_response = _make_tool_call_response("_get_city", {"city_name": "Berlin"})
+    final_response = LLMMessage(sender=None, content="Berlin has 1M people.")
+
+    llm = MockedChat(responses=[tool_response, final_response])
+    result = llm.prompt("Look up Berlin.", tools=[_get_city])
+
+    assert result == "Berlin has 1M people."
+    # Only 2 invocations: tool call + final text answer. No extra schema call.
+    assert len(llm.invocations) == 2
+
+
+def test_schema_call_sees_tool_history():
+    """The schema-only call should see the tool conversation history."""
+    tool_response = _make_tool_call_response("_get_city", {"city_name": "Berlin"})
+    text_response = LLMMessage(sender=None, content="Berlin has 1M people.")
+    schema_response = LLMMessage(
+        sender=None, content='{"name": "Berlin", "population": 1000000}'
+    )
+
+    llm = MockedChat(
+        responses=[tool_response, text_response, schema_response],
+        support_structured_outputs=True,
+    )
+    llm.prompt("Look up Berlin.", tools=[_get_city], schema=_CityInfo)
+
+    # The third invocation (schema call) should include messages from the
+    # tool loop — at minimum the tool result and the text answer.
+    messages_round3, _ = llm.invocations[2]
+    # Should have more messages than the first round (user prompt only)
+    # because tool results and LLM responses were appended.
+    messages_round1, _ = llm.invocations[0]
+    assert len(messages_round3) > len(messages_round1)

--- a/tests/tools/test_base.py
+++ b/tests/tools/test_base.py
@@ -51,10 +51,14 @@ def test_invoke_tool_success():
 def test_invoke_tool_not_found():
     call = ToolInvocation(name="non_existent_tool", arguments={})
     result = invoke_tool(call, [simple_tool])
-    assert "Error: Tool 'non_existent_tool' not found." in result.output
+    assert result.error is not None
+    assert "Error: Tool 'non_existent_tool' not found." in result.error
+    assert result.output is None
 
 
 def test_invoke_tool_exception():
     call = ToolInvocation(name="tool_that_raises", arguments={})
     result = invoke_tool(call, [tool_that_raises])
-    assert "Error invoking tool 'tool_that_raises': This tool failed." in result.output
+    assert result.error is not None
+    assert "Error invoking tool 'tool_that_raises': This tool failed." in result.error
+    assert result.output is None

--- a/tests/tools/test_functions.py
+++ b/tests/tools/test_functions.py
@@ -51,10 +51,11 @@ def test_get_function_schema_with_unserializable_arg():
 def test_function_to_openai_tool():
     tool = function_to_openai_tool(sample_function)
     assert tool["type"] == "function"
-    assert tool["name"] == "sample_function"
-    assert tool["description"] == "This is a sample function."
-    assert tool["parameters"]["properties"]["a"]["type"] == "integer"
-    assert "a" in tool["parameters"]["required"]
+    func = tool["function"]
+    assert func["name"] == "sample_function"
+    assert func["description"] == "This is a sample function."
+    assert func["parameters"]["properties"]["a"]["type"] == "integer"
+    assert "a" in func["parameters"]["required"]
 
 
 def test_function_to_openai_pydantic():
@@ -67,9 +68,10 @@ def test_function_to_openai_pydantic():
         return args.a
 
     tool = function_to_openai_tool(sample_function_pydantic)
-    assert tool["name"] == "sample_function_pydantic"
-    assert tool["parameters"]["properties"]["args"]["$ref"] == "#/$defs/Args"
-    defs = tool["parameters"]["$defs"]
+    func = tool["function"]
+    assert func["name"] == "sample_function_pydantic"
+    assert func["parameters"]["properties"]["args"]["$ref"] == "#/$defs/Args"
+    defs = func["parameters"]["$defs"]
     assert defs["Args"]["properties"]["a"]["type"] == "integer"
     assert defs["Args"]["properties"]["b"]["type"] == "string"
 

--- a/user_guide.md
+++ b/user_guide.md
@@ -263,14 +263,13 @@ traces = kbench.last_reasoning_traces()  # model's internal reasoning
 ### `llm.prompt()` with Tool Calling
 
 You can allow the LLM to use Python functions as tools by passing them
-in a list to the `tools` parameter.
-
-**Note: Automatic tool calling currently requires loading the model with
-`api="genai"`.**
+in a list to the `tools` parameter. The library handles multi-turn tool
+calling automatically: it sends the tools to the model, executes any
+requested tool calls, feeds the results back, and repeats until the
+model produces a final answer.
 
 ``` python
 import kaggle_benchmarks as kbench
-from kaggle_benchmarks.kaggle import models
 
 
 def weird_multiply(a: int, b: int) -> int:
@@ -278,18 +277,43 @@ def weird_multiply(a: int, b: int) -> int:
     return 42
 
 
-# NOTE: Automatic tool calling requires the `genai` API.
-# For `openai` API, tools must be called manually:
-# e.g., see example `use_calculator_tool.py`
-llm_with_genai_api = models.load_model(
-    model_name=kbench.llm.name,
-    api="genai",
-)
-
-response = llm_with_genai_api.prompt(
+response = kbench.llm.prompt(
     "Answer user questions by only using the provided tool: what is 2 times 3?",
     tools=[weird_multiply],
 )
+```
+
+Tools can be combined with `schema` to get structured output after the
+tool-calling phase completes:
+
+``` python
+from dataclasses import dataclass
+
+
+@dataclass
+class CityInfo:
+    name: str
+    population: int
+
+
+def get_city_data(city_name: str) -> dict:
+    """Returns data about a city."""
+    return {"name": city_name, "population": 3_700_000}
+
+
+result = kbench.llm.prompt(
+    "Look up Berlin and return it as a CityInfo.",
+    tools=[get_city_data],
+    schema=CityInfo,
+)
+# result is a CityInfo instance
+```
+
+You can verify that a tool was actually called using the built-in
+`assert_tool_was_invoked` assertion:
+
+``` python
+kbench.assertions.assert_tool_was_invoked(get_city_data)
 ```
 
 ### `kbench.user.send()` and Multi-Turn Chats
@@ -447,6 +471,9 @@ some of the ones you’ll use most often:
   or list) is empty.
 - `assert_not_empty(container, ...)`: Checks if a container is not
   empty.
+- `assert_tool_was_invoked(tool, ...)`: Checks if a specific tool
+  function was invoked during the current task. Accepts either a
+  callable or a tool name string.
 - `assert_fail(expectation)`: Signals a test failure unconditionally,
   with an optional message.
 


### PR DESCRIPTION
# PR: Native Tool Calling

Adds **native** (API-level) tool calling to `llm.prompt()` across OpenAI and GenAI backends. This complements the **simulated** tool agents in PR #12 and #117 — those inject tool results into prompts as text, while native tool calling uses the model's built-in function calling protocol for structured tool use.

```python
llm.prompt("What is 12 * 34?", tools=[multiply])
# LLM calls multiply(12, 34) → receives 408 → responds "408"
```

## Changes

**Tool loop** ([`native.py`](file:///usr/local/google/home/limagoog/git/kaggle-benchmarks/src/kaggle_benchmarks/tools/native.py) — new): `native_tool_agent()` implements the multi-turn loop using `chats.fork()` to isolate tool round-trips. Both backends normalize tool calls to a shared dict schema.

**Backend integration** ([`llms.py`](file:///usr/local/google/home/limagoog/git/kaggle-benchmarks/src/kaggle_benchmarks/actors/llms.py)): `prompt(..., tools=)` routes through the tool agent. `OpenAI.invoke()` and `GoogleGenAI.invoke()` convert callables to their respective tool schemas and extract tool calls from responses.

**Serializers** ([`openai.py`](file:///usr/local/google/home/limagoog/git/kaggle-benchmarks/src/kaggle_benchmarks/serializers/openai.py), [`genai.py`](file:///usr/local/google/home/limagoog/git/kaggle-benchmarks/src/kaggle_benchmarks/serializers/genai.py)): Tool call history is now serialized as `{"role": "assistant", "tool_calls": [...]}` + `{"role": "tool", "tool_call_id": ...}` messages (Chat Completions format), replacing the previous `function_call`/`function_call_output` format. This matches what Model Proxy expects for multi-turn tool conversations.

**Tool infra** ([`base.py`](file:///usr/local/google/home/limagoog/git/kaggle-benchmarks/src/kaggle_benchmarks/tools/base.py)): Added `ToolInvocation.from_api_dict()`, error field on results, and filtering of injected `signature` args from Model Proxy.

**Model Proxy fix** ([`model_proxy.py`](file:///usr/local/google/home/limagoog/git/kaggle-benchmarks/src/kaggle_benchmarks/kaggle/model_proxy.py)): Disabled constrained structured output for Gemma (returns markdown-fenced JSON).

**Golden tests**: Rotated 5 stale models → 5 current ones, added 7 tool-calling tests. All exclusions documented.

## Golden test results

13 models × 2 APIs = 475 test cases. **450 passed (94.7%)**.

25 failures break down as:

| Category | Count | Root cause |
|---|---|---|
| `test_tool_with_schema_output` | 4 | Gemini 2.0-flash / 2.5-pro refuse to call tool when user prompt references unknown schema type; GPT-5.5 via genai hits empty `json_schema.name` bug |
| MP `json_schema.name` bug (fix in progress) | 6 | MP sends empty `json_schema.name` when routing GenAI structured output to OpenAI (GPT-5.5 extractions) |
| Gemini multiple tools (openai) | 6 | Gemini 2.x via OpenAI endpoint rejects multiple tool declarations (`multiple_tool_selection` + `multi_step_tool_chain`) |
| Reasoning unsupported | 4 | gemini-2.0-flash, gemma-4-31b don't support `reasoning=` |
| Image base64 (1×1 pixel) | 2 | GPT-5.5 doesn't process 1×1 pixel images |
| gemini-2.0-flash tool return | 2 | Returns incorrect answer on complex tool return test |
| Other (flaky) | 1 | deepseek-v3.2 complex tool return / multi-step tool chain 500 error |


## TODOs

1. Move tool calls from `response._meta` to `response.tool_calls` (pending LLMMessage migration)
