### PR TITLE
Create a lightweight install option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,6 @@ dependencies = [
   "jupyter",
   "docker>=7.1.0",
   "panel>=1.6.3",
-  "playwright>=1.50.0",
-  "nest-asyncio>=1.6.0",
   "hishel[httpx]>1.1.8",
   "pydantic>=2.11.5",
   "joblib",
@@ -40,6 +38,10 @@ dependencies = [
 [project.optional-dependencies]
 kaggle-client = [
   "jupytext",
+]
+web-tools = [
+  "playwright>=1.50.0",
+  "nest-asyncio>=1.6.0",
 ]
 
 # Configuration for the build backend to find the version file
@@ -63,6 +65,7 @@ test = [
     "kaggle_benchmarks[kaggle-client]",
 ]
 kaggle = [
+  "kaggle_benchmarks[web-tools]",
   "kagglehub>=0.3.10",
   "pip>=25.0.1",
   "nbdev>=2.4.2",

--- a/src/kaggle_benchmarks/tools/__init__.py
+++ b/src/kaggle_benchmarks/tools/__init__.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kaggle_benchmarks.tools import container, functions, native, python, search, web
+from kaggle_benchmarks.tools import container, functions, native, python, search
+
+try:
+    from kaggle_benchmarks.tools import web
+except ImportError:
+    web = None  # type: ignore[assignment]
+
 from kaggle_benchmarks.tools.base import (
     ModelResponse,
     ToolCallModel,

--- a/src/kaggle_benchmarks/tools/web.py
+++ b/src/kaggle_benchmarks/tools/web.py
@@ -17,14 +17,25 @@ import base64
 import dataclasses
 import re
 
-import nest_asyncio
-from playwright.async_api import async_playwright
-
 from kaggle_benchmarks import actors, chats
 from kaggle_benchmarks.envs import InternalUnsafeLocalEnvironment
 
-# required as jupyter runs its own asyncio loop
-nest_asyncio.apply()
+_MISSING_DEPS_MESSAGE = (
+    "The web browser tool requires additional dependencies. Install them with:\n"
+    "    pip install kaggle-benchmarks[web-tools]"
+)
+
+
+def _require_playwright():
+    try:
+        import nest_asyncio
+        from playwright.async_api import async_playwright
+    except ImportError as e:
+        raise ImportError(_MISSING_DEPS_MESSAGE) from e
+
+    # required as jupyter runs its own asyncio loop
+    nest_asyncio.apply()
+    return async_playwright
 
 
 def extract_html(html_string: str) -> str:
@@ -70,6 +81,7 @@ async def async_take_snapshot(
     width: int = 400,
     height: int = 600,
 ) -> Snapshot:
+    async_playwright = _require_playwright()
     logs = []
     async with async_playwright() as p:
         browser = await p.chromium.launch()
@@ -95,6 +107,7 @@ async def async_take_snapshot(
 
 class Browser(actors.Actor):
     def __init__(self):
+        _require_playwright()
         super().__init__(role="tool", avatar="🌐", name="Browser")
         self.env = InternalUnsafeLocalEnvironment(_internal=True)
 

--- a/src/kaggle_benchmarks/tools/web.py
+++ b/src/kaggle_benchmarks/tools/web.py
@@ -22,7 +22,7 @@ from kaggle_benchmarks.envs import InternalUnsafeLocalEnvironment
 
 _MISSING_DEPS_MESSAGE = (
     "The web browser tool requires additional dependencies. Install them with:\n"
-    "    pip install kaggle-benchmarks[web-tools]"
+    "    uv pip install kaggle-benchmarks[web-tools]"
 )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1881,11 +1881,9 @@ dependencies = [
     { name = "hishel", extra = ["httpx"] },
     { name = "joblib" },
     { name = "jupyter" },
-    { name = "nest-asyncio" },
     { name = "openai" },
     { name = "pandas" },
     { name = "panel" },
-    { name = "playwright" },
     { name = "protobuf" },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -1895,6 +1893,10 @@ dependencies = [
 [package.optional-dependencies]
 kaggle-client = [
     { name = "jupytext" },
+]
+web-tools = [
+    { name = "nest-asyncio" },
+    { name = "playwright" },
 ]
 
 [package.dev-dependencies]
@@ -1908,7 +1910,7 @@ dev = [
     { name = "jupyter-lsp" },
     { name = "jupyter-server" },
     { name = "jupyterlab-lsp" },
-    { name = "kaggle-benchmarks", extra = ["kaggle-client"] },
+    { name = "kaggle-benchmarks", extra = ["kaggle-client", "web-tools"] },
     { name = "kagglehub" },
     { name = "moviepy" },
     { name = "mypy" },
@@ -1953,6 +1955,7 @@ kaggle = [
     { name = "jupyter-lsp" },
     { name = "jupyter-server" },
     { name = "jupyterlab-lsp" },
+    { name = "kaggle-benchmarks", extra = ["web-tools"] },
     { name = "kagglehub" },
     { name = "nbconvert" },
     { name = "nbdev" },
@@ -1979,17 +1982,17 @@ requires-dist = [
     { name = "joblib" },
     { name = "jupyter" },
     { name = "jupytext", marker = "extra == 'kaggle-client'" },
-    { name = "nest-asyncio", specifier = ">=1.6.0" },
+    { name = "nest-asyncio", marker = "extra == 'web-tools'", specifier = ">=1.6.0" },
     { name = "openai", specifier = ">=1.66" },
     { name = "pandas" },
     { name = "panel", specifier = ">=1.6.3" },
-    { name = "playwright", specifier = ">=1.50.0" },
+    { name = "playwright", marker = "extra == 'web-tools'", specifier = ">=1.50.0" },
     { name = "protobuf", specifier = ">=5.29.3,<6.0" },
     { name = "pydantic", specifier = ">=2.11.5" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "tqdm" },
 ]
-provides-extras = ["kaggle-client"]
+provides-extras = ["kaggle-client", "web-tools"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2003,6 +2006,7 @@ dev = [
     { name = "jupyter-server", specifier = "==2.12.5" },
     { name = "jupyterlab-lsp" },
     { name = "kaggle-benchmarks", extras = ["kaggle-client"] },
+    { name = "kaggle-benchmarks", extras = ["web-tools"] },
     { name = "kagglehub", specifier = ">=0.3.10" },
     { name = "moviepy", specifier = ">=2.2.1" },
     { name = "mypy" },
@@ -2047,6 +2051,7 @@ kaggle = [
     { name = "jupyter-lsp", specifier = "==1.5.1" },
     { name = "jupyter-server", specifier = "==2.12.5" },
     { name = "jupyterlab-lsp" },
+    { name = "kaggle-benchmarks", extras = ["web-tools"] },
     { name = "kagglehub", specifier = ">=0.3.10" },
     { name = "nbconvert", specifier = ">=6.5.1" },
     { name = "nbdev", specifier = ">=2.4.2" },


### PR DESCRIPTION
Playwright pulls in Chromium and ~20 system libraries and +400 MB of binaries but is only used by
the web.Browser tool, which itself seems to be used by relatively few benchmarks. Move it (and nest-asyncio) into
a new `web-tools` optional group with lazy imports, so users who don't need the browser tool can skip the heavy install. This should make kaggle-benchmarks small enough to be added to docker-python for some but not all use cases. The kaggle group still pulls in playwright, so the Kaggle/CI image remains unaffected.

Note that this doesn't change the user experience for people who install the base package, as pip installing playwright doesn't cover the chromium binaries required for playwright to run.

Precursor PR to https://github.com/Kaggle/docker-python/compare/add_benchmarks

Co-authored-by: kaggle-agent <kaggle-agent@users.noreply.github.com>

---

Task: [sohier-20260619224002-c6cb83f1](https://agents.dev.kaggle.net/tasks/sohier-20260619224002-c6cb83f1)

