### PR TITLE
Mark local environment as internal only

### DIFF
--- a/src/kaggle_benchmarks/envs/__init__.py
+++ b/src/kaggle_benchmarks/envs/__init__.py
@@ -18,6 +18,6 @@ Tools for LLM interaction with execution environments (OS, Docker).
 
 from kaggle_benchmarks.envs.docker import DockerEnvironment
 from kaggle_benchmarks.envs.environment import Environment, RunResult
-from kaggle_benchmarks.envs.local import LocalEnvironment
+from kaggle_benchmarks.envs.local import InternalUnsafeLocalEnvironment
 
-current = LocalEnvironment()
+current = InternalUnsafeLocalEnvironment(_internal=True)

--- a/src/kaggle_benchmarks/envs/local.py
+++ b/src/kaggle_benchmarks/envs/local.py
@@ -14,19 +14,55 @@
 
 import os
 import subprocess
+import warnings
 
 from kaggle_benchmarks.envs import environment, mixins
 
 
-class LocalEnvironment(mixins.TemporalDirectoryMixin):
-    def __init__(self):
+class InternalUnsafeLocalEnvironment(mixins.TemporalDirectoryMixin):
+    """An **unsandboxed** local execution environment. Internal use only.
+
+    .. warning::
+
+        **This class provides NO sandboxing or isolation.** Commands execute with
+        the full privileges of the host process. Specifically:
+
+        - Path traversal (e.g. ``../``) can escape the temporary directory and
+          read/write anywhere the current user has access.
+        - String commands run with ``shell=True``, allowing shell metacharacter
+          injection.
+
+        **Do not use this with untrusted or adversarial model outputs.** For
+        isolated execution, use :class:`DockerEnvironment` instead.
+
+        This class exists to support internal tooling (e.g. the Python script
+        runner and Browser tool). External SDK users should not instantiate it
+        directly.
+    """
+
+    def __init__(self, *, _internal: bool = False):
         super().__init__()
         self.original_dir = os.getcwd()
+        if not _internal:
+            warnings.warn(
+                "InternalUnsafeLocalEnvironment provides NO sandboxing or "
+                "isolation — commands run with full host privileges. "
+                "This class is intended for internal use only. "
+                "For isolated execution with untrusted models, use "
+                "DockerEnvironment instead.",
+                UserWarning,
+                stacklevel=2,
+            )
 
     def run(
         self, command: str | list[str], input: str | None = None
     ) -> environment.RunResult:
-        """Runs a shell command in the temporary directory."""
+        """Runs a shell command in the temporary directory.
+
+        .. warning::
+            No sandboxing is applied. The command has full access to the host
+            filesystem and network.
+        """
         result = subprocess.run(
             command,
             shell=isinstance(command, str),

--- a/src/kaggle_benchmarks/tools/web.py
+++ b/src/kaggle_benchmarks/tools/web.py
@@ -21,7 +21,7 @@ import nest_asyncio
 from playwright.async_api import async_playwright
 
 from kaggle_benchmarks import actors, chats
-from kaggle_benchmarks.envs import LocalEnvironment
+from kaggle_benchmarks.envs import InternalUnsafeLocalEnvironment
 
 # required as jupyter runs its own asyncio loop
 nest_asyncio.apply()
@@ -96,7 +96,7 @@ async def async_take_snapshot(
 class Browser(actors.Actor):
     def __init__(self):
         super().__init__(role="tool", avatar="🌐", name="Browser")
-        self.env = LocalEnvironment()
+        self.env = InternalUnsafeLocalEnvironment(_internal=True)
 
     def __enter__(self):
         return self

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -19,7 +19,7 @@ import pytest
 from kaggle_benchmarks.envs import docker, local
 
 envs = [
-    pytest.param(local.LocalEnvironment, {}, id="local"),
+    pytest.param(local.InternalUnsafeLocalEnvironment, {}, id="local"),
     pytest.param(
         docker.DockerEnvironment,
         dict(image="python:3.11", working_dir="/tmp"),

--- a/tests/test_unsafe_local_environment.py
+++ b/tests/test_unsafe_local_environment.py
@@ -1,0 +1,52 @@
+# Copyright 2025 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+
+import pytest
+
+from kaggle_benchmarks.envs.local import InternalUnsafeLocalEnvironment
+
+
+class TestInternalUnsafeLocalEnvironmentWarning:
+    """Tests for the runtime safety warning on InternalUnsafeLocalEnvironment."""
+
+    def test_warns_by_default(self):
+        """External callers (default _internal=False) should see a UserWarning."""
+        with pytest.warns(UserWarning, match="NO sandboxing"):
+            env = InternalUnsafeLocalEnvironment()
+        env.close()
+
+    def test_no_warning_when_internal(self):
+        """Internal callers passing _internal=True should not see a warning."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            env = InternalUnsafeLocalEnvironment(_internal=True)
+        env.close()
+
+    def test_warning_message_mentions_docker(self):
+        """The warning should guide users toward DockerEnvironment."""
+        with pytest.warns(UserWarning, match="DockerEnvironment"):
+            env = InternalUnsafeLocalEnvironment()
+        env.close()
+
+    def test_still_functional_regardless_of_internal_flag(self):
+        """Both _internal=True and _internal=False produce a working environment."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            for internal in (True, False):
+                with InternalUnsafeLocalEnvironment(_internal=internal) as env:
+                    result = env.run("echo hello")
+                    assert result.exit_code == 0
+                    assert result.stdout.strip() == "hello"

--- a/tests/tools/test_python.py
+++ b/tests/tools/test_python.py
@@ -18,7 +18,7 @@ from kaggle_benchmarks.envs import docker, local
 from kaggle_benchmarks.tools import python
 
 envs = [
-    pytest.param(local.LocalEnvironment, {}, id="local"),
+    pytest.param(local.InternalUnsafeLocalEnvironment, {}, id="local"),
     pytest.param(
         docker.DockerEnvironment,
         dict(image="python:3.11"),


### PR DESCRIPTION
Related to: https://github.com/Kaggle/kaggle-benchmarks/issues/159 

1. Rename `LocalEnvironment` to internal use only. Internal usage sends in a list of parts as a command which is safe.

2. Show a warning when there is an external import of `InternalUnsafeLocalEnvironment` .
