### PR TITLE
feat: enhance large dataset evaluation

### DIFF
--- a/cookbook.md
+++ b/cookbook.md
@@ -293,9 +293,13 @@ print(results.as_dataframe())
 
 ### Recipe: Best Practices for Large Datasets (Caching & Retries)
 
-When running benchmarks on large datasets (like MMLU or GSM8K), runs can take hours and may fail midway due to API rate limits, timeouts, or transient errors. 
+When running benchmarks on large datasets (like MMLU or GSM8K), evaluations can take hours and may hit transient failures — API rate limits, network blips, or 5xx errors. By default, `evaluate()` raises on the first such failure, which is the right behavior for development but not for production-scale runs where a single flake shouldn't waste hundreds of already-completed samples.
 
-You can use the framework's built-in caching and retry mechanisms to handle these failures gracefully without losing progress.
+The recommended production pattern combines three features:
+
+- **`on_failure="continue"`** — tell `evaluate()` to catch per-sample exceptions, record them as failed runs, and keep going instead of raising.
+- **`max_attempts > 1`** — retry the evaluation; with `on_failure="continue"`, only the samples that failed get re-run.
+- **`enable_cache()`** — persist successful samples to disk so that retries (and reruns of the whole notebook) skip the work that's already done.
 
 ``` python
 import kaggle_benchmarks as kbench
@@ -311,20 +315,33 @@ def evaluate_sample(llm, question, expected_answer) -> bool:
     return expected_answer.lower() in response.lower()
 
 
-# 2. Use enable_cache() and evaluate() with retry parameters
-with kbench.enable_cache():
-    runs = evaluate_sample.evaluate(
+# 2. Run with failure tolerance + caching + retries
+with kbench.client.enable_cache():
+    results = evaluate_sample.evaluate(
         llm=[kbench.llm],
         evaluation_data=df,
-        max_attempts=3,  # Retry failed samples up to 3 times within this run
-        retry_delay=5,  # Wait 5 seconds between retries
-        remove_run_files=False,  # Keep per-sample files for safety
+        on_failure="continue",  # collect failures instead of raising
+        max_attempts=3,         # retry transient failures up to twice
+        retry_delay=5,          # wait 5 seconds between attempts
     )
 
-# 3. Calculate aggregate score
-accuracy = runs.as_dataframe()["result"].mean()
+# 3. Inspect what completed and what didn't
+print(f"Completed: {len(results.completed_runs)} / {len(results)}")
+print(f"Errored:   {len(results.errored_runs)}")
+for run in results.errored_runs:
+    print(f"  {run.params}: {run.error_message[:200]}")
+
+# 4. Aggregate over successful runs ONLY.
+# Important: failed runs have run.result == results.FAILED (a sentinel).
+# Aggregating over the full Runs would raise TypeError on .mean() / .sum().
+# Always filter to .completed_runs before numeric aggregation.
+accuracy = results.completed_runs.as_dataframe()["result"].mean()
 print(f"Final Accuracy: {accuracy:.4f}")
 ```
+
+**How the retry mechanic works.** On attempt 1, every sample runs. Successful samples write a `.run.json` to disk with `state=COMPLETED`; failed samples write one with `state=ERRORED`. On attempt 2, the cache check skips `COMPLETED` files (no re-run) but treats `ERRORED` files as cache misses (re-run). So credits and wall time are only spent on the samples that actually need to be retried. Results from all attempts merge into one `Runs` object in evaluation-data row order.
+
+**Without `on_failure="continue"`.** A single per-sample failure causes `evaluate()` to raise a `RuntimeError` summarizing the failure count, with a hint pointing back at the `on_failure="continue"` option. This is the default because silent failures are worse than loud ones — but for production-scale runs you almost always want the opt-in.
 
 ### Recipe: Comparing Multiple Models Side-by-Side
 

--- a/documentation/examples/dataset_evaluation.py
+++ b/documentation/examples/dataset_evaluation.py
@@ -95,4 +95,39 @@ with kbench.client.enable_cache():
 
 eval_df = runs.as_dataframe()
 eval_df
+
+# %%
+# Resilient evaluation pattern for large/flaky datasets.
+#
+# For production-scale evals where transient per-sample failures (API
+# timeouts, rate limits, 5xx) are expected, pair `on_failure="continue"`
+# with `max_attempts > 1` and `enable_cache()`. Behavior:
+#   - Successful samples persist to disk (state=COMPLETED).
+#   - Failed samples persist to disk (state=ERRORED).
+#   - Retries skip cached successes and re-run only the errored samples.
+#   - Results from all attempts merge into one Runs in row order.
+with kbench.client.enable_cache():
+    results = single_qa_task.evaluate(
+        llm=[kbench.llm],
+        evaluation_data=df,
+        on_failure="continue",  # collect failures instead of raising
+        max_attempts=3,  # retry transient failures up to twice
+        retry_delay=5,
+        n_jobs=2,
+        timeout=120,
+    )
+
+# Split the merged result by status.
+print(f"Completed: {len(results.completed_runs)} / {len(results)}")
+print(f"Errored:   {len(results.errored_runs)}")
+for run in results.errored_runs:
+    print(f"  {run.params}: {run.error_message[:200]}")
+
+# Aggregate over completed runs ONLY. Failed runs carry the
+# `results.FAILED` sentinel which would break .mean() / .sum().
+completed_df = results.completed_runs.as_dataframe()
+if len(completed_df) > 0:
+    accuracy = float(completed_df.result.str.get("is_correct").mean())
+    print(f"Accuracy over completed samples: {accuracy:.4f}")
+
 # %%

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -55,7 +55,6 @@ from kaggle_benchmarks.content_types import (
 
 # Models to be tested as the primary subject.
 TEST_LLM_NAMES = {
-    "google/gemini-2.0-flash",
     "google/gemini-2.5-flash",
     "google/gemini-2.5-pro",
     "google/gemini-3-flash-preview",
@@ -78,7 +77,6 @@ JUDGE_LLM_NAMES = {
 
 # Models that support audio input.
 AUDIO_LLM_NAMES = {
-    "google/gemini-2.0-flash",
     "google/gemini-2.5-flash",
     "google/gemini-2.5-pro",
     "google/gemini-3-flash-preview",
@@ -391,41 +389,40 @@ def test_dataset_eval(llm, df) -> tuple[float, float]:
 
 
 # %%
-# --- Test Case: Dataset evaluation with failure tolerance (production pattern) ---
-# Demonstrates the recommended call shape for large evals where transient
-# per-sample failures (timeouts, 5xx, network blips) are expected. Pair
-# on_failure="continue" with max_attempts > 1 and enable_cache() so that:
-#   - failed samples are retried on subsequent attempts
-#   - successful samples are skipped (cache hit) on retry
-#   - results from all attempts are merged into one Runs object
+# --- Test Case: Dataset evaluation with intentional failure ---
+# Exercises the on_failure="continue" path with an actual failure: one sample
+# raises after the LLM call. Verifies that completed_runs and errored_runs
+# split correctly end-to-end with real API calls.
 
 
-def assert_resilient_qa_result(run):
+def assert_resilient_with_failure_result(run):
     completed, errored = run.result
-    # All 2 simple QA samples should complete on the first attempt.
-    assert completed == 2
-    assert errored == 0
+    # One of two samples intentionally fails → 1 completed, 1 errored.
+    assert completed == 1
+    assert errored == 1
 
 
 @benchmark_test(
     df=df,
-    verify_fn=assert_resilient_qa_result,
+    verify_fn=assert_resilient_with_failure_result,
 )
 @kbench.task()
-def test_dataset_eval_resilient(llm, df) -> tuple[int, int]:
-    with kbench.client.enable_cache():
-        results = single_qa_task.evaluate(
-            llm=[llm],
-            evaluation_data=df,
-            n_jobs=2,
-            on_failure="continue",  # collect failures instead of raising
-            max_attempts=3,  # retry transient failures up to twice
-            remove_run_files=True,
-        )
+def test_dataset_eval_with_failure(llm, df) -> tuple[int, int]:
+    @kbench.task(name="qa_with_failure", store_task=False)
+    def qa_with_failure(llm, question, answer) -> dict:
+        response = llm.prompt(question)
+        # Intentionally fail the first sample to exercise the failure path.
+        if "Singapore" in answer:
+            raise ValueError(f"Intentional failure for sample: {answer}")
+        return {"question": question, "predicted_answer": response}
 
-    # Split results: completed vs errored. Always filter to .completed_runs
-    # before aggregating numeric columns — .result for errored runs is the
-    # `results.FAILED` sentinel, which would break .mean() / .sum() / etc.
+    results = qa_with_failure.evaluate(
+        llm=[llm],
+        evaluation_data=df,
+        n_jobs=1,
+        on_failure="continue",
+    )
+
     return len(results.completed_runs), len(results.errored_runs)
 
 
@@ -633,7 +630,7 @@ def test_audio_url(llm):
 # support it (not all models return traces).
 
 
-# Known failures: gemini-2.0-flash, gemma-4-31b — do not support reasoning.
+# Known failures: gemma-4-31b — does not support reasoning.
 @benchmark_test()
 @kbench.task()
 def test_reasoning_param(llm):
@@ -952,7 +949,7 @@ def get_user_profile(user_id: str) -> dict:
     return {"name": "Unknown", "role": "User", "skills": []}
 
 
-# Known failures: gemini-2.0-flash returns incorrect role on both APIs.
+# Known failures: (none currently).
 @benchmark_test(
     exclude={
         "deepseek-ai/deepseek-r1-0528",

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -391,6 +391,45 @@ def test_dataset_eval(llm, df) -> tuple[float, float]:
 
 
 # %%
+# --- Test Case: Dataset evaluation with failure tolerance (production pattern) ---
+# Demonstrates the recommended call shape for large evals where transient
+# per-sample failures (timeouts, 5xx, network blips) are expected. Pair
+# on_failure="continue" with max_attempts > 1 and enable_cache() so that:
+#   - failed samples are retried on subsequent attempts
+#   - successful samples are skipped (cache hit) on retry
+#   - results from all attempts are merged into one Runs object
+
+
+def assert_resilient_qa_result(run):
+    completed, errored = run.result
+    # All 2 simple QA samples should complete on the first attempt.
+    assert completed == 2
+    assert errored == 0
+
+
+@benchmark_test(
+    df=df,
+    verify_fn=assert_resilient_qa_result,
+)
+@kbench.task()
+def test_dataset_eval_resilient(llm, df) -> tuple[int, int]:
+    with kbench.client.enable_cache():
+        results = single_qa_task.evaluate(
+            llm=[llm],
+            evaluation_data=df,
+            n_jobs=2,
+            on_failure="continue",  # collect failures instead of raising
+            max_attempts=3,  # retry transient failures up to twice
+            remove_run_files=True,
+        )
+
+    # Split results: completed vs errored. Always filter to .completed_runs
+    # before aggregating numeric columns — .result for errored runs is the
+    # `results.FAILED` sentinel, which would break .mean() / .sum() / etc.
+    return len(results.completed_runs), len(results.errored_runs)
+
+
+# %%
 # --- Test Case: Image inputs (URL) ---
 
 

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -176,10 +176,15 @@ def assess_with_judge_task(llm, judge_llm) -> None:
 
 
 # We fix the test LLM to one reliable model to focus on testing the judges.
-@pytest.mark.parametrize("llm_name", ["google/gemini-2.5-flash"])
+@pytest.mark.parametrize(
+    "llm, api",
+    [
+        pytest.param(kbench.kaggle.load_model("google/gemini-2.5-flash", api="genai"), "genai", id="genai-google/gemini-2.5-flash"),
+        pytest.param(kbench.kaggle.load_model("google/gemini-2.5-flash", api="openai"), "openai", id="openai-google/gemini-2.5-flash"),
+    ]
+)
 @pytest.mark.parametrize("judge_llm_name", JUDGE_LLM_NAMES)
-def test_assess_with_judge(llm_name, judge_llm_name):
-    llm = kbench.kaggle.load_model(llm_name)
+def test_assess_with_judge(llm, api, judge_llm_name):
     judge_llm = kbench.kaggle.load_model(judge_llm_name)
     run = assess_with_judge_task.run(llm, judge_llm)
     assert run.passed
@@ -422,9 +427,14 @@ def dataset_eval_with_failure(llm, df) -> tuple[int, int]:
     return len(results.completed_runs), len(results.errored_runs)
 
 
-@pytest.mark.parametrize("llm_name", ["google/gemini-2.5-flash"])
-def test_dataset_eval_with_failure_run(llm_name):
-    llm = kbench.kaggle.load_model(llm_name)
+@pytest.mark.parametrize(
+    "llm, api",
+    [
+        pytest.param(kbench.kaggle.load_model("google/gemini-2.5-flash", api="genai"), "genai", id="genai-google/gemini-2.5-flash"),
+        pytest.param(kbench.kaggle.load_model("google/gemini-2.5-flash", api="openai"), "openai", id="openai-google/gemini-2.5-flash"),
+    ]
+)
+def test_dataset_eval_with_failure_run(llm, api):
     run = dataset_eval_with_failure.run(llm, df=df)
     assert run.status == kbench.utils.Status.SUCCESS
     assert_resilient_with_failure_result(run)

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -402,12 +402,8 @@ def assert_resilient_with_failure_result(run):
     assert errored == 1
 
 
-@benchmark_test(
-    df=df,
-    verify_fn=assert_resilient_with_failure_result,
-)
 @kbench.task()
-def test_dataset_eval_with_failure(llm, df) -> tuple[int, int]:
+def dataset_eval_with_failure(llm, df) -> tuple[int, int]:
     @kbench.task(name="qa_with_failure", store_task=False)
     def qa_with_failure(llm, question, answer) -> dict:
         response = llm.prompt(question)
@@ -424,6 +420,14 @@ def test_dataset_eval_with_failure(llm, df) -> tuple[int, int]:
     )
 
     return len(results.completed_runs), len(results.errored_runs)
+
+
+@pytest.mark.parametrize("llm_name", ["google/gemini-2.5-flash"])
+def test_dataset_eval_with_failure_run(llm_name):
+    llm = kbench.kaggle.load_model(llm_name)
+    run = dataset_eval_with_failure.run(llm, df=df)
+    assert run.status == kbench.utils.Status.SUCCESS
+    assert_resilient_with_failure_result(run)
 
 
 # %%

--- a/golden_tests/test_cookbook_examples_report.yaml
+++ b/golden_tests/test_cookbook_examples_report.yaml
@@ -64,24 +64,25 @@ genai://deepseek-ai/deepseek-v3.2:
   config:
     structured_output: false
   tests:
-    test_complex_tool_return: passed
-    test_dataset_eval: passed
-    test_extract_bool: passed
-    test_extract_composite_pydantic: passed
-    test_extract_dataclass: passed
-    test_extract_dict: passed
-    test_extract_int: passed
-    test_extract_pydantic: passed
-    test_multi_step_tool_chain: passed
-    test_multiple_tool_selection: passed
-    test_reasoning_param: passed
-    test_simple_tool_use: passed
-    test_stateful_tool_double_execution: passed
-    test_tool_error_handling: passed
+    test_complex_tool_return: failed
+    test_dataset_eval: failed
+    test_extract_bool: failed
+    test_extract_composite_pydantic: failed
+    test_extract_dataclass: failed
+    test_extract_dict: failed
+    test_extract_int: failed
+    test_extract_pydantic: failed
+    test_multi_step_tool_chain: failed
+    test_multiple_tool_selection: failed
+    test_reasoning_param: failed
+    test_simple_tool_use: failed
+    test_stateful_tool_double_execution: failed
+    test_tool_error_handling: failed
 genai://google/gemini-2.5-flash:
   config:
     structured_output: true
   tests:
+    test_assess_with_judge: passed
     test_audio_base64: passed
     test_audio_local_file: passed
     test_audio_url: passed
@@ -93,6 +94,7 @@ genai://google/gemini-2.5-flash:
     test_chatroom_talk_structured_output: passed
     test_complex_tool_return: passed
     test_dataset_eval: passed
+    test_dataset_eval_with_failure_run: passed
     test_extract_bool: passed
     test_extract_composite_pydantic: passed
     test_extract_dataclass: passed
@@ -346,24 +348,25 @@ openai://deepseek-ai/deepseek-v3.2:
   config:
     structured_output: false
   tests:
-    test_complex_tool_return: passed
-    test_dataset_eval: passed
-    test_extract_bool: passed
-    test_extract_composite_pydantic: passed
-    test_extract_dataclass: passed
-    test_extract_dict: passed
-    test_extract_int: passed
-    test_extract_pydantic: passed
-    test_multi_step_tool_chain: passed
-    test_multiple_tool_selection: passed
-    test_reasoning_param: passed
-    test_simple_tool_use: passed
-    test_stateful_tool_double_execution: passed
-    test_tool_error_handling: passed
+    test_complex_tool_return: failed
+    test_dataset_eval: failed
+    test_extract_bool: failed
+    test_extract_composite_pydantic: failed
+    test_extract_dataclass: failed
+    test_extract_dict: failed
+    test_extract_int: failed
+    test_extract_pydantic: failed
+    test_multi_step_tool_chain: failed
+    test_multiple_tool_selection: failed
+    test_reasoning_param: failed
+    test_simple_tool_use: failed
+    test_stateful_tool_double_execution: failed
+    test_tool_error_handling: failed
 openai://google/gemini-2.5-flash:
   config:
     structured_output: true
   tests:
+    test_assess_with_judge: passed
     test_audio_base64: passed
     test_audio_local_file: passed
     test_audio_url: passed
@@ -375,6 +378,7 @@ openai://google/gemini-2.5-flash:
     test_chatroom_talk_structured_output: passed
     test_complex_tool_return: passed
     test_dataset_eval: passed
+    test_dataset_eval_with_failure_run: passed
     test_extract_bool: passed
     test_extract_composite_pydantic: passed
     test_extract_dataclass: passed
@@ -435,7 +439,7 @@ openai://google/gemini-3-flash-preview:
     test_chatroom_talk_structured_output: passed
     test_complex_tool_return: passed
     test_dataset_eval: passed
-    test_extra_api_params_max_tokens_openai: passed
+    test_extra_api_params_max_tokens_openai: failed
     test_extract_bool: passed
     test_extract_composite_pydantic: passed
     test_extract_dataclass: passed

--- a/golden_tests/test_cookbook_examples_report.yaml
+++ b/golden_tests/test_cookbook_examples_report.yaml
@@ -78,31 +78,6 @@ genai://deepseek-ai/deepseek-v3.2:
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: passed
     test_tool_error_handling: passed
-genai://google/gemini-2.0-flash:
-  config:
-    structured_output: true
-  tests:
-    test_audio_base64: passed
-    test_audio_local_file: passed
-    test_audio_url: passed
-    test_complex_tool_return: failed
-    test_dataset_eval: passed
-    test_extract_bool: passed
-    test_extract_composite_pydantic: passed
-    test_extract_dataclass: passed
-    test_extract_dict: passed
-    test_extract_int: passed
-    test_extract_pydantic: passed
-    test_image_base64: passed
-    test_image_local_file: passed
-    test_image_url: passed
-    test_multi_step_tool_chain: passed
-    test_multiple_tool_selection: passed
-    test_reasoning_param: failed
-    test_simple_tool_use: passed
-    test_stateful_tool_double_execution: passed
-    test_tool_error_handling: passed
-    test_tool_with_schema_output: passed
 genai://google/gemini-2.5-flash:
   config:
     structured_output: true
@@ -161,7 +136,7 @@ genai://google/gemini-2.5-pro:
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: passed
     test_tool_error_handling: passed
-    test_tool_with_schema_output: passed
+    test_tool_with_schema_output: failed
     test_video_url: passed
 genai://google/gemini-3-flash-preview:
   config:
@@ -385,31 +360,6 @@ openai://deepseek-ai/deepseek-v3.2:
     test_simple_tool_use: passed
     test_stateful_tool_double_execution: passed
     test_tool_error_handling: passed
-openai://google/gemini-2.0-flash:
-  config:
-    structured_output: true
-  tests:
-    test_audio_base64: passed
-    test_audio_local_file: passed
-    test_audio_url: passed
-    test_complex_tool_return: failed
-    test_dataset_eval: passed
-    test_extract_bool: passed
-    test_extract_composite_pydantic: passed
-    test_extract_dataclass: passed
-    test_extract_dict: passed
-    test_extract_int: passed
-    test_extract_pydantic: passed
-    test_image_base64: passed
-    test_image_local_file: passed
-    test_image_url: passed
-    test_multi_step_tool_chain: failed
-    test_multiple_tool_selection: failed
-    test_reasoning_param: failed
-    test_simple_tool_use: passed
-    test_stateful_tool_double_execution: passed
-    test_tool_error_handling: passed
-    test_tool_with_schema_output: passed
 openai://google/gemini-2.5-flash:
   config:
     structured_output: true

--- a/quick_start.md
+++ b/quick_start.md
@@ -440,6 +440,14 @@ visual indicator of how many tasks have been completed. It returns a
 `Runs` object, which is a list of individual `Run` objects for each row
 in your dataset.
 
+By default, `.evaluate()` raises if any sample fails — the right
+behavior for development. For large datasets where transient failures
+(API timeouts, rate limits) are expected, pass `on_failure="continue"`
+to collect failures into `results.errored_runs` instead of raising, and
+pair with `max_attempts > 1` and `enable_cache()` to retry only the
+failed samples. See the cookbook recipe "Best Practices for Large
+Datasets" for the full pattern.
+
 For large datasets, the detailed evaluation of individual items can be
 verbose and slow. To dramatically speed up the process and remove this
 detail, simply set the environment variable:

--- a/skill_tests/agent_test_scenarios.md
+++ b/skill_tests/agent_test_scenarios.md
@@ -423,6 +423,61 @@ These map directly to golden test patterns in `golden_tests/test_cookbook_exampl
 
 ---
 
+### Scenario 4.6 — Failure-Tolerant Evaluation (`on_failure="continue"`)
+
+**Prompt:**
+> I'm running a 500-sample benchmark against a third-party API. A few samples fail every run because of API timeouts and 5xx errors. By default `.evaluate()` raises on the first failure and I lose all the work. How do I make it collect failures into the results instead of raising?
+
+**Expected Answer:**
+- [ ] Recommends `on_failure="continue"` parameter on `.evaluate()`
+- [ ] Explains the default is `"raise"` (which is why the eval aborts today)
+- [ ] Explains failed runs are returned in the `Runs` object with `status=FAILED`
+- [ ] Shows splitting via `results.completed_runs` and `results.errored_runs`
+- [ ] Warns that aggregating over the full `Runs` (e.g., `.as_dataframe().result.mean()`) will break because failed runs carry the `results.FAILED` sentinel — must aggregate over `results.completed_runs` only
+- [ ] Mentions inspecting `run.error_message` on errored runs for debugging
+
+**Source of Truth:** `SKILL.md` §3 "Failure Handling: `on_failure='raise'` vs `'continue'`"; `golden_tests/test_cookbook_examples.py` `test_dataset_eval_resilient`; `tests/test_benchmarks.py` `test_runs_completed_and_errored_partition`
+
+---
+
+### Scenario 4.7 — Resilient Production Pattern (Cache + Retry + Continue)
+
+**Prompt:**
+> Write a complete benchmark task for a 500-sample evaluation against a flaky API. The eval should: (1) collect failures rather than raising, (2) automatically retry failed samples up to 3 times (without re-running samples that already succeeded), (3) merge results from all attempts, (4) return accuracy as a float computed over only the samples that completed.
+
+**Expected Answer:**
+- [ ] Defines a per-sample sub-task with `store_task=False`
+- [ ] Main task wraps `.evaluate()` in `with kbench.client.enable_cache():`
+- [ ] Passes `on_failure="continue"` to `.evaluate()`
+- [ ] Passes `max_attempts=3` (or similar > 1) to `.evaluate()`
+- [ ] May also pass `retry_delay=` for backoff between attempts
+- [ ] Uses `results.completed_runs.as_dataframe()` (NOT `results.as_dataframe()`) for accuracy aggregation
+- [ ] Optionally reports `len(results.errored_runs)` for visibility
+- [ ] Returns `-> float` (or `-> dict` with accuracy + error stats)
+- [ ] Does NOT manually loop and call `.run()` per sample — uses `.evaluate()`
+- [ ] Does NOT try to catch exceptions inside the task body (that would poison the cache with bogus successes)
+
+**Source of Truth:** `SKILL.md` §3 "Resilient Pattern for Large Datasets" + §9 Pattern H.5; `cookbook.md` "Recipe: Best Practices for Large Datasets"; `documentation/examples/dataset_evaluation.py`
+
+---
+
+### Scenario 4.8 — Default `on_failure` Behavior
+
+**Prompt:**
+> What's the default value of `on_failure` on `.evaluate()`? What happens when I don't pass it and one of my samples raises?
+
+**Expected Answer:**
+- [ ] Says the default is `"raise"`
+- [ ] In dev mode: the first per-sample exception aborts the eval immediately (joblib worker raises, propagates out)
+- [ ] In Kaggle batch mode: all parallel workers finish, then `evaluate()` raises a `RuntimeError` summarizing the failures (NOT silent partial results)
+- [ ] The `RuntimeError` message includes a hint pointing at `on_failure="continue"` and the `max_attempts` + `enable_cache()` pattern
+- [ ] Says `"raise"` is the right default because silent failures are worse than loud ones
+- [ ] Does NOT claim the default is `"continue"` or that batch mode silently drops failures (that was old behavior, fixed in v0.7.0)
+
+**Source of Truth:** `SKILL.md` §3 "Failure Handling" table; `src/kaggle_benchmarks/tasks.py` `evaluate()` `on_failure` parameter default; `docs/large_eval_rerun/detailed_design.md` §1
+
+---
+
 ## Category 5: Medium — Combining Basics
 
 ### Scenario 5.1 — Structured Output + Judge Evaluation
@@ -1194,6 +1249,9 @@ These scenarios validate the agent's understanding of the `ChatRoom` / `Particip
 | 4.3 | Eval with full params | Dataset Eval | Medium | |
 | 4.4 | Multi-model comparison | Dataset Eval | Medium | |
 | 4.5 | Math word problems | Dataset Eval | Medium | |
+| 4.6 | on_failure="continue" | Dataset Eval | Medium | |
+| 4.7 | Resilient prod pattern | Dataset Eval | Advanced | |
+| 4.8 | Default on_failure behavior | Dataset Eval / Knowledge | Basic | |
 | 5.1 | Structured + judge | Combined | Medium | |
 | 5.2 | Hallucination detect | Combined | Medium | |
 | 5.3 | System + struct + code | Combined | Medium | |

--- a/skills/kaggle-benchmarks/SKILL.md
+++ b/skills/kaggle-benchmarks/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: kaggle-benchmarks
-version: 0.5.0
-description: Write benchmark tasks to evaluate LLMs using the kaggle_benchmarks Python library. Covers task decorators, structured outputs, assertions, tools, dataset evaluation, and multi-turn conversations.
+version: 0.7.0
+description: Write benchmark tasks to evaluate LLMs using the kaggle_benchmarks Python library. Covers task decorators, structured outputs, assertions, tools, dataset evaluation (including failure-tolerant retry patterns for large datasets), and multi-turn conversations.
 ---
 
 # Skill: Writing Kaggle Benchmarks Tasks
 
-> This skill file teaches you how to write high-quality benchmark tasks using the `kaggle-benchmarks` Python library (version 0.5.0+).
+> This skill file teaches you how to write high-quality benchmark tasks using the `kaggle-benchmarks` Python library (version 0.7.0+).
 > Always verify patterns against the actual source code in `src/kaggle_benchmarks/` when in doubt.
 
 ## Quick Reference
@@ -105,6 +105,8 @@ math_benchmark.run(kbench.llm)
 | Using `store_task=True` for sub-tasks | Set `store_task=False` for helper tasks called inside other tasks |
 | Using `!pip install` without commenting | Use `# !pip install -q pkg` — uncommented magics break local execution |
 | Forgetting `last_reasoning_traces()` can be `None` | Always check: `traces = kbench.last_reasoning_traces(); if traces: ...` |
+| Aggregating over all runs after `on_failure="continue"` | Filter first: `results.completed_runs.as_dataframe().result.mean()` — failed runs carry the `results.FAILED` sentinel which breaks `.mean()` / `.sum()` |
+| Using `max_attempts > 1` without `on_failure="continue"` | The default `"raise"` aborts on first failure, so retries never happen. Pair `max_attempts > 1` with `on_failure="continue"` and `enable_cache()` for selective retry. |
 
 ---
 
@@ -315,6 +317,7 @@ results = my_task.evaluate(
     timeout=120,                          # Per-job timeout in seconds
     max_attempts=3,                       # Retry count
     retry_delay=15,                       # Seconds between retries
+    on_failure="raise",                   # "raise" (default) or "continue"
     stop_condition=lambda runs: len(runs) == df.shape[0],  # Early stop
     remove_run_files=True,                # Clean up after
 )
@@ -324,6 +327,56 @@ results.as_dataframe()
 ```
 
 > **Note:** Any extra keyword arguments (beyond `llm`, `evaluation_data`, etc.) are forwarded to the task function. For example, if your task has a `critic` parameter, pass `critic=[critic_llm]` to `.evaluate()`.
+
+### Failure Handling: `on_failure="raise"` vs `"continue"`
+
+`.evaluate()` has two modes for handling per-sample failures (a task body raising an exception, e.g., from an API timeout):
+
+| Mode | Behavior | When to use |
+|---|---|---|
+| `"raise"` (default) | First per-sample failure aborts the eval. Dev: raises immediately. Kaggle batch: waits for all parallel workers, then raises a summary. | Default — strict, loud, the right choice for development and tests that should never have failures. |
+| `"continue"` | Failed runs are caught, recorded with `status=FAILED`, and included in the returned `Runs`. The eval keeps going. | Production-scale evals where transient failures (timeouts, rate limits) are expected. |
+
+When `on_failure="continue"` returns a mixed `Runs`, split it with the two properties:
+
+```python
+results = my_task.evaluate(..., on_failure="continue")
+
+print(f"Completed: {len(results.completed_runs)}")  # status=SUCCESS
+print(f"Errored:   {len(results.errored_runs)}")    # status=FAILED
+
+# Inspect failures for debugging
+for run in results.errored_runs:
+    print(f"{run.params}: {run.error_message[:200]}")
+
+# CRITICAL: always aggregate over completed_runs ONLY.
+# Failed runs carry the `results.FAILED` sentinel which breaks .mean() / .sum().
+accuracy = results.completed_runs.as_dataframe().result.mean()
+```
+
+### Resilient Pattern for Large Datasets
+
+The production pattern combines three features so that transient failures don't lose work:
+
+```python
+import kaggle_benchmarks as kbench
+
+with kbench.client.enable_cache():
+    results = my_task.evaluate(
+        llm=[kbench.llm],
+        evaluation_data=df,         # e.g. 500 samples
+        n_jobs=20,
+        on_failure="continue",      # collect failures instead of raising
+        max_attempts=3,             # retry transient failures up to twice
+        retry_delay=30,
+    )
+```
+
+How it works:
+- **Attempt 1** runs every sample. Successes persist to disk as `state=COMPLETED`; failures persist as `state=ERRORED`.
+- **Attempt 2** re-runs everything via `Task.run()`. The cache check skips `COMPLETED` files (no re-run) but re-runs `ERRORED` ones. So only the failed samples actually re-execute.
+- **Results merge** across attempts by positional index — attempt 2's successes overwrite attempt 1's failures at the same slot. Output order matches `evaluation_data` row order.
+- **Early exit** when no failed runs remain (stops the loop before exhausting `max_attempts`).
 
 ### Multi-Model Comparison
 
@@ -1200,6 +1253,8 @@ judge_poem.run(kbench.llm, question="Write a haiku about clouds.")
 
 ### Pattern H: Dataset Evaluation with Parallel Execution
 
+The basic shape — for small datasets where any failure should abort.
+
 ```python
 import pandas as pd
 
@@ -1219,6 +1274,50 @@ runs = riddle_solver.evaluate(
     llm=[kbench.llm], evaluation_data=df, n_jobs=3
 )
 runs.as_dataframe()
+```
+
+### Pattern H.5: Resilient Dataset Evaluation (Production)
+
+For large datasets (500+ samples) where transient API failures are expected. Combines `on_failure="continue"` for visibility, `max_attempts` for selective retry, and `enable_cache()` for skipping work that already succeeded.
+
+```python
+import pandas as pd
+
+@kbench.task(name="per_sample_qa", store_task=False)
+def per_sample_qa(llm, question: str, answer: str) -> dict:
+    response = llm.prompt(question)
+    return {"is_correct": answer.lower() in response.lower()}
+
+
+@kbench.task(name="resilient_qa_benchmark")
+def resilient_qa_benchmark(llm, df) -> dict:
+    with kbench.client.enable_cache():
+        results = per_sample_qa.evaluate(
+            llm=[llm],
+            evaluation_data=df,
+            n_jobs=20,
+            on_failure="continue",   # collect failures into results.errored_runs
+            max_attempts=3,          # retry transient failures up to twice
+            retry_delay=30,
+        )
+
+    # Split successes from failures.
+    completed = results.completed_runs
+    errored = results.errored_runs
+
+    # IMPORTANT: aggregate over completed_runs only — results.FAILED breaks .mean()
+    accuracy = float(completed.as_dataframe().result.str.get("is_correct").mean())
+
+    return {
+        "accuracy": accuracy,
+        "completed": len(completed),
+        "errored": len(errored),
+        "total": len(results),
+        "failed_samples": [r.params for r in errored],  # for debugging
+    }
+
+
+# resilient_qa_benchmark.run(kbench.llm, df)
 ```
 
 ### Pattern I.5: Multi-Agent ChatRoom (Debate)

--- a/skills/kaggle-benchmarks/SKILL.md
+++ b/skills/kaggle-benchmarks/SKILL.md
@@ -330,12 +330,12 @@ results.as_dataframe()
 
 ### Failure Handling: `on_failure="raise"` vs `"continue"`
 
-`.evaluate()` has two modes for handling per-sample failures (a task body raising an exception, e.g., from an API timeout):
+`.evaluate()` has one knob for per-sample failures:
 
-| Mode | Behavior | When to use |
-|---|---|---|
-| `"raise"` (default) | First per-sample failure aborts the eval. Dev: raises immediately. Kaggle batch: waits for all parallel workers, then raises a summary. | Default — strict, loud, the right choice for development and tests that should never have failures. |
-| `"continue"` | Failed runs are caught, recorded with `status=FAILED`, and included in the returned `Runs`. The eval keeps going. | Production-scale evals where transient failures (timeouts, rate limits) are expected. |
+- **`on_failure="raise"`** (default) — if any sample fails, `.evaluate()` raises. Use for development, CI, and small evals; you want failures to be loud.
+- **`on_failure="continue"`** — failed samples land in `results.errored_runs` and the eval keeps going. Use for large/flaky production evals, typically paired with `max_attempts > 1` and `enable_cache()` for selective retry.
+
+> **Note (Kaggle batch):** In `"raise"` mode, the Kaggle batch runner waits for all parallel workers to finish, then raises a single `RuntimeError` summarizing all failures — so you still get a hard failure, just at the end rather than on the first error. The exception type differs (`RuntimeError` summary vs. the original `ValueError`/`TimeoutError` in dev), but `try/except Exception` catches both.
 
 When `on_failure="continue"` returns a mixed `Runs`, split it with the two properties:
 

--- a/src/kaggle_benchmarks/kaggle/client.py
+++ b/src/kaggle_benchmarks/kaggle/client.py
@@ -114,10 +114,15 @@ class KaggleClient(clients.Client):
             case {"booleanResult": value}:
                 return value
 
-            case {"numericResult": {"value": value, "confidenceInterval": ci}}:
-                return (value, ci)
-
-            case {"numericResult": {"value": value}}:
+            # proto3 JSON drops default-valued fields, so a numeric result
+            # of 0.0 round-trips to `{}`, and (0.0, ci) to `{"confidenceInterval": ci}`.
+            # Extract by key with defaults instead of matching by shape.
+            # Known limitation: a tuple `(v, 0.0)` collapses to scalar `v`
+            # because zero CI is indistinguishable from "no CI" on disk.
+            case {"numericResult": nr}:
+                value = nr.get("value", 0.0)
+                if "confidenceInterval" in nr:
+                    return (value, nr["confidenceInterval"])
                 return value
 
             case {"dictResult": value}:

--- a/src/kaggle_benchmarks/runs.py
+++ b/src/kaggle_benchmarks/runs.py
@@ -125,16 +125,19 @@ class Run(Generic[T]):
 
     @property
     def passed(self):
-        # Short-circuit only for cached SUCCESS runs. A cached FAILED run
-        # (possible once Task.run() persists failures) should report False.
-        if self.cached and self.status == utils.Status.SUCCESS:
-            return True
-        # A run that hit a general exception in the task body is FAILED.
-        # Most result types' `passed(value)` returns True regardless of the
-        # value passed, so without this guard a failed run with no failing
-        # assertions would incorrectly report passed=True.
+        # Reject known-bad first: a run whose task body raised an exception.
+        # Without this guard, result_type.passed() would return True for most
+        # result types regardless of the value, masking the failure.
         if self.status == utils.Status.FAILED:
             return False
+        # TODO: cached runs always report passed=True here because
+        # _handle_cached_run restores self.result but not assertion_results
+        # or subruns. This is fine for dataset eval (the primary use case),
+        # where correctness lives in the result value, not assertions.
+        # To fix for assertion-heavy tasks: restore assertions + subruns
+        # from disk on cache load, then remove this short-circuit.
+        if self.cached:
+            return True
         return (
             self.task.result_type.passed(self.result)
             and all(result.passed for result in self.assertion_results)

--- a/src/kaggle_benchmarks/runs.py
+++ b/src/kaggle_benchmarks/runs.py
@@ -125,8 +125,16 @@ class Run(Generic[T]):
 
     @property
     def passed(self):
-        if self.cached:
+        # Short-circuit only for cached SUCCESS runs. A cached FAILED run
+        # (possible once Task.run() persists failures) should report False.
+        if self.cached and self.status == utils.Status.SUCCESS:
             return True
+        # A run that hit a general exception in the task body is FAILED.
+        # Most result types' `passed(value)` returns True regardless of the
+        # value passed, so without this guard a failed run with no failing
+        # assertions would incorrectly report passed=True.
+        if self.status == utils.Status.FAILED:
+            return False
         return (
             self.task.result_type.passed(self.result)
             and all(result.passed for result in self.assertion_results)
@@ -183,6 +191,26 @@ class Runs(Generic[T], abc.MutableSequence):
 
     def __len__(self):
         return len(self.runs)
+
+    @property
+    def completed_runs(self) -> "Runs[T]":
+        """Runs whose execution completed (status=SUCCESS).
+
+        Note: "completed" is not the same as "passed". A completed run
+        may still have failed assertions or scored 0. Use `run.passed`
+        to check that.
+        """
+        return Runs([r for r in self.runs if r.status == utils.Status.SUCCESS])
+
+    @property
+    def errored_runs(self) -> "Runs[T]":
+        """Runs that hit an infrastructure error (status=FAILED).
+
+        These appear when `evaluate(..., on_failure="continue")` is used.
+        They're the candidates that `max_attempts > 1` will retry on the
+        next attempt (with `enable_cache()` enabled).
+        """
+        return Runs([r for r in self.runs if r.status == utils.Status.FAILED])
 
     def as_dataframe(self) -> pd.DataFrame:
         return pd.DataFrame(

--- a/src/kaggle_benchmarks/tasks.py
+++ b/src/kaggle_benchmarks/tasks.py
@@ -248,7 +248,13 @@ class Task(Generic[T]):
                             If provided, the evaluation will stop when this
                             condition is met.
             max_attempts: The maximum number of evaluation attempts.
-                          Defaults to 1 (no retries).
+                          Defaults to 1 (no retries). When combined with
+                          `on_failure="continue"` and `enable_cache()`,
+                          subsequent attempts re-run only the previously
+                          failed samples (cached successes are skipped);
+                          results from all attempts are merged into the
+                          returned `Runs`. The loop also exits early when
+                          no failed runs remain.
                           Note: Nested task evaluations always run with
                           `max_attempts=1` regardless of the value passed;
                           a warning is logged if a different value is provided.
@@ -335,6 +341,20 @@ class Task(Generic[T]):
 
             return all_runs
 
+        # Accumulator across attempts, keyed by positional index within the
+        # attempt. Position is stable across attempts because joblib returns
+        # results in input order regardless of n_jobs or cache hits, and
+        # because the grid/evaluation_data don't change between attempts.
+        #
+        # We use position rather than run.cache_id because cache_id falls
+        # back to the per-run sequential `id` when param_id is None
+        # (no evaluation_data), which would generate a fresh key on every
+        # attempt and prevent the merge from ever overwriting.
+        #
+        # Python dicts preserve insertion order, and reassigning an existing
+        # key updates the value without moving its iteration position — so
+        # output order matches the original attempt-1 order.
+        runs_by_position: dict[int, "runs.Run[T]"] = {}
         all_runs = runs.Runs()
         attempt = 0
         try:
@@ -344,7 +364,7 @@ class Task(Generic[T]):
                     logging.info(f"Attempt {attempt}/{max_attempts}.")
 
                 try:
-                    all_runs = _evaluate_once()
+                    attempt_runs = _evaluate_once()
                 except Exception as e:
                     logging.warning(
                         f"An error occurred during evaluation attempt {attempt}: {e}"
@@ -352,6 +372,16 @@ class Task(Generic[T]):
                     # Always re-raise exception because the `continue_with_exceptions``
                     # setting should only apply to the subruns level.
                     raise e
+
+                # Merge: new successes append at their position; retried
+                # failures overwrite in place at the same position.
+                for position, run in enumerate(attempt_runs):
+                    runs_by_position[position] = run
+                all_runs = runs.Runs(list(runs_by_position.values()))
+
+                # Nothing failed — no point trying again.
+                if not any(r.status == utils.Status.FAILED for r in all_runs):
+                    break
 
                 if stop_condition and stop_condition(all_runs):
                     logging.info("Stop condition met.")

--- a/src/kaggle_benchmarks/tasks.py
+++ b/src/kaggle_benchmarks/tasks.py
@@ -281,7 +281,7 @@ class Task(Generic[T]):
         from kaggle_benchmarks.kaggle import serialization
 
         # Literal[] is a static hint only; validate at runtime so a typo
-        # like on_failure="contiune" fails loudly instead of silently
+        # like on_failure="continue" fails loudly instead of silently
         # falling through both branches.
         if on_failure not in ("raise", "continue"):
             raise ValueError(

--- a/src/kaggle_benchmarks/tasks.py
+++ b/src/kaggle_benchmarks/tasks.py
@@ -280,6 +280,14 @@ class Task(Generic[T]):
         from kaggle_benchmarks import contexts, orchestration, runs
         from kaggle_benchmarks.kaggle import serialization
 
+        # Literal[] is a static hint only; validate at runtime so a typo
+        # like on_failure="contiune" fails loudly instead of silently
+        # falling through both branches.
+        if on_failure not in ("raise", "continue"):
+            raise ValueError(
+                f"on_failure must be 'raise' or 'continue', got {on_failure!r}"
+            )
+
         ctx = contexts.get_current()
         if ctx.parent and ctx.parent.run and max_attempts > 1:
             logger.warning(

--- a/src/kaggle_benchmarks/tasks.py
+++ b/src/kaggle_benchmarks/tasks.py
@@ -102,8 +102,34 @@ class Task(Generic[T]):
                 logger.warning(f"Reading cached run failed: {e}")
         return None
 
+    def _finalize_and_persist(self, run: "runs.Run[T]", ctx) -> None:
+        """Stamp end_time, link to parent, and write the run file.
+
+        Called after `contexts.enter` has exited, so `run.status` is
+        already set to its final value (SUCCESS or FAILED) by
+        `contexts.enter`'s own finally block. Skipped for cached runs,
+        which are fully handled by `_handle_cached_run`.
+        """
+        from kaggle_benchmarks import client
+
+        if run.cached:
+            return
+
+        run.end_time = datetime.datetime.now(datetime.timezone.utc)
+
+        if ctx.parent and ctx.parent.run and run not in ctx.parent.run.subruns:
+            ctx.parent.run.subruns.append(run)
+
+        if self.store_run:
+            try:
+                client.store_run(run)
+            except Exception as store_exc:
+                # Persistence failure must not mask the original task
+                # outcome (success or failure).
+                logger.warning(f"Failed to store run {run.id}: {store_exc}")
+
     def run(self, *args, _id=None, **kwargs) -> "runs.Run[T]":
-        from kaggle_benchmarks import client, contexts, runs
+        from kaggle_benchmarks import contexts, runs
 
         # Internal flag set only by Task._evaluate_once() when
         # on_failure="continue". Popped from kwargs (not added to the public
@@ -132,70 +158,54 @@ class Task(Generic[T]):
                 cached_run = self._handle_cached_run(run, ctx)
                 if cached_run is not None:
                     # Cached path is fully handled by _handle_cached_run
-                    # (parent linkage included). Skip the finalize/persist
-                    # path entirely.
+                    # (parent linkage included). Early return skips both
+                    # the except/else clauses below.
                     return cached_run
 
-                try:
-                    run.start_time = datetime.datetime.now(datetime.timezone.utc)
+                run.start_time = datetime.datetime.now(datetime.timezone.utc)
 
-                    with chats.new(self.name, orphan=True) as chat:
-                        try:
-                            run.chat = chat
-                            events.manager.dispatch("run_update", run)
-                            run.result = self.func(*args, **kwargs)
-                            if not self.result_type.check_value(run.result):
-                                logger.warning(
-                                    f"Wrong return type {type(run.result)}. Expected {self.result_type._type}. This may need to lead to unexpected task behavior."
-                                )
-                        # Always make AssertionError non-blocking.
-                        # This allows users to write/track native Python asserts within a task.
-                        except AssertionError as e:
-                            run.handle_assertion_exception(e)
-                        # Let KeyboardInterrupt propagate to stop execution.
-                        except (NonRecoverableError, KeyboardInterrupt):
-                            raise
-                        # Handle all other exceptions.
-                        # Always re-raise — contexts.enter and the outer
-                        # except below decide whether to propagate further.
-                        except Exception as e:
-                            run.handle_general_exception(e)
-                finally:
-                    # Always finalize and persist, even on exception, so
-                    # failed runs are debuggable on disk and the retry loop
-                    # can overwrite them on success.
-                    run.end_time = datetime.datetime.now(datetime.timezone.utc)
-
-                    if (
-                        ctx.parent
-                        and ctx.parent.run
-                        and run not in ctx.parent.run.subruns
-                    ):
-                        ctx.parent.run.subruns.append(run)
-
-                    if self.store_run:
-                        try:
-                            client.store_run(run)
-                        except Exception as store_exc:
-                            # Persistence failure must not mask the original
-                            # task failure (if any).
-                            logger.warning(f"Failed to store run {run.id}: {store_exc}")
+                with chats.new(self.name, orphan=True) as chat:
+                    try:
+                        run.chat = chat
+                        events.manager.dispatch("run_update", run)
+                        run.result = self.func(*args, **kwargs)
+                        if not self.result_type.check_value(run.result):
+                            logger.warning(
+                                f"Wrong return type {type(run.result)}. Expected {self.result_type._type}. This may need to lead to unexpected task behavior."
+                            )
+                    # Always make AssertionError non-blocking.
+                    # This allows users to write/track native Python asserts within a task.
+                    except AssertionError as e:
+                        run.handle_assertion_exception(e)
+                    # Let KeyboardInterrupt propagate to stop execution.
+                    except (NonRecoverableError, KeyboardInterrupt):
+                        raise
+                    # Handle all other exceptions.
+                    # Always re-raise — the outer except below decides
+                    # whether to propagate further.
+                    except Exception as e:
+                        run.handle_general_exception(e)
         except (NonRecoverableError, KeyboardInterrupt):
-            # Ctrl-C and unrecoverable errors always propagate, even when
-            # the caller asked for suppression.
+            # Don't persist runs interrupted by Ctrl-C or unrecoverable
+            # errors. contexts.enter's KbdInt handler skips setting the
+            # FAILED status (see contexts.py:75-76), so a persisted run
+            # would end up with state=COMPLETED and pollute the cache.
             raise
         except Exception:
-            # By here, run.status=FAILED and run.error_message is populated
-            # (handle_general_exception did this inside the with-block).
-            # The finally already persisted the failed run.
+            # contexts.enter has exited and set run.status=FAILED. Persist
+            # the failed run for debugging and for the retry loop, then
+            # decide whether to propagate.
+            self._finalize_and_persist(run, ctx)
             if not _suppress_raise:
                 raise
+        else:
+            # No exception reached us: either the task body succeeded
+            # (status=SUCCESS) or contexts.enter swallowed a failure at
+            # root with continue_with_exceptions=True (status=FAILED).
+            # Either way, contexts.enter's finally has set the right
+            # status — persist now.
+            self._finalize_and_persist(run, ctx)
 
-        # Note: when continue_with_exceptions=True (Kaggle batch default),
-        # contexts.enter swallows the exception above and we return the
-        # failed Run here — matching today's behavior for direct callers.
-        # Task.evaluate() handles "raise on any FAILED" at the eval level
-        # so this method's contract stays stable for everyone else.
         return run
 
     def evaluate(

--- a/src/kaggle_benchmarks/tasks.py
+++ b/src/kaggle_benchmarks/tasks.py
@@ -186,24 +186,22 @@ class Task(Generic[T]):
                     except Exception as e:
                         run.handle_general_exception(e)
         except (NonRecoverableError, KeyboardInterrupt):
-            # Don't persist runs interrupted by Ctrl-C or unrecoverable
-            # errors. contexts.enter's KbdInt handler skips setting the
-            # FAILED status (see contexts.py:75-76), so a persisted run
-            # would end up with state=COMPLETED and pollute the cache.
+            # Fatal — propagate without persisting (prevents cache pollution).
             raise
         except Exception:
-            # contexts.enter has exited and set run.status=FAILED. Persist
-            # the failed run for debugging and for the retry loop, then
-            # decide whether to propagate.
+            # The exception escaped contexts.enter (which has already set
+            # run.status=FAILED). This happens in dev mode, or for nested
+            # runs in batch mode. Persist the failed run, then optionally
+            # suppress the exception (for on_failure="continue").
             self._finalize_and_persist(run, ctx)
             if not _suppress_raise:
                 raise
         else:
-            # No exception reached us: either the task body succeeded
-            # (status=SUCCESS) or contexts.enter swallowed a failure at
-            # root with continue_with_exceptions=True (status=FAILED).
-            # Either way, contexts.enter's finally has set the right
-            # status — persist now.
+            # No exception escaped contexts.enter. Two sub-cases:
+            #  (a) Task succeeded → status=SUCCESS
+            #  (b) Task failed but contexts.enter swallowed the exception
+            #      at root (batch mode, continue_with_exceptions) → status=FAILED
+            # Either way, persist with the final status.
             self._finalize_and_persist(run, ctx)
 
         return run
@@ -327,16 +325,20 @@ class Task(Generic[T]):
                 failures = [r for r in all_runs if r.status == utils.Status.FAILED]
                 if failures:
                     first = failures[0]
+                    summary = (
+                        f"1 of {len(all_runs)} runs failed."
+                        if len(failures) == 1
+                        else f"{len(failures)} of {len(all_runs)} runs failed."
+                    )
                     msg = (
                         f"Task {self.name!r} run {first.id} failed:\n"
-                        f"{first.error_message}"
+                        f"{first.error_message}\n\n"
+                        f"({summary} Pass on_failure='continue' to collect "
+                        "failures into results.errored_runs instead of "
+                        "raising. For large evals with transient errors, "
+                        "pair with max_attempts > 1 and enable_cache() to "
+                        "retry only the failed samples.)"
                     )
-                    if len(failures) > 1:
-                        msg += (
-                            f"\n\n({len(failures)} of {len(all_runs)} runs "
-                            "failed. Pass on_failure='continue' to collect "
-                            "failures instead of raising.)"
-                        )
                     raise RuntimeError(msg)
 
             return all_runs

--- a/src/kaggle_benchmarks/tasks.py
+++ b/src/kaggle_benchmarks/tasks.py
@@ -18,7 +18,16 @@ import functools
 import inspect
 import logging
 import time
-from typing import TYPE_CHECKING, Any, Callable, Generic, Iterable, Self, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Generic,
+    Iterable,
+    Literal,
+    Self,
+    TypeVar,
+)
 
 import pandas as pd
 
@@ -96,6 +105,11 @@ class Task(Generic[T]):
     def run(self, *args, _id=None, **kwargs) -> "runs.Run[T]":
         from kaggle_benchmarks import client, contexts, runs
 
+        # Internal flag set only by Task._evaluate_once() when
+        # on_failure="continue". Popped from kwargs (not added to the public
+        # signature) to keep it out of inspect.signature() and IDE autocomplete.
+        _suppress_raise = kwargs.pop("_suppress_raise", False)
+
         signature = inspect.signature(self.func)
         bound_args = signature.bind(*args, **kwargs)
         bound_args.apply_defaults()
@@ -113,42 +127,75 @@ class Task(Generic[T]):
             param_id=_id,
         )
 
-        with contexts.enter(run=run) as ctx:
-            cached_run = self._handle_cached_run(run, ctx)
-            if cached_run is not None:
-                return cached_run
+        try:
+            with contexts.enter(run=run) as ctx:
+                cached_run = self._handle_cached_run(run, ctx)
+                if cached_run is not None:
+                    # Cached path is fully handled by _handle_cached_run
+                    # (parent linkage included). Skip the finalize/persist
+                    # path entirely.
+                    return cached_run
 
-            run.start_time = datetime.datetime.now(datetime.timezone.utc)
-
-            with chats.new(self.name, orphan=True) as chat:
                 try:
-                    run.chat = chat
-                    events.manager.dispatch("run_update", run)
-                    run.result = self.func(*args, **kwargs)
-                    if not self.result_type.check_value(run.result):
-                        logger.warning(
-                            f"Wrong return type {type(run.result)}. Expected {self.result_type._type}. This may need to lead to unexpected task behavior."
-                        )
-                # Always make AssertionError non-blocking.
-                # This allows users to write/track native Python asserts within a task.
-                except AssertionError as e:
-                    run.handle_assertion_exception(e)
-                # Let KeyboardInterrupt propagate to stop execution.
-                except (NonRecoverableError, KeyboardInterrupt):
-                    raise
-                # Handle all other exceptions.
-                # Always re-raise the exception because it will be handled in contexts.enter.
-                except Exception as e:
-                    run.handle_general_exception(e)
+                    run.start_time = datetime.datetime.now(datetime.timezone.utc)
 
-        run.end_time = datetime.datetime.now(datetime.timezone.utc)
+                    with chats.new(self.name, orphan=True) as chat:
+                        try:
+                            run.chat = chat
+                            events.manager.dispatch("run_update", run)
+                            run.result = self.func(*args, **kwargs)
+                            if not self.result_type.check_value(run.result):
+                                logger.warning(
+                                    f"Wrong return type {type(run.result)}. Expected {self.result_type._type}. This may need to lead to unexpected task behavior."
+                                )
+                        # Always make AssertionError non-blocking.
+                        # This allows users to write/track native Python asserts within a task.
+                        except AssertionError as e:
+                            run.handle_assertion_exception(e)
+                        # Let KeyboardInterrupt propagate to stop execution.
+                        except (NonRecoverableError, KeyboardInterrupt):
+                            raise
+                        # Handle all other exceptions.
+                        # Always re-raise — contexts.enter and the outer
+                        # except below decide whether to propagate further.
+                        except Exception as e:
+                            run.handle_general_exception(e)
+                finally:
+                    # Always finalize and persist, even on exception, so
+                    # failed runs are debuggable on disk and the retry loop
+                    # can overwrite them on success.
+                    run.end_time = datetime.datetime.now(datetime.timezone.utc)
 
-        if ctx.parent and ctx.parent.run:
-            ctx.parent.run.subruns.append(run)
+                    if (
+                        ctx.parent
+                        and ctx.parent.run
+                        and run not in ctx.parent.run.subruns
+                    ):
+                        ctx.parent.run.subruns.append(run)
 
-        if self.store_run:
-            client.store_run(run)
+                    if self.store_run:
+                        try:
+                            client.store_run(run)
+                        except Exception as store_exc:
+                            # Persistence failure must not mask the original
+                            # task failure (if any).
+                            logger.warning(f"Failed to store run {run.id}: {store_exc}")
+        except (NonRecoverableError, KeyboardInterrupt):
+            # Ctrl-C and unrecoverable errors always propagate, even when
+            # the caller asked for suppression.
+            raise
+        except Exception:
+            # By here, run.status=FAILED and run.error_message is populated
+            # (handle_general_exception did this inside the with-block).
+            # The finally already persisted the failed run.
+            if not _suppress_raise:
+                raise
 
+        # Note: when continue_with_exceptions=True (Kaggle batch default),
+        # contexts.enter swallows the exception above and we return the
+        # failed Run here — matching today's behavior for direct callers.
+        # Task.evaluate() handles "raise on any FAILED" at the eval level
+        # so this method's contract stays stable for everyone else.
         return run
 
     def evaluate(
@@ -161,6 +208,7 @@ class Task(Generic[T]):
         max_attempts: int = 1,
         retry_delay: int = 1,
         remove_run_files: bool = False,
+        on_failure: Literal["raise", "continue"] = "raise",
         **kwargs: Iterable[Any],
     ) -> "runs.Runs[T]":
         """Evaluates the function over a grid of parameters, with optional retries.
@@ -196,11 +244,24 @@ class Task(Generic[T]):
                           a warning is logged if a different value is provided.
             retry_delay: The delay in seconds between retry attempts.
             remove_run_files: Remove generated run files when done.
+            on_failure: How to handle per-sample task failures.
+                - `"raise"` (default): if any sample fails, raise after the
+                  current attempt finishes. In dev mode (no
+                  `continue_with_exceptions`), a failure raises immediately
+                  via the joblib worker. In Kaggle batch mode, the eval
+                  finishes all parallel workers and then raises a summary —
+                  so you still get a hard failure instead of a silent drop.
+                - `"continue"`: catch per-sample failures, include the
+                  failed runs in the returned `Runs`, and keep going.
+                  Use `results.completed_runs` / `results.errored_runs` to
+                  split them. Pair with `enable_cache()` + `max_attempts > 1`
+                  to retry only the failures.
             **kwargs: Alternative way to specify the parameter grid.
 
         Returns:
-            A `runs.Runs` object containing the results of all successful
-            evaluations.
+            A `runs.Runs` object. With `on_failure="raise"` (default) it
+            contains only successful runs. With `on_failure="continue"` it
+            contains both successful and failed runs.
         """
         from kaggle_benchmarks import contexts, orchestration, runs
         from kaggle_benchmarks.kaggle import serialization
@@ -222,19 +283,47 @@ class Task(Generic[T]):
             evaluation_data = evaluation_data.reset_index(names=["_id"])
 
         def _evaluate_once():
-            return runs.Runs(
+            # In "continue" mode, tell Task.run() not to re-raise so the
+            # failed Run object comes back to us instead of crashing the
+            # joblib worker. In "raise" mode, leave Task.run()'s behavior
+            # untouched (it raises in dev, returns the failed Run in batch).
+            runner = functools.partial(
+                self.run, _suppress_raise=(on_failure == "continue")
+            )
+            all_runs = runs.Runs(
                 [
                     run
                     for _, _, run in orchestration.evaluate_function(
-                        self.run,
+                        runner,
                         grid=grid,
                         evaluation_data=evaluation_data,
                         n_jobs=n_jobs,
                         timeout=timeout,
                     )
-                    if run is not None and run.status == utils.Status.SUCCESS
+                    if run is not None
                 ]
             )
+
+            # In "raise" mode, surface any failed runs that slipped through
+            # because contexts.enter swallowed them (Kaggle batch). In dev
+            # mode, the worker already raised and we never reach here.
+            if on_failure == "raise":
+                failures = [r for r in all_runs if r.status == utils.Status.FAILED]
+                if failures:
+                    first = failures[0]
+                    msg = (
+                        f"Task {self.name!r} run {first.id} failed:\n"
+                        f"{first.error_message}"
+                    )
+                    if len(failures) > 1:
+                        msg += (
+                            f"\n\n({len(failures)} of {len(all_runs)} runs "
+                            "failed. Pass on_failure='continue' to collect "
+                            "failures instead of raising.)"
+                        )
+                    raise RuntimeError(msg)
+
+            return all_runs
 
         all_runs = runs.Runs()
         attempt = 0

--- a/tests/kaggle/test_integration.py
+++ b/tests/kaggle/test_integration.py
@@ -231,6 +231,51 @@ def test_load_failed_cached_run_reruns(client, monkeypatch, duck):
     assert call_count == 2  # Should have been called again.
 
 
+def test_evaluate_retries_only_failed_samples_with_cache(client, monkeypatch, duck):
+    """End-to-end demonstration of the production retry pattern.
+
+    With `enable_cache()` + `on_failure="continue"` + `max_attempts > 1`,
+    the retry attempt skips successful samples (cache hit on COMPLETED file)
+    and re-runs only the failed ones (no skip on ERRORED file). Results
+    from all attempts are merged into one Runs.
+    """
+    monkeypatch.setattr(config, "continue_with_exceptions", True)
+    import pandas as pd
+
+    call_counts: dict[str, int] = {}
+
+    @task()
+    def per_sample_task(llm, sample_id: str) -> bool:
+        call_counts[sample_id] = call_counts.get(sample_id, 0) + 1
+        # Sample "b" fails on its first call, succeeds on retry.
+        # Samples "a" and "c" always succeed.
+        if sample_id == "b" and call_counts[sample_id] == 1:
+            raise ValueError(f"transient failure for {sample_id}")
+        return True
+
+    df = pd.DataFrame({"sample_id": ["a", "b", "c"]})
+
+    with client.enable_cache():
+        results = per_sample_task.evaluate(
+            llm=[duck],
+            evaluation_data=df,
+            on_failure="continue",
+            max_attempts=2,
+        )
+
+    # All three samples present in the merged result (positions 0, 1, 2),
+    # all successful after the retry.
+    assert len(results) == 3
+    assert len(results.completed_runs) == 3
+    assert len(results.errored_runs) == 0
+
+    # The whole point: "a" and "c" ran exactly once (cache hit on retry),
+    # "b" ran twice (failed first, retried successfully).
+    assert call_counts["a"] == 1
+    assert call_counts["c"] == 1
+    assert call_counts["b"] == 2
+
+
 def test_cache_id_uses_model_over_name(client):
     """cache_id should prefer the `model` attribute over `name` when present."""
     from tests.mocks import MockedChat

--- a/tests/kaggle/test_integration.py
+++ b/tests/kaggle/test_integration.py
@@ -149,6 +149,60 @@ def test_load_cached_run_dict(client, duck):
         assert call_count == 1
 
 
+def test_load_cached_run_float_zero(client, duck):
+    """proto3 JSON drops default-valued fields, so a float result of 0.0
+    round-trips to `numericResult: {}` on disk. load_run_result must treat
+    a missing `value` as the default 0.0 instead of raising ValueError.
+
+    Regression test for warning seen in real eval runs:
+        "Reading cached run failed: Could not determine result from cached
+         run file: ... No known result key found in 'results' field."
+    """
+    call_count = 0
+
+    @task()
+    def zero_task(llm) -> float:
+        nonlocal call_count
+        call_count += 1
+        return 0.0
+
+    run1 = zero_task.run(duck, _id="zero")
+    assert not run1.cached
+    assert run1.result == 0.0
+    assert call_count == 1
+
+    client.use_cache = True
+    run2 = zero_task.run(duck, _id="zero")
+    assert run2.cached
+    assert run2.result == 0.0
+    assert call_count == 1  # cache hit, not re-executed
+
+
+def test_load_cached_run_metric_with_zero_value_nonzero_ci(client, duck):
+    """A (0.0, ci) tuple has its `value` dropped by proto3 JSON, leaving
+    `numericResult: {"confidenceInterval": ci}`. The load path must still
+    reconstruct a tuple, not fall through to ValueError.
+    """
+    call_count = 0
+
+    @task()
+    def zero_value_ci(llm) -> tuple[float, float]:
+        nonlocal call_count
+        call_count += 1
+        return (0.0, 0.05)
+
+    run1 = zero_value_ci.run(duck, _id="zero_v_ci")
+    assert not run1.cached
+    assert run1.result == pytest.approx((0.0, 0.05))
+    assert call_count == 1
+
+    client.use_cache = True
+    run2 = zero_value_ci.run(duck, _id="zero_v_ci")
+    assert run2.cached
+    assert run2.result == pytest.approx((0.0, 0.05))
+    assert call_count == 1
+
+
 def test_load_cached_run_metric_with_ci(client, duck):
     call_count = 0
 
@@ -274,6 +328,125 @@ def test_evaluate_retries_only_failed_samples_with_cache(client, monkeypatch, du
     assert call_counts["a"] == 1
     assert call_counts["c"] == 1
     assert call_counts["b"] == 2
+
+
+def test_retry_merge_preserves_position_under_parallelism(client, monkeypatch, duck):
+    """Position-based retry merge stays correct when n_jobs > 1.
+
+    The merge in `Task._evaluate()` keys results by enumerate-index of each
+    attempt's `Runs`. That only works if joblib returns results in input
+    order even with parallelism. Heterogeneous failure pattern + n_jobs=4
+    confirms each retried success lands at the original evaluation_data
+    row's position.
+    """
+    import threading
+
+    import pandas as pd
+
+    monkeypatch.setattr(config, "continue_with_exceptions", True)
+
+    lock = threading.Lock()
+    call_counts: dict[str, int] = {}
+
+    @task()
+    def per_sample_task(llm, sample_id: str) -> bool:
+        with lock:
+            call_counts[sample_id] = call_counts.get(sample_id, 0) + 1
+            n = call_counts[sample_id]
+        # Samples at non-adjacent positions fail on attempt 1 to ensure
+        # the retry attempt has a different parallelism pattern (fewer
+        # samples → different worker scheduling) from attempt 1.
+        if sample_id in {"s1", "s4", "s7"} and n == 1:
+            raise ValueError(f"transient for {sample_id}")
+        return True
+
+    sample_ids = [f"s{i}" for i in range(10)]
+    df = pd.DataFrame({"sample_id": sample_ids})
+
+    with client.enable_cache():
+        results = per_sample_task.evaluate(
+            llm=[duck],
+            evaluation_data=df,
+            n_jobs=4,
+            on_failure="continue",
+            max_attempts=2,
+        )
+
+    assert len(results) == 10
+    assert len(results.completed_runs) == 10
+
+    # The critical assertion: each merged result is at the position
+    # matching its evaluation_data row.
+    for position, expected_id in enumerate(sample_ids):
+        run = results[position]
+        assert run.params["sample_id"] == expected_id, (
+            f"Position {position}: expected sample_id={expected_id!r}, "
+            f"got {run.params['sample_id']!r} (merge corrupted ordering)"
+        )
+        # And the user sees the retry's success, not a stale FAILED status.
+        assert run.status == utils.Status.SUCCESS
+
+    # Sanity: only the three flaky samples were retried.
+    assert call_counts["s1"] == 2
+    assert call_counts["s4"] == 2
+    assert call_counts["s7"] == 2
+    for i in (0, 2, 3, 5, 6, 8, 9):
+        assert call_counts[f"s{i}"] == 1
+
+
+def test_recommended_pattern_end_to_end_with_parallelism(client, monkeypatch, duck):
+    """End-to-end exercise of the cookbook's recommended production pattern.
+
+    Combines `enable_cache()` + `on_failure="continue"` + `max_attempts>1`
+    + `n_jobs>1`, and aggregates via `completed_runs.as_dataframe()` per
+    the documented usage. Sized to look like a miniature 'large eval'.
+    """
+    import threading
+
+    import pandas as pd
+
+    monkeypatch.setattr(config, "continue_with_exceptions", True)
+
+    lock = threading.Lock()
+    attempts: dict[int, int] = {}
+
+    @task()
+    def score_sample(llm, sample_id: int) -> bool:
+        with lock:
+            attempts[sample_id] = attempts.get(sample_id, 0) + 1
+            n = attempts[sample_id]
+        # Every 5th sample fails on attempt 1 (transient).
+        if sample_id % 5 == 0 and n == 1:
+            raise ValueError("transient")
+        return sample_id % 2 == 0
+
+    df = pd.DataFrame({"sample_id": list(range(20))})
+
+    with client.enable_cache():
+        results = score_sample.evaluate(
+            llm=[duck],
+            evaluation_data=df,
+            n_jobs=4,
+            on_failure="continue",
+            max_attempts=3,
+            retry_delay=0,
+        )
+
+    assert len(results) == 20
+    assert len(results.completed_runs) == 20
+    assert len(results.errored_runs) == 0
+
+    # Aggregate using the documented pattern.
+    completed_df = results.completed_runs.as_dataframe()
+    accuracy = completed_df["result"].mean()
+    assert accuracy == pytest.approx(0.5)  # half of 0..19 are even
+
+    # Cache + selective retry: failed samples ran exactly twice; the rest once.
+    for sample_id in range(20):
+        expected = 2 if sample_id % 5 == 0 else 1
+        assert attempts[sample_id] == expected, (
+            f"sample_id={sample_id}: expected {expected} calls, got {attempts[sample_id]}"
+        )
 
 
 def test_cache_id_uses_model_over_name(client):

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -111,9 +111,7 @@ def test_evaluate_with_retries_succeeds_on_retry(monkeypatch):
 
     # Stop when all runs succeed.
     result = fallible_task.evaluate(
-        stop_condition=lambda runs: all(
-            r.status == utils.Status.SUCCESS for r in runs
-        ),
+        stop_condition=lambda runs: all(r.status == utils.Status.SUCCESS for r in runs),
         max_attempts=5,
         on_failure="continue",
     )
@@ -134,9 +132,7 @@ def test_evaluate_with_retries_fails_after_retries(monkeypatch):
         return failer()
 
     result = fallible_task.evaluate(
-        stop_condition=lambda runs: all(
-            r.status == utils.Status.SUCCESS for r in runs
-        ),
+        stop_condition=lambda runs: all(r.status == utils.Status.SUCCESS for r in runs),
         max_attempts=2,
         on_failure="continue",
     )
@@ -266,9 +262,7 @@ def test_evaluate_with_retries_parallel(monkeypatch):
     result = fallible_task.evaluate(
         evaluation_data=evaluation_data,
         n_jobs=2,
-        stop_condition=lambda runs: all(
-            r.status == utils.Status.SUCCESS for r in runs
-        ),
+        stop_condition=lambda runs: all(r.status == utils.Status.SUCCESS for r in runs),
         max_attempts=5,
         on_failure="continue",
     )
@@ -417,11 +411,6 @@ def test_nested_task_evaluate_with_retries_coerces_to_one(duck, caplog):
     assert len(nested_runs) == df.shape[0]
 
 
-# ---------------------------------------------------------------------------
-# Change 1 & 2 tests: failure persistence + on_failure parameter
-# ---------------------------------------------------------------------------
-
-
 class RecordingClient(clients.InMemoryClient):
     """InMemoryClient that records store_run calls for inspection."""
 
@@ -465,7 +454,7 @@ def test_successful_run_stored_with_success_status(recording_client):
     def ok():
         return True
 
-    run = ok.run()
+    ok.run()
     assert recording_client.stored_runs[0].status == utils.Status.SUCCESS
 
 
@@ -556,3 +545,24 @@ def test_failed_run_reports_passed_false():
     run = bad.run(_suppress_raise=True)
     assert run.status == utils.Status.FAILED
     assert not run.passed
+
+
+def test_retry_merge_overwrites_failures():
+    """Change 5: retried successes overwrite earlier failures at the same
+    position, so len(result) == sample count, not accumulated across attempts."""
+    call_counts = [0, 0, 0]
+
+    @tasks.task(name="Merge Retry")
+    def flaky(x):
+        call_counts[x] += 1
+        if x == 1 and call_counts[x] <= 1:
+            raise ValueError("transient")
+
+    result = flaky.evaluate(
+        evaluation_data=pd.DataFrame({"x": [0, 1, 2]}),
+        max_attempts=3,
+        on_failure="continue",
+    )
+
+    assert len(result) == 3  # merged, not 6
+    assert all(r.passed for r in result)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -591,3 +591,37 @@ def test_retry_merge_overwrites_failures():
 
     assert len(result) == 3  # merged, not 6
     assert all(r.passed for r in result)
+
+
+def test_on_failure_raise_in_dev_mode(monkeypatch):
+    """Gap 1: on_failure='raise' in dev mode propagates the original exception
+    type (ValueError), not RuntimeError — because in dev mode the exception
+    escapes the joblib worker directly, never reaching the RuntimeError wrapper."""
+    monkeypatch.setattr(config, "continue_with_exceptions", False)
+
+    @tasks.task(name="Dev Raise")
+    def bad():
+        raise ValueError("dev boom")
+
+    with pytest.raises(ValueError, match="dev boom"):
+        bad.evaluate(on_failure="raise")
+
+
+def test_swallowed_failure_persisted_in_batch_mode(monkeypatch):
+    """Gap 3: when contexts.enter swallows a root-level exception in batch mode,
+    the run still gets persisted with status=FAILED via the else branch."""
+    monkeypatch.setattr(config, "continue_with_exceptions", True)
+
+    recording_client = RecordingClient()
+    monkeypatch.setattr("kaggle_benchmarks.client", recording_client)
+
+    @tasks.task(name="Swallowed")
+    def bad():
+        raise ValueError("swallowed")
+
+    run = bad.run()
+    # The exception was swallowed — we get a Run back, not an exception.
+    assert run.status == utils.Status.FAILED
+    # The run was persisted via the else branch (no exception escaped).
+    assert len(recording_client.stored_runs) == 1
+    assert recording_client.stored_runs[0].status == utils.Status.FAILED

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -571,6 +571,7 @@ def test_on_failure_raise_in_batch_mode(monkeypatch):
     with pytest.raises(RuntimeError, match="batch boom"):
         bad.evaluate(on_failure="raise")
 
+
 def test_retry_merge_overwrites_failures():
     """Change 5: retried successes overwrite earlier failures at the same
     position, so len(result) == sample count, not accumulated across attempts."""

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -587,6 +587,21 @@ def test_on_failure_continue_returns_failed_runs():
     assert len([r for r in result if r.status == utils.Status.FAILED]) == 1
 
 
+def test_on_failure_rejects_invalid_value():
+    """Typos like on_failure='contiune' must fail loudly, not silently
+    flow through as a falsy comparison against both 'raise' and 'continue'."""
+
+    @tasks.task(name="Validate OnFailure")
+    def ok(x):
+        return True
+
+    with pytest.raises(ValueError, match="on_failure must be 'raise' or 'continue'"):
+        ok.evaluate(
+            evaluation_data=pd.DataFrame({"x": [1]}),
+            on_failure="contiune",  # typo
+        )
+
+
 def test_on_failure_raise_in_batch_mode(monkeypatch):
     """Change 2: on_failure='raise' (default) raises even in batch mode."""
     monkeypatch.setattr(config, "continue_with_exceptions", True)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -532,6 +532,33 @@ def test_store_run_error_doesnt_mask_task_error(monkeypatch):
         bad.run()
 
 
+def test_store_run_error_swallowed_for_successful_run(monkeypatch, caplog):
+    """A store_run failure on a SUCCESSFUL task is logged, not raised.
+
+    Pre-PR behavior was to propagate the IO error (store_run was unguarded).
+    This PR wraps the call in `_finalize_and_persist` with a try/except so
+    persistence failures never mask the task outcome — true for failed runs
+    (see test_store_run_error_doesnt_mask_task_error) and also for successful
+    ones (this test). Guard against silently regressing back to raising.
+    """
+    monkeypatch.setattr(config, "continue_with_exceptions", False)
+    monkeypatch.setattr(
+        "kaggle_benchmarks.client.store_run",
+        lambda run: (_ for _ in ()).throw(IOError("disk full")),
+    )
+
+    @tasks.task(name="IO OK")
+    def ok():
+        return True
+
+    with caplog.at_level("WARNING", logger="kaggle_benchmarks.tasks"):
+        run = ok.run()  # must not raise
+
+    assert run.status == utils.Status.SUCCESS
+    assert run.result is True
+    assert any("Failed to store run" in r.message for r in caplog.records)
+
+
 def test_nonrecoverable_propagates_despite_suppress():
     """Change 1: NonRecoverableError always propagates, even with _suppress_raise."""
 

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -271,6 +271,64 @@ def test_evaluate_with_retries_parallel(monkeypatch):
     assert all(run.passed for run in result)
 
 
+def test_runs_completed_and_errored_partition(monkeypatch):
+    """Runs.completed_runs and .errored_runs cleanly split a mixed Runs.
+
+    Demonstrates the Change 3 API surface: when `on_failure="continue"` lets
+    failed runs into the returned Runs, users can split successes and
+    failures with two convenience properties.
+    """
+    monkeypatch.setattr(config, "continue_with_exceptions", True)
+
+    @tasks.task()
+    def per_sample_task(x: str) -> bool:
+        if x == "fail":
+            raise ValueError(f"intentional failure for {x}")
+        return True
+
+    df = pd.DataFrame({"x": ["ok_a", "fail", "ok_b"]})
+
+    results = per_sample_task.evaluate(
+        evaluation_data=df,
+        on_failure="continue",
+        max_attempts=1,
+    )
+
+    assert len(results) == 3
+    assert len(results.completed_runs) == 2
+    assert len(results.errored_runs) == 1
+
+    completed_ids = {r.id for r in results.completed_runs}
+    errored_ids = {r.id for r in results.errored_runs}
+    assert completed_ids.isdisjoint(errored_ids)
+
+    # The errored run is the one for x="fail"; its params reflect that.
+    [errored] = list(results.errored_runs)
+    assert errored.params["x"] == "fail"
+    assert errored.status == utils.Status.FAILED
+
+
+def test_run_passed_false_when_status_failed(monkeypatch):
+    """Run.passed reports False when the run hit a general exception, regardless
+    of result type's default `passed(value)` behavior.
+
+    Demonstrates the Change 4 guard: most Result subclasses' `passed()`
+    returns True by default for any value; without an explicit
+    `status == FAILED -> False` check, a failed run with no failing
+    assertions would incorrectly report passed=True.
+    """
+    monkeypatch.setattr(config, "continue_with_exceptions", True)
+
+    @tasks.task()
+    def fails_with_score() -> float:
+        raise ValueError("boom")
+
+    run = fails_with_score.run()
+
+    assert run.status == utils.Status.FAILED
+    assert not run.passed
+
+
 def test_subruns(duck):
     @tasks.task()
     def outer(llm):
@@ -512,40 +570,6 @@ def test_on_failure_raise_in_batch_mode(monkeypatch):
 
     with pytest.raises(RuntimeError, match="batch boom"):
         bad.evaluate(on_failure="raise")
-
-
-def test_completed_and_errored_runs_split():
-    """Change 3: completed_runs + errored_runs partition the results cleanly."""
-
-    @tasks.task(name="Split")
-    def mixed(x):
-        if x == 2:
-            raise ValueError("fail")
-
-    result = mixed.evaluate(
-        evaluation_data=pd.DataFrame({"x": [1, 2, 3]}),
-        on_failure="continue",
-    )
-
-    assert len(result.completed_runs) + len(result.errored_runs) == len(result)
-    assert len(result.completed_runs) == 2
-    assert len(result.errored_runs) == 1
-    # Both return Runs (not list), so .as_dataframe() chains.
-    assert hasattr(result.completed_runs, "as_dataframe")
-
-
-def test_failed_run_reports_passed_false():
-    """Change 4: a FAILED run reports passed=False even when result_type.passed()
-    would return True (which most types do by default)."""
-
-    @tasks.task(name="Passed Guard")
-    def bad():
-        raise ValueError("fail")
-
-    run = bad.run(_suppress_raise=True)
-    assert run.status == utils.Status.FAILED
-    assert not run.passed
-
 
 def test_retry_merge_overwrites_failures():
     """Change 5: retried successes overwrite earlier failures at the same

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -523,3 +523,36 @@ def test_on_failure_raise_in_batch_mode(monkeypatch):
 
     with pytest.raises(RuntimeError, match="batch boom"):
         bad.evaluate(on_failure="raise")
+
+
+def test_completed_and_errored_runs_split():
+    """Change 3: completed_runs + errored_runs partition the results cleanly."""
+
+    @tasks.task(name="Split")
+    def mixed(x):
+        if x == 2:
+            raise ValueError("fail")
+
+    result = mixed.evaluate(
+        evaluation_data=pd.DataFrame({"x": [1, 2, 3]}),
+        on_failure="continue",
+    )
+
+    assert len(result.completed_runs) + len(result.errored_runs) == len(result)
+    assert len(result.completed_runs) == 2
+    assert len(result.errored_runs) == 1
+    # Both return Runs (not list), so .as_dataframe() chains.
+    assert hasattr(result.completed_runs, "as_dataframe")
+
+
+def test_failed_run_reports_passed_false():
+    """Change 4: a FAILED run reports passed=False even when result_type.passed()
+    would return True (which most types do by default)."""
+
+    @tasks.task(name="Passed Guard")
+    def bad():
+        raise ValueError("fail")
+
+    run = bad.run(_suppress_raise=True)
+    assert run.status == utils.Status.FAILED
+    assert not run.passed

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -18,7 +18,7 @@ import pandas as pd
 import panel as pn
 import pytest
 
-from kaggle_benchmarks import chats, config, runs, tasks, utils
+from kaggle_benchmarks import chats, clients, config, runs, tasks, utils
 
 
 @tasks.task()
@@ -109,33 +109,39 @@ def test_evaluate_with_retries_succeeds_on_retry(monkeypatch):
     def fallible_task():
         return failer()
 
-    # Stop after 2 attempts if the task is still failing.
-    runs = fallible_task.evaluate(
-        stop_condition=lambda runs: len(runs.runs) == 1,
+    # Stop when all runs succeed.
+    result = fallible_task.evaluate(
+        stop_condition=lambda runs: all(
+            r.status == utils.Status.SUCCESS for r in runs
+        ),
         max_attempts=5,
+        on_failure="continue",
     )
 
-    assert len(runs.runs) == 1
-    run = runs.runs[0]
-    assert run.passed
     assert failer.attempts == 2
+    successes = [r for r in result if r.status == utils.Status.SUCCESS]
+    assert len(successes) >= 1
+    assert successes[0].passed
 
 
 def test_evaluate_with_retries_fails_after_retries(monkeypatch):
     monkeypatch.setattr(config, "continue_with_exceptions", True)
     failer = Failer(fail_times=10)
 
-    # With 2 retries, it will attempt 3 times (1 initial + 2 retries) and fail each time.
+    # With 2 retries, it will attempt 2 times and fail each time.
     @tasks.task()
     def fallible_task():
         return failer()
 
-    runs = fallible_task.evaluate(
-        stop_condition=lambda runs: len(runs.runs) == 1,
+    result = fallible_task.evaluate(
+        stop_condition=lambda runs: all(
+            r.status == utils.Status.SUCCESS for r in runs
+        ),
         max_attempts=2,
+        on_failure="continue",
     )
 
-    assert len(runs.runs) == 0
+    assert any(r.status == utils.Status.FAILED for r in result)
     assert failer.attempts == 2
 
 
@@ -223,19 +229,23 @@ def test_evaluate_on_exception(monkeypatch, continue_with_exceptions):
         failer()
 
     if continue_with_exceptions:
-        # It will eventually succeed with enough attempts.
-        runs = fallible_task.evaluate(
-            stop_condition=lambda runs: len(runs.runs) == 1,
+        # With on_failure="continue", it will eventually succeed.
+        result = fallible_task.evaluate(
+            stop_condition=lambda runs: all(
+                r.status == utils.Status.SUCCESS for r in runs
+            ),
             max_attempts=3,
+            on_failure="continue",
         )
-        assert len(runs.runs) == 1
+        successes = [r for r in result if r.status == utils.Status.SUCCESS]
+        assert len(successes) == 1
         assert failer.attempts == 3
-        assert runs.runs[0].passed
-        assert runs.runs[0].status == utils.Status.SUCCESS
-        assert runs.runs[0].error_message is None
+        assert successes[0].passed
+        assert successes[0].status == utils.Status.SUCCESS
+        assert successes[0].error_message is None
     else:
         with pytest.raises(ValueError, match="Intentional failure on attempt 1"):
-            runs = fallible_task.evaluate(
+            fallible_task.evaluate(
                 stop_condition=lambda runs: len(runs.runs) == 1,
                 max_attempts=3,
             )
@@ -253,15 +263,18 @@ def test_evaluate_with_retries_parallel(monkeypatch):
         index=[f"run{i}" for i in range(4)],
     )
 
-    runs = fallible_task.evaluate(
+    result = fallible_task.evaluate(
         evaluation_data=evaluation_data,
         n_jobs=2,
-        stop_condition=lambda runs: len(runs.runs) == 4,
+        stop_condition=lambda runs: all(
+            r.status == utils.Status.SUCCESS for r in runs
+        ),
         max_attempts=5,
+        on_failure="continue",
     )
 
-    assert len(runs) == 4
-    assert all(run.passed for run in runs)
+    assert len(result) == 4
+    assert all(run.passed for run in result)
 
 
 def test_subruns(duck):
@@ -402,3 +415,111 @@ def test_nested_task_evaluate_with_retries_coerces_to_one(duck, caplog):
     nested_runs = run.result
     assert isinstance(nested_runs, runs.Runs)
     assert len(nested_runs) == df.shape[0]
+
+
+# ---------------------------------------------------------------------------
+# Change 1 & 2 tests: failure persistence + on_failure parameter
+# ---------------------------------------------------------------------------
+
+
+class RecordingClient(clients.InMemoryClient):
+    """InMemoryClient that records store_run calls for inspection."""
+
+    def __init__(self):
+        super().__init__()
+        self.stored_runs: list[runs.Run] = []
+
+    def store_run(self, run: runs.Run):
+        self.stored_runs.append(run)
+
+
+@pytest.fixture()
+def recording_client(monkeypatch):
+    rc = RecordingClient()
+    monkeypatch.setattr("kaggle_benchmarks.client", rc)
+    return rc
+
+
+def test_failed_run_persisted_with_correct_status(monkeypatch, recording_client):
+    """Change 1: failed runs are always persisted, even in dev mode."""
+    monkeypatch.setattr(config, "continue_with_exceptions", False)
+
+    @tasks.task(name="Persist Fail")
+    def bad():
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        bad.run()
+
+    assert len(recording_client.stored_runs) == 1
+    stored = recording_client.stored_runs[0]
+    assert stored.status == utils.Status.FAILED
+    assert "boom" in stored.error_message
+    assert stored.end_time is not None
+
+
+def test_successful_run_stored_with_success_status(recording_client):
+    """Change 1: successful runs are stored with SUCCESS (not RUNNING)."""
+
+    @tasks.task(name="Persist OK")
+    def ok():
+        return True
+
+    run = ok.run()
+    assert recording_client.stored_runs[0].status == utils.Status.SUCCESS
+
+
+def test_store_run_error_doesnt_mask_task_error(monkeypatch):
+    """Change 1: if store_run raises, the original task error surfaces."""
+    monkeypatch.setattr(config, "continue_with_exceptions", False)
+    monkeypatch.setattr(
+        "kaggle_benchmarks.client.store_run",
+        lambda run: (_ for _ in ()).throw(IOError("disk full")),
+    )
+
+    @tasks.task(name="IO Mask")
+    def bad():
+        raise ValueError("original")
+
+    with pytest.raises(ValueError, match="original"):
+        bad.run()
+
+
+def test_nonrecoverable_propagates_despite_suppress():
+    """Change 1: NonRecoverableError always propagates, even with _suppress_raise."""
+
+    @tasks.task(name="Fatal")
+    def fatal():
+        raise tasks.NonRecoverableError("fatal")
+
+    with pytest.raises(tasks.NonRecoverableError):
+        fatal.run(_suppress_raise=True)
+
+
+def test_on_failure_continue_returns_failed_runs():
+    """Change 2: on_failure='continue' includes failures in returned Runs."""
+
+    @tasks.task(name="Mixed")
+    def mixed(x):
+        if x == 2:
+            raise ValueError("fail")
+
+    result = mixed.evaluate(
+        evaluation_data=pd.DataFrame({"x": [1, 2, 3]}),
+        on_failure="continue",
+    )
+    assert len(result) == 3
+    assert len([r for r in result if r.status == utils.Status.SUCCESS]) == 2
+    assert len([r for r in result if r.status == utils.Status.FAILED]) == 1
+
+
+def test_on_failure_raise_in_batch_mode(monkeypatch):
+    """Change 2: on_failure='raise' (default) raises even in batch mode."""
+    monkeypatch.setattr(config, "continue_with_exceptions", True)
+
+    @tasks.task(name="Batch Raise")
+    def bad():
+        raise ValueError("batch boom")
+
+    with pytest.raises(RuntimeError, match="batch boom"):
+        bad.evaluate(on_failure="raise")

--- a/user_guide.md
+++ b/user_guide.md
@@ -151,6 +151,32 @@ success_rate = runs.as_dataframe()["result"].mean()
 print(f"Success rate: {success_rate:.2f}")
 ```
 
+By default, `.evaluate()` raises on the first per-sample failure (the
+right behavior for development). For production-scale evaluations where
+some samples may hit transient errors (API timeouts, rate limits, etc.),
+pass `on_failure="continue"` to collect failed runs into the returned
+`Runs` instead of raising:
+
+``` python
+results = solve_and_check_riddle.evaluate(
+    llm=[kbench.llm],
+    evaluation_data=riddle_df,
+    on_failure="continue",
+)
+
+# Split successes from failures
+print(f"Completed: {len(results.completed_runs)}")
+print(f"Errored:   {len(results.errored_runs)}")
+
+# Always aggregate over completed_runs only — failed runs carry the
+# results.FAILED sentinel which breaks .mean() / .sum().
+success_rate = results.completed_runs.as_dataframe()["result"].mean()
+```
+
+Combine with `max_attempts > 1` and `enable_cache()` to retry only the
+failed samples on subsequent attempts. See the cookbook recipe "Best
+Practices for Large Datasets" for the full pattern.
+
 ## 2. Interacting with LLMs
 
 The `LLM` object provides several methods to communicate with the model.

--- a/user_guide.md
+++ b/user_guide.md
@@ -151,31 +151,52 @@ success_rate = runs.as_dataframe()["result"].mean()
 print(f"Success rate: {success_rate:.2f}")
 ```
 
-By default, `.evaluate()` raises on the first per-sample failure (the
-right behavior for development). For production-scale evaluations where
-some samples may hit transient errors (API timeouts, rate limits, etc.),
-pass `on_failure="continue"` to collect failed runs into the returned
-`Runs` instead of raising:
+### Handling per-sample failures
+
+`.evaluate()` has one knob for per-sample failures, `on_failure`:
+
+- **`on_failure="raise"`** (default) — if any sample fails, `.evaluate()`
+  raises. Use for development, CI, and small evals; you want failures to
+  be loud.
+- **`on_failure="continue"`** — failed samples land in
+  `results.errored_runs` and the eval keeps going. Use for large/flaky
+  production evals, typically paired with `max_attempts > 1` and
+  `enable_cache()` to retry only the failed samples:
 
 ``` python
-results = solve_and_check_riddle.evaluate(
-    llm=[kbench.llm],
-    evaluation_data=riddle_df,
-    on_failure="continue",
-)
+with kbench.client.enable_cache():
+    results = solve_and_check_riddle.evaluate(
+        llm=[kbench.llm],
+        evaluation_data=riddle_df,
+        on_failure="continue",   # collect failures into results.errored_runs
+        max_attempts=3,          # retry transient failures
+    )
 
-# Split successes from failures
 print(f"Completed: {len(results.completed_runs)}")
 print(f"Errored:   {len(results.errored_runs)}")
+
+for run in results.errored_runs:
+    print(f"{run.params}: {run.error_message[:200]}")
 
 # Always aggregate over completed_runs only — failed runs carry the
 # results.FAILED sentinel which breaks .mean() / .sum().
 success_rate = results.completed_runs.as_dataframe()["result"].mean()
 ```
 
-Combine with `max_attempts > 1` and `enable_cache()` to retry only the
-failed samples on subsequent attempts. See the cookbook recipe "Best
-Practices for Large Datasets" for the full pattern.
+How the retry works: attempt 1 runs every sample. Successes persist to
+disk as `state=COMPLETED`; failures persist as `state=ERRORED`. On the
+next attempt the cache check skips `COMPLETED` files (no re-run) but
+re-runs `ERRORED` ones, so only the failed samples actually re-execute.
+Results from all attempts merge by positional index into one `Runs` in
+evaluation-data row order. The loop exits early when no failures remain.
+
+> **Note (Kaggle batch):** In `"raise"` mode, the Kaggle batch runner
+> waits for all parallel workers to finish before raising a single
+> `RuntimeError` summarizing all failures — so you still get a hard
+> failure, just at the end rather than on the first error. The
+> exception type differs (`RuntimeError` summary vs. the original
+> `ValueError`/`TimeoutError` in dev), but `try/except Exception`
+> catches both.
 
 ## 2. Interacting with LLMs
 


### PR DESCRIPTION
# PR Summary: Surface and recover from per-sample failures in `evaluate()`

## Changes
- Before: evaluate() behaved differently depending on where you ran it, and neither mode was good. In interactive mode, the first per-sample failure raised an exception and aborted the entire eval — you lost all the work, and `max_attempts > 1` was effectively a no-op because the retry loop never ran. In batch mode, the eval kept going but silently dropped failed samples from the returned Runs, so a 448-sample GPQA eval with 5 attempts came back with 443 results and an aggregated score that looked fine but was quietly wrong. You had to choose between losing all your work (dev) or publishing wrong scores (batch).
  
- After: there's one user-facing knob — on_failure — and it behaves the same way in both environments. With the default `on_failure="raise"`, any per-sample failure causes evaluate() to raise; running interactive notebook raises immediately, batch raises a RuntimeError summary at the end, but in both cases the eval refuses to pretend it succeeded with missing samples. With `on_failure="continue"`, failures are caught and recorded as status=FAILED runs in the returned Runs, accessible via results.errored_runs with their params and error_message intact; the eval never fails on per-sample errors, and pairing with `max_attempts > 1` + `enable_cache()` retries only the failed samples automatically.
  
- Why it's better: three concrete wins. (1) Consistent — same mental model in dev and batch; you can test failure handling locally and trust it will behave the same in production. (2) Accurate — len(results) always matches len(evaluation_data); no silently-dropped samples, no quietly-wrong aggregations. (3) Inspectable — when something fails, you know which samples and why each one, instead of getting back anonymous "missing" runs. You no longer have to wrap your task body in try/except or wrap evaluate() in try/except to keep things working at scale — that scaffolding is now built into the framework.

Closes the 448-sample GPQA case where transient API failures prevented a complete score on large evals in [issue #168](https://github.com/Kaggle/kaggle-benchmarks/issues/168).


## Concepts: `on_failure="raise"` vs `"continue"`

The user-facing knob is one parameter on `.evaluate()`:

- **`on_failure="raise"`** (default) — if any sample fails, `.evaluate()` raises. Use for development, CI, and small evals; you want failures to be loud.
- **`on_failure="continue"`** — failed samples land in `results.errored_runs` and the eval keeps going. Use for large/flaky production evals, typically paired with `max_attempts > 1` and `enable_cache()` for selective retry.

### Implementation note (for reviewers)

Internally there is a second knob, `config.continue_with_exceptions`, which is set by the runtime — `False` in dev/Jupyter/pytest, `True` on the Kaggle batch runner — to control whether root-run exceptions propagate or are swallowed. Users don't set this; it composes automatically with `on_failure`:

| | `on_failure="raise"` | `on_failure="continue"` |
|---|---|---|
| **Dev** | First failure raises the original exception via the joblib worker; eval aborts. | Failed samples land in `results.errored_runs`; eval continues. |
| **Batch** | All workers finish, then `.evaluate()` raises `RuntimeError` summarizing failures (with hint about `on_failure="continue"`). | Same as dev + continue. |

The pre-PR bug was the batch + raise cell: failures were silently dropped (no exception, no record). That's now a loud `RuntimeError`, which is the breaking change below.

## Breaking change

Pre-PR, batch mode silently dropped failed samples. Post-PR it raises`RuntimeError`. To restore "keep going" with failures visible, use `on_failure="continue"` mode:

```python
results = my_task.evaluate(..., on_failure="continue")
```

Dev mode behavior is unchanged.

## End-to-end usage

```python
import kaggle_benchmarks as kbench

with kbench.client.enable_cache():
    results = my_task.evaluate(
        llm=[kbench.llm],
        evaluation_data=df,           # 448 samples
        n_jobs=20,
        on_failure="continue",        # collect failures
        max_attempts=3,               # retry transient failures
        retry_delay=30,
    )

print(f"Completed: {len(results.completed_runs)}")
print(f"Errored:   {len(results.errored_runs)}")

for run in results.errored_runs:
    print(f"{run.params}: {run.error_message[:200]}")

# IMPORTANT: aggregate over completed_runs ONLY. Failed runs carry the
# `results.FAILED` sentinel which breaks .mean() / .sum().
score = results.completed_runs.as_dataframe().result.mean()
```

**How retry works.** Attempt 1 runs every sample; successes write` state=COMPLETED`, failures write `state=ERRORED`. Attempt 2's cache check skips `COMPLETED` files but re-runs `ERRORED` ones — so only the
failed samples actually re-execute. Results from all attempts merge by positional index into one `Runs` in evaluation-data row order. The loop exits early when no failed runs remain.

## Test coverage

- `tests/test_benchmarks.py`
- `tests/kaggle/test_integration.py`
- `golden_tests/test_cookbook_examples.py`
