### PR TITLE
refactor: tool_calls normalization

### DIFF
--- a/documentation/examples/use_calculator_tool.py
+++ b/documentation/examples/use_calculator_tool.py
@@ -17,8 +17,6 @@
 # title: Manual Calculator Tool Calling
 # ---
 # %%
-import json
-
 from kaggle_benchmarks import actors, assertions, llm, messages, task
 
 tool = actors.Actor(name="Tool", role="tool", avatar="🛠️")
@@ -70,11 +68,7 @@ def use_calculator(
     )
 
     tool_call = tool_calls[0]
-    function_args = (
-        tool_call.arguments
-        if isinstance(tool_call.arguments, dict)
-        else json.loads(tool_call.arguments)
-    )
+    function_args = tool_call.arguments
     # Removes 'signature' parameter in thinking mode.
     function_args.pop("signature", None)
     tool_result = ""

--- a/documentation/examples/use_calculator_tool.py
+++ b/documentation/examples/use_calculator_tool.py
@@ -70,7 +70,11 @@ def use_calculator(
     )
 
     tool_call = tool_calls[0]
-    function_args = json.loads(tool_call["function"]["arguments"])
+    function_args = (
+        tool_call.arguments
+        if isinstance(tool_call.arguments, dict)
+        else json.loads(tool_call.arguments)
+    )
     # Removes 'signature' parameter in thinking mode.
     function_args.pop("signature", None)
     tool_result = ""
@@ -83,7 +87,7 @@ def use_calculator(
         messages.Message(
             sender=tool,
             content=str(tool_result),
-            _meta={"tool_call_id": tool_call["id"]},
+            _meta={"tool_call_id": tool_call.call_id},
         )
     )
 

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -895,6 +895,39 @@ def test_simple_tool_use(llm):
 
 
 # %%
+# --- Test Case: Tool Use (Streaming) ---
+# Mirrors test_simple_tool_use with stream_responses=True. Exercises the
+# streaming path that other tool tests skip: stream() chunk accumulation +
+# _finalize_tool_calls converting accumulated dicts to typed ToolInvocation.
+# Real-world chunk shapes vary by backend (byte-by-byte vs. chunked-by-segment
+# vs. full-args-in-final-chunk) and unit tests can only fake one shape; this
+# test surfaces SDK-quirk regressions that mocks can't catch.
+
+STREAMING_TOOL_LLM_NAMES = {
+    "google/gemini-3.5-flash",
+    "anthropic/claude-sonnet-4-6@default",
+}
+
+
+@benchmark_test(include=STREAMING_TOOL_LLM_NAMES)
+@kbench.task()
+def test_streaming_tool_use(llm):
+    """Same as test_simple_tool_use but with streaming enabled."""
+    llm.stream_responses = True
+
+    problem = "What is 50 plus 25?"
+    expected_answer = 75.0
+
+    final_answer = llm.prompt(problem, tools=[run_simple_calculator])
+    kbench.assertions.assert_tool_was_invoked(run_simple_calculator)
+
+    kbench.assertions.assert_true(
+        str(int(expected_answer)) in final_answer,
+        f"Expected '{expected_answer}' to be in the final answer, got '{final_answer}'.",
+    )
+
+
+# %%
 def increment_counter() -> int:
     """Increments a counter and returns the value."""
     increment_counter.count += 1

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -912,12 +912,7 @@ def test_simple_tool_use(llm):
 
 # %%
 # --- Test Case: Tool Use (Streaming) ---
-# Mirrors test_simple_tool_use with stream_responses=True. Exercises the
-# streaming path that other tool tests skip: stream() chunk accumulation +
-# _finalize_tool_calls converting accumulated dicts to typed ToolInvocation.
-# Real-world chunk shapes vary by backend (byte-by-byte vs. chunked-by-segment
-# vs. full-args-in-final-chunk) and unit tests can only fake one shape; this
-# test surfaces SDK-quirk regressions that mocks can't catch.
+# Real-world chunk shapes vary by backend; unit tests can only fake one shape.
 
 STREAMING_TOOL_LLM_NAMES = {
     "google/gemini-3.5-flash",

--- a/golden_tests/test_cookbook_examples.py
+++ b/golden_tests/test_cookbook_examples.py
@@ -179,9 +179,17 @@ def assess_with_judge_task(llm, judge_llm) -> None:
 @pytest.mark.parametrize(
     "llm, api",
     [
-        pytest.param(kbench.kaggle.load_model("google/gemini-2.5-flash", api="genai"), "genai", id="genai-google/gemini-2.5-flash"),
-        pytest.param(kbench.kaggle.load_model("google/gemini-2.5-flash", api="openai"), "openai", id="openai-google/gemini-2.5-flash"),
-    ]
+        pytest.param(
+            kbench.kaggle.load_model("google/gemini-2.5-flash", api="genai"),
+            "genai",
+            id="genai-google/gemini-2.5-flash",
+        ),
+        pytest.param(
+            kbench.kaggle.load_model("google/gemini-2.5-flash", api="openai"),
+            "openai",
+            id="openai-google/gemini-2.5-flash",
+        ),
+    ],
 )
 @pytest.mark.parametrize("judge_llm_name", JUDGE_LLM_NAMES)
 def test_assess_with_judge(llm, api, judge_llm_name):
@@ -430,9 +438,17 @@ def dataset_eval_with_failure(llm, df) -> tuple[int, int]:
 @pytest.mark.parametrize(
     "llm, api",
     [
-        pytest.param(kbench.kaggle.load_model("google/gemini-2.5-flash", api="genai"), "genai", id="genai-google/gemini-2.5-flash"),
-        pytest.param(kbench.kaggle.load_model("google/gemini-2.5-flash", api="openai"), "openai", id="openai-google/gemini-2.5-flash"),
-    ]
+        pytest.param(
+            kbench.kaggle.load_model("google/gemini-2.5-flash", api="genai"),
+            "genai",
+            id="genai-google/gemini-2.5-flash",
+        ),
+        pytest.param(
+            kbench.kaggle.load_model("google/gemini-2.5-flash", api="openai"),
+            "openai",
+            id="openai-google/gemini-2.5-flash",
+        ),
+    ],
 )
 def test_dataset_eval_with_failure_run(llm, api):
     run = dataset_eval_with_failure.run(llm, df=df)

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -630,7 +630,9 @@ class GoogleGenAI(LLMChat):
                             id=fc.id or f"call_{uuid.uuid4().hex[:8]}",
                             function=SimpleNamespace(
                                 name=fc.name,
-                                arguments=json.dumps(dict(fc.args)) if fc.args else "{}",
+                                arguments=json.dumps(dict(fc.args))
+                                if fc.args
+                                else "{}",
                             ),
                             thought_signature=getattr(part, "thought_signature", None),
                             thought=getattr(part, "thought", None),

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -92,6 +92,7 @@ import json
 import re
 import typing
 import uuid
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, TypeVar
 
 import openai
@@ -612,8 +613,6 @@ class GoogleGenAI(LLMChat):
         # TODO: Streaming does not capture reasoning_traces. Thought parts
         # are filtered out by _extract_text, so last_reasoning_traces() will
         # return None when streaming is enabled.
-        from types import SimpleNamespace
-
         for chunk in response_stream:
             tool_calls = None
             if chunk.candidates and chunk.candidates[0].content:

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -103,6 +103,7 @@ from kaggle_benchmarks._config import config
 from kaggle_benchmarks.content_types import audios, images, videos
 from kaggle_benchmarks.serializers import genai as genai_serializer
 from kaggle_benchmarks.serializers import openai as openai_serializer
+from kaggle_benchmarks.tools import base as tool_utils
 from kaggle_benchmarks.tools import functions, native
 
 if TYPE_CHECKING:
@@ -331,7 +332,16 @@ class LLMChat(actors.Actor):
         if isinstance(invoke_response, LLMResponse):
             # A response can have either content, tool_calls, or both in some cases.
             response.content = invoke_response.content or ""
-            response._meta["tool_calls"] = invoke_response.tool_calls
+            # Normalize provider-format dicts to typed ToolInvocation objects
+            # so downstream consumers (serializers, native_tool_agent, cookbook
+            # examples) see a single canonical shape regardless of backend.
+            if invoke_response.tool_calls:
+                response._meta["tool_calls"] = [
+                    tool_utils.ToolInvocation.from_api_dict(tc)
+                    for tc in invoke_response.tool_calls
+                ]
+            else:
+                response._meta["tool_calls"] = None
             response._meta.update(invoke_response.meta)
             response._meta["reasoning_traces"] = invoke_response.reasoning_traces
             response.status = utils.Status.SUCCESS
@@ -562,6 +572,9 @@ class GoogleGenAI(LLMChat):
             **_extract_extra_usage_metadata(usage),
         }
 
+    # "medium" exists for OpenAI's `reasoning_effort`; GenAI's ThinkingLevel
+    # enum only has LOW/HIGH, so "MEDIUM" triggers a UserWarning from the
+    # SDK. Left as-is to surface the asymmetry rather than silently round.
     _REASONING_LEVEL_MAP = {
         "none": None,
         "low": "LOW",

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -332,9 +332,7 @@ class LLMChat(actors.Actor):
         if isinstance(invoke_response, LLMResponse):
             # A response can have either content, tool_calls, or both in some cases.
             response.content = invoke_response.content or ""
-            # Normalize provider-format dicts to typed ToolInvocation objects
-            # so downstream consumers (serializers, native_tool_agent, cookbook
-            # examples) see a single canonical shape regardless of backend.
+            # Normalize provider dicts → typed ToolInvocation for downstream.
             if invoke_response.tool_calls:
                 response._meta["tool_calls"] = [
                     tool_utils.ToolInvocation.from_api_dict(tc)
@@ -614,12 +612,36 @@ class GoogleGenAI(LLMChat):
         # TODO: Streaming does not capture reasoning_traces. Thought parts
         # are filtered out by _extract_text, so last_reasoning_traces() will
         # return None when streaming is enabled.
-        # We currently only support text outputs
+        from types import SimpleNamespace
+
         for chunk in response_stream:
+            tool_calls = None
+            if chunk.candidates and chunk.candidates[0].content:
+                parts = chunk.candidates[0].content.parts or []
+                fn_parts = [p for p in parts if p.function_call]
+                if fn_parts:
+                    tool_calls = []
+                    # Per-chunk enumerate assumes GenAI emits each call atomically.
+                    # If calls ever span chunks, switch to a per-stream counter.
+                    for i, part in enumerate(fn_parts):
+                        fc = part.function_call
+                        tc_chunk = SimpleNamespace(
+                            index=i,
+                            id=fc.id or f"call_{uuid.uuid4().hex[:8]}",
+                            function=SimpleNamespace(
+                                name=fc.name,
+                                arguments=json.dumps(dict(fc.args)) if fc.args else "{}",
+                            ),
+                            thought_signature=getattr(part, "thought_signature", None),
+                            thought=getattr(part, "thought", None),
+                        )
+                        tool_calls.append(tc_chunk)
+
             yield LLMResponse(
                 content=self._extract_text(chunk)
                 if chunk.candidates
                 else (chunk.text or ""),
+                tool_calls=tool_calls,
                 meta=self._get_usage_meta(chunk.usage_metadata),
             )
 

--- a/src/kaggle_benchmarks/messages.py
+++ b/src/kaggle_benchmarks/messages.py
@@ -192,8 +192,7 @@ class Message(Generic[T]):
         raw_calls = self._meta.get("tool_calls")
         if not raw_calls:
             return
-        # Guard against double-conversion on repeat calls.
-        if isinstance(raw_calls[0], dict):
-            self._meta["tool_calls"] = [
-                tool_utils.ToolInvocation.from_api_dict(tc) for tc in raw_calls
-            ]
+        self._meta["tool_calls"] = [
+            tool_utils.ToolInvocation.from_api_dict(tc) if isinstance(tc, dict) else tc
+            for tc in raw_calls
+        ]

--- a/src/kaggle_benchmarks/messages.py
+++ b/src/kaggle_benchmarks/messages.py
@@ -173,4 +173,33 @@ class Message(Generic[T]):
                     self._update_from_tool_call_chunk(tool_call_chunk)
             events.manager.dispatch("new_chunk", self, chunk)
 
+        # Convert accumulated dicts in _meta["tool_calls"] to typed
+        # ToolInvocation objects now that all argument chunks have arrived
+        # and the JSON can be parsed.
+        self._finalize_tool_calls()
         events.manager.dispatch("end_content", self)
+
+    def _finalize_tool_calls(self):
+        """Converts accumulated _meta['tool_calls'] dicts to ToolInvocation.
+
+        Streaming accumulates tool call arguments as string concatenation
+        across many chunks — a partial JSON like '{"city": "Bei' is not
+        parseable. This pass runs once after all chunks have arrived, so the
+        argument JSON is complete by the time `from_api_dict` calls
+        `json.loads` on it.
+
+        Defined on `Message` rather than `LLMMessage` because the stream()
+        loop lives here. In practice only LLM responses produce tool-call
+        chunks during streaming.
+        """
+        from kaggle_benchmarks.tools import base as tool_utils
+
+        raw_calls = self._meta.get("tool_calls")
+        if not raw_calls:
+            return
+        # Only convert if values are still dicts; guards against
+        # double-conversion if called more than once.
+        if isinstance(raw_calls[0], dict):
+            self._meta["tool_calls"] = [
+                tool_utils.ToolInvocation.from_api_dict(tc) for tc in raw_calls
+            ]

--- a/src/kaggle_benchmarks/messages.py
+++ b/src/kaggle_benchmarks/messages.py
@@ -149,6 +149,10 @@ class Message(Generic[T]):
             current_call["function"]["arguments"] = ""
         if args := getattr(tc_chunk.function, "arguments", None):
             current_call["function"]["arguments"] += args
+        if getattr(tc_chunk, "thought_signature", None) is not None:
+            current_call["_thought_signature"] = tc_chunk.thought_signature
+        if getattr(tc_chunk, "thought", None) is not None:
+            current_call["_thought"] = tc_chunk.thought
 
     def stream(self, content: Iterable[Chunk]):
         """Streams content into the message, updating its content and metadata.
@@ -173,32 +177,22 @@ class Message(Generic[T]):
                     self._update_from_tool_call_chunk(tool_call_chunk)
             events.manager.dispatch("new_chunk", self, chunk)
 
-        # Convert accumulated dicts in _meta["tool_calls"] to typed
-        # ToolInvocation objects now that all argument chunks have arrived
-        # and the JSON can be parsed.
+        # Now that all argument chunks have arrived, the JSON is parseable.
         self._finalize_tool_calls()
         events.manager.dispatch("end_content", self)
 
     def _finalize_tool_calls(self):
         """Converts accumulated _meta['tool_calls'] dicts to ToolInvocation.
 
-        Streaming accumulates tool call arguments as string concatenation
-        across many chunks — a partial JSON like '{"city": "Bei' is not
-        parseable. This pass runs once after all chunks have arrived, so the
-        argument JSON is complete by the time `from_api_dict` calls
-        `json.loads` on it.
-
-        Defined on `Message` rather than `LLMMessage` because the stream()
-        loop lives here. In practice only LLM responses produce tool-call
-        chunks during streaming.
+        Must run after the stream loop completes — partial JSON can't be
+        parsed mid-stream.
         """
         from kaggle_benchmarks.tools import base as tool_utils
 
         raw_calls = self._meta.get("tool_calls")
         if not raw_calls:
             return
-        # Only convert if values are still dicts; guards against
-        # double-conversion if called more than once.
+        # Guard against double-conversion on repeat calls.
         if isinstance(raw_calls[0], dict):
             self._meta["tool_calls"] = [
                 tool_utils.ToolInvocation.from_api_dict(tc) for tc in raw_calls

--- a/src/kaggle_benchmarks/serializers/genai.py
+++ b/src/kaggle_benchmarks/serializers/genai.py
@@ -71,20 +71,30 @@ class GenAISerializer(BaseSerializer):
         tool_calls = message.tool_calls
         if tool_calls and self.get_role(message.sender) == "model":
             for tc in tool_calls:
-                func = tc.get("function", {})
-                part = types.Part.from_function_call(
-                    name=func.get("name", ""),
-                    args=func.get("arguments", {}),
-                )
-                part.function_call.id = tc.get("id")
+                if isinstance(tc.arguments, dict):
+                    args = tc.arguments
+                else:
+                    logging.warning(
+                        "ToolInvocation %s has non-dict arguments (likely "
+                        "malformed JSON from streaming): %r — using empty args",
+                        tc.name,
+                        tc.arguments,
+                    )
+                    args = {}
+                part = types.Part.from_function_call(name=tc.name, args=args)
+                # Matches prior unconditional behavior; FunctionCall.id is
+                # Optional[str] so writing None is equivalent to the default,
+                # except under model_dump(exclude_unset=True) — keep the
+                # explicit write to avoid any wire-serialization drift.
+                part.function_call.id = tc.call_id
                 # Round-trip thought_signature/thought back onto the Part.
                 # Gemini 3.x requires these on function_call Parts in
                 # multi-turn conversations; without them the API rejects
                 # the follow-up request.
-                if "_thought_signature" in tc:
-                    part.thought_signature = tc["_thought_signature"]
-                if "_thought" in tc:
-                    part.thought = tc["_thought"]
+                if tc.thought_signature:
+                    part.thought_signature = tc.thought_signature
+                if tc.thought:
+                    part.thought = tc.thought
                 parts.append(part)
 
         # Ensure at least one part is present to avoid empty Content objects.

--- a/src/kaggle_benchmarks/serializers/genai.py
+++ b/src/kaggle_benchmarks/serializers/genai.py
@@ -75,25 +75,20 @@ class GenAISerializer(BaseSerializer):
                     args = tc.arguments
                 else:
                     logging.warning(
-                        "ToolInvocation %s has non-dict arguments (likely "
-                        "malformed JSON from streaming): %r — using empty args",
+                        "ToolInvocation %s has non-dict arguments: %r — using {}",
                         tc.name,
                         tc.arguments,
                     )
                     args = {}
                 part = types.Part.from_function_call(name=tc.name, args=args)
-                # Matches prior unconditional behavior; FunctionCall.id is
-                # Optional[str] so writing None is equivalent to the default,
-                # except under model_dump(exclude_unset=True) — keep the
-                # explicit write to avoid any wire-serialization drift.
+                # Explicit write (vs. leaving default) avoids drift under
+                # model_dump(exclude_unset=True).
                 part.function_call.id = tc.call_id
-                # Round-trip thought_signature/thought back onto the Part.
-                # Gemini 3.x requires these on function_call Parts in
-                # multi-turn conversations; without them the API rejects
-                # the follow-up request.
-                if tc.thought_signature:
+                # Required by Gemini 3.x for multi-turn tool calls.
+                # `is not None` keeps the round-trip symmetric with the accumulator.
+                if tc.thought_signature is not None:
                     part.thought_signature = tc.thought_signature
-                if tc.thought:
+                if tc.thought is not None:
                     part.thought = tc.thought
                 parts.append(part)
 

--- a/src/kaggle_benchmarks/serializers/openai.py
+++ b/src/kaggle_benchmarks/serializers/openai.py
@@ -94,16 +94,12 @@ class OpenAICompletionSerializer(BaseSerializer):
             "content": message.content or None,
         }
 
-        # Assistant messages may carry normalized ToolInvocation objects in
-        # _meta["tool_calls"] (populated by respond()). Convert them back to
-        # the Chat Completions wire format.
+        # Convert normalized ToolInvocation back to Chat Completions wire format.
         tool_calls = message.tool_calls
         if tool_calls and self.get_role(message.sender) == "assistant":
             msg["tool_calls"] = [
                 {
-                    # `id` is required by the OpenAI spec. tc.call_id is
-                    # populated by both backends in practice; the `or ""`
-                    # is defensive for test fixtures / custom code.
+                    # `id` is required by the spec; `or ""` defends against test fixtures.
                     "id": tc.call_id or "",
                     "type": "function",
                     "function": {

--- a/src/kaggle_benchmarks/serializers/openai.py
+++ b/src/kaggle_benchmarks/serializers/openai.py
@@ -94,14 +94,29 @@ class OpenAICompletionSerializer(BaseSerializer):
             "content": message.content or None,
         }
 
-        # TODO: Remove once respond() returns LLMMessage for assistant
-        # messages. Today, assistant messages with tool calls arrive here as
-        # plain Message (not LLMMessage), so we must attach tool_calls
-        # manually. After the migration, they'll route to dump_llm_message
-        # instead and these lines become unnecessary.
+        # Assistant messages may carry normalized ToolInvocation objects in
+        # _meta["tool_calls"] (populated by respond()). Convert them back to
+        # the Chat Completions wire format.
         tool_calls = message.tool_calls
         if tool_calls and self.get_role(message.sender) == "assistant":
-            msg["tool_calls"] = tool_calls
+            msg["tool_calls"] = [
+                {
+                    # `id` is required by the OpenAI spec. tc.call_id is
+                    # populated by both backends in practice; the `or ""`
+                    # is defensive for test fixtures / custom code.
+                    "id": tc.call_id or "",
+                    "type": "function",
+                    "function": {
+                        "name": tc.name,
+                        "arguments": (
+                            json.dumps(tc.arguments)
+                            if isinstance(tc.arguments, dict)
+                            else tc.arguments
+                        ),
+                    },
+                }
+                for tc in tool_calls
+            ]
 
         yield msg
 

--- a/src/kaggle_benchmarks/tools/base.py
+++ b/src/kaggle_benchmarks/tools/base.py
@@ -31,15 +31,11 @@ class ToolInvocation:
     """Represents a tool invocation requested by the LLM."""
 
     name: str
-    # Widened from dict[str, Any] to accommodate from_api_dict's
-    # JSONDecodeError fallback, which keeps malformed JSON as a string
+    # `str` accommodates from_api_dict's fallback when JSON can't be parsed
     # (e.g., truncated streaming output).
     arguments: dict[str, Any] | str
     call_id: str | None = None
-    # Gemini 3.x round-trip carriers (SDK-internal, required by the API
-    # for multi-turn tool conversations). Absent for non-Gemini models.
-    # Types mirror google.genai types.Part: thought_signature is bytes,
-    # thought is a bool flag (True iff this part contains thinking).
+    # Gemini 3.x round-trip carriers; types mirror google.genai types.Part.
     thought_signature: bytes | None = None
     thought: bool | None = None
 
@@ -69,19 +65,14 @@ class ToolInvocation:
             try:
                 parsed = json.loads(raw_str)
             except json.JSONDecodeError:
-                # Unparseable (e.g., truncated streaming JSON). Keep the
-                # original string; downstream (invoke_tool, serializers)
-                # must handle both dict and str.
+                # Unparseable → keep raw_str; invoke_tool surfaces the error.
                 pass
             else:
                 if isinstance(parsed, dict):
                     arguments = parsed
                 elif parsed is None:
-                    # "null" → treat as no-args, matching the missing-key default.
-                    arguments = {}
-                # else (list, scalar, ...) — keep raw_str so invoke_tool
-                # surfaces a clean parse error rather than crashing with
-                # AttributeError on `(list).items()` etc.
+                    arguments = {}  # "null" → no-args
+                # else (list/scalar): keep raw_str; invoke_tool surfaces the error.
         return cls(
             name=func["name"],
             arguments=arguments,
@@ -96,8 +87,7 @@ class ToolInvocationResult:
     """Represents the result of a tool invocation."""
 
     name: str
-    # Mirrors ToolInvocation.arguments: may be a str when the original tool
-    # call arrived with unparseable JSON arguments (see invoke_tool).
+    # `str` mirrors ToolInvocation.arguments (unparseable JSON case).
     arguments: dict[str, Any] | str
     call_id: str | None = None
     output: Any = None
@@ -180,8 +170,7 @@ def invoke_tool(call: ToolInvocation, tools: list[Callable]) -> ToolInvocationRe
             call_id=call.call_id,
         )
     if isinstance(call.arguments, str):
-        # from_api_dict couldn't parse the arguments JSON (e.g., truncated
-        # streaming output). Surface a clear error instead of crashing.
+        # from_api_dict couldn't parse the JSON; surface a clear error.
         return ToolInvocationResult(
             name=call.name,
             arguments=call.arguments,

--- a/src/kaggle_benchmarks/tools/base.py
+++ b/src/kaggle_benchmarks/tools/base.py
@@ -31,8 +31,17 @@ class ToolInvocation:
     """Represents a tool invocation requested by the LLM."""
 
     name: str
-    arguments: dict[str, Any]
+    # Widened from dict[str, Any] to accommodate from_api_dict's
+    # JSONDecodeError fallback, which keeps malformed JSON as a string
+    # (e.g., truncated streaming output).
+    arguments: dict[str, Any] | str
     call_id: str | None = None
+    # Gemini 3.x round-trip carriers (SDK-internal, required by the API
+    # for multi-turn tool conversations). Absent for non-Gemini models.
+    # Types mirror google.genai types.Part: thought_signature is bytes,
+    # thought is a bool flag (True iff this part contains thinking).
+    thought_signature: bytes | None = None
+    thought: bool | None = None
 
     @classmethod
     def from_api_dict(cls, call_data: dict) -> Self:
@@ -50,15 +59,35 @@ class ToolInvocation:
         Handles edge cases from various backends:
         - ``arguments`` may be a JSON string (OpenAI) or a dict (GenAI).
         - ``arguments`` may be ``None`` for parameterless tools.
+        - Malformed JSON in ``arguments`` is kept as a string rather than
+          raising, so a single bad tool call doesn't crash an entire stream.
         """
         func = call_data["function"]
         arguments = func.get("arguments") or {}
         if isinstance(arguments, str):
-            arguments = json.loads(arguments)
+            raw_str = arguments
+            try:
+                parsed = json.loads(raw_str)
+            except json.JSONDecodeError:
+                # Unparseable (e.g., truncated streaming JSON). Keep the
+                # original string; downstream (invoke_tool, serializers)
+                # must handle both dict and str.
+                pass
+            else:
+                if isinstance(parsed, dict):
+                    arguments = parsed
+                elif parsed is None:
+                    # "null" → treat as no-args, matching the missing-key default.
+                    arguments = {}
+                # else (list, scalar, ...) — keep raw_str so invoke_tool
+                # surfaces a clean parse error rather than crashing with
+                # AttributeError on `(list).items()` etc.
         return cls(
             name=func["name"],
             arguments=arguments,
             call_id=call_data.get("id"),
+            thought_signature=call_data.get("_thought_signature"),
+            thought=call_data.get("_thought"),
         )
 
 
@@ -67,7 +96,9 @@ class ToolInvocationResult:
     """Represents the result of a tool invocation."""
 
     name: str
-    arguments: dict[str, Any]
+    # Mirrors ToolInvocation.arguments: may be a str when the original tool
+    # call arrived with unparseable JSON arguments (see invoke_tool).
+    arguments: dict[str, Any] | str
     call_id: str | None = None
     output: Any = None
     error: str | None = None
@@ -146,6 +177,18 @@ def invoke_tool(call: ToolInvocation, tools: list[Callable]) -> ToolInvocationRe
             name=call.name,
             arguments=call.arguments,
             error=error_message,
+            call_id=call.call_id,
+        )
+    if isinstance(call.arguments, str):
+        # from_api_dict couldn't parse the arguments JSON (e.g., truncated
+        # streaming output). Surface a clear error instead of crashing.
+        return ToolInvocationResult(
+            name=call.name,
+            arguments=call.arguments,
+            error=(
+                f"Error: Tool '{call.name}' arguments could not be parsed as JSON: "
+                f"{call.arguments!r}"
+            ),
             call_id=call.call_id,
         )
     try:

--- a/src/kaggle_benchmarks/tools/native.py
+++ b/src/kaggle_benchmarks/tools/native.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from kaggle_benchmarks.tools.base import (
-    ToolInvocation,
     ToolInvocationLimitExhausted,
     invoke_tool,
 )
@@ -82,14 +81,17 @@ def native_tool_agent(
         for _ in range(max_tool_rounds):
             response = llm.respond(tools=tools, **respond_kwargs)
 
-            # TODO: Use response.tool_calls once respond() returns LLMMessage.
-            tool_calls = response._meta.get("tool_calls")
+            # tool_calls is a list[ToolInvocation] post-normalization:
+            #  - plain Message responses: normalized in respond()'s LLMResponse
+            #    branch (Step 2) or in stream()'s finalize pass (Step 3)
+            #  - LLMMessage responses (e.g., MockedChat): typed field set
+            #    directly by the producer
+            tool_calls = response.tool_calls
             if not tool_calls:
                 exhausted = False
                 break
 
-            for call_data in tool_calls:
-                invocation = ToolInvocation.from_api_dict(call_data)
+            for invocation in tool_calls:
                 result = invoke_tool(invocation, tools)
                 actors.Tool(name=invocation.name).send(result)
 

--- a/tests/serializers/test_genai_serializer.py
+++ b/tests/serializers/test_genai_serializer.py
@@ -230,6 +230,95 @@ MESSAGE_FORMATS = [
 ]
 
 
+# Mirrors GoogleGenAI's roles_mapping. The bare parametrized batch above uses
+# the default mapping (passthrough); these tests need assistant→model so the
+# `dump_text_message` tool_calls branch fires (it checks for role == "model").
+_GENAI_ROLES = {"assistant": "model", "system": "user", "tool": "user"}
+_assistant_actor = actors.Actor(name="LLM", role="assistant", avatar="🤖")
+
+
+def test_dump_text_message_with_meta_tool_invocation():
+    """Plain Message with normalized ToolInvocation in _meta — the path
+    taken by built-in LLM responses after respond()'s normalization."""
+    serializer = genai_serializer.GenAISerializer(roles_mapping=_GENAI_ROLES)
+    msg = messages.Message(
+        content="",
+        sender=_assistant_actor,
+        _meta={
+            "tool_calls": [
+                ToolInvocation(name="test_tool", call_id="123", arguments={"x": 1})
+            ]
+        },
+    )
+    expected = [
+        types.Content(
+            role="model",
+            parts=[_make_function_call_part("test_tool", {"x": 1}, "123")],
+        )
+    ]
+    actual = [c.model_dump() for c in serializer.dump_message(msg)]
+    assert actual == [c.model_dump() for c in expected]
+
+
+def test_dump_text_message_carries_thought_signature():
+    """thought_signature (bytes) / thought (bool) round-trip from
+    ToolInvocation into the GenAI Part — required by Gemini 3.x multi-turn
+    tool conversations. Types mirror google.genai types.Part."""
+    serializer = genai_serializer.GenAISerializer(roles_mapping=_GENAI_ROLES)
+    msg = messages.Message(
+        content="",
+        sender=_assistant_actor,
+        _meta={
+            "tool_calls": [
+                ToolInvocation(
+                    name="test_tool",
+                    call_id="123",
+                    arguments={},
+                    thought_signature=b"sig-bytes",
+                    thought=True,
+                )
+            ]
+        },
+    )
+    actual = [c.model_dump() for c in serializer.dump_message(msg)]
+    # Inspect the single Part we expect to see.
+    [content] = actual
+    assert content["role"] == "model"
+    [part] = content["parts"]
+    assert part["function_call"]["name"] == "test_tool"
+    assert part["function_call"]["id"] == "123"
+    assert part["thought_signature"] == b"sig-bytes"
+    assert part["thought"] is True
+
+
+def test_dump_text_message_with_string_arguments_logs_warning(caplog):
+    """If arguments is a string (JSONDecodeError fallback from streaming),
+    the serializer logs a warning and emits empty args rather than crashing."""
+    import logging
+
+    serializer = genai_serializer.GenAISerializer(roles_mapping=_GENAI_ROLES)
+    msg = messages.Message(
+        content="",
+        sender=_assistant_actor,
+        _meta={
+            "tool_calls": [
+                ToolInvocation(
+                    name="test_tool", call_id="123", arguments='{"a":'
+                )
+            ]
+        },
+    )
+    with caplog.at_level(logging.WARNING):
+        actual = [c.model_dump() for c in serializer.dump_message(msg)]
+
+    assert any("non-dict arguments" in rec.message for rec in caplog.records)
+    [content] = actual
+    [part] = content["parts"]
+    assert part["function_call"]["name"] == "test_tool"
+    # Empty args fallback.
+    assert part["function_call"]["args"] in (None, {})
+
+
 @pytest.mark.parametrize("message, expected_raw_messages", MESSAGE_FORMATS)
 def test_dump_message(message, expected_raw_messages):
     serializer = genai_serializer.GenAISerializer()

--- a/tests/serializers/test_genai_serializer.py
+++ b/tests/serializers/test_genai_serializer.py
@@ -230,16 +230,12 @@ MESSAGE_FORMATS = [
 ]
 
 
-# Mirrors GoogleGenAI's roles_mapping. The bare parametrized batch above uses
-# the default mapping (passthrough); these tests need assistant→model so the
-# `dump_text_message` tool_calls branch fires (it checks for role == "model").
+# assistant→model mapping is required to exercise the dump_text_message tool_calls branch.
 _GENAI_ROLES = {"assistant": "model", "system": "user", "tool": "user"}
 _assistant_actor = actors.Actor(name="LLM", role="assistant", avatar="🤖")
 
 
 def test_dump_text_message_with_meta_tool_invocation():
-    """Plain Message with normalized ToolInvocation in _meta — the path
-    taken by built-in LLM responses after respond()'s normalization."""
     serializer = genai_serializer.GenAISerializer(roles_mapping=_GENAI_ROLES)
     msg = messages.Message(
         content="",
@@ -261,9 +257,7 @@ def test_dump_text_message_with_meta_tool_invocation():
 
 
 def test_dump_text_message_carries_thought_signature():
-    """thought_signature (bytes) / thought (bool) round-trip from
-    ToolInvocation into the GenAI Part — required by Gemini 3.x multi-turn
-    tool conversations. Types mirror google.genai types.Part."""
+    """thought_signature / thought round-trip onto the GenAI Part (Gemini 3.x)."""
     serializer = genai_serializer.GenAISerializer(roles_mapping=_GENAI_ROLES)
     msg = messages.Message(
         content="",
@@ -281,7 +275,6 @@ def test_dump_text_message_carries_thought_signature():
         },
     )
     actual = [c.model_dump() for c in serializer.dump_message(msg)]
-    # Inspect the single Part we expect to see.
     [content] = actual
     assert content["role"] == "model"
     [part] = content["parts"]
@@ -292,8 +285,7 @@ def test_dump_text_message_carries_thought_signature():
 
 
 def test_dump_text_message_with_string_arguments_logs_warning(caplog):
-    """If arguments is a string (JSONDecodeError fallback from streaming),
-    the serializer logs a warning and emits empty args rather than crashing."""
+    """String args → warning + empty-args fallback (no crash)."""
     import logging
 
     serializer = genai_serializer.GenAISerializer(roles_mapping=_GENAI_ROLES)

--- a/tests/serializers/test_genai_serializer.py
+++ b/tests/serializers/test_genai_serializer.py
@@ -302,9 +302,7 @@ def test_dump_text_message_with_string_arguments_logs_warning(caplog):
         sender=_assistant_actor,
         _meta={
             "tool_calls": [
-                ToolInvocation(
-                    name="test_tool", call_id="123", arguments='{"a":'
-                )
+                ToolInvocation(name="test_tool", call_id="123", arguments='{"a":')
             ]
         },
     )

--- a/tests/serializers/test_openai_serializer.py
+++ b/tests/serializers/test_openai_serializer.py
@@ -216,6 +216,77 @@ def test_dump_image_message_with_extra_api_params():
     ]
 
 
+# Mirrors how built-in OpenAI/ModelProxy LLMChat clients map sender roles.
+# Standalone tests (below) need an assistant-role sender so the
+# `dump_text_message` tool_calls branch fires (it checks for role ==
+# "assistant"). The default parametrized batch uses roles_mapping={}, which
+# would prevent the branch from running for an actor with a different role.
+_assistant_actor = actors.Actor(name="LLM", role="assistant", avatar="🤖")
+
+
+def test_dump_text_message_with_meta_tool_invocation():
+    """Plain Message with normalized ToolInvocation in _meta — the path
+    taken by built-in LLM responses after respond()'s normalization. The
+    serializer converts back to OpenAI Chat Completions wire format."""
+    serializer = openai_serializer.OpenAICompletionSerializer(roles_mapping={})
+    msg = messages.Message(
+        content="here you go",
+        sender=_assistant_actor,
+        _meta={
+            "tool_calls": [
+                ToolInvocation(name="add", call_id="call_1", arguments={"a": 1, "b": 2})
+            ]
+        },
+    )
+    [out] = list(serializer.dump_message(msg))
+    assert out["role"] == "assistant"
+    assert out["content"] == "here you go"
+    assert out["tool_calls"] == [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {
+                "name": "add",
+                "arguments": '{"a": 1, "b": 2}',
+            },
+        }
+    ]
+
+
+def test_dump_text_message_with_string_arguments_passthrough():
+    """When arguments is a string (JSONDecodeError fallback from streaming),
+    it's passed through verbatim — the wire format accepts a JSON string."""
+    serializer = openai_serializer.OpenAICompletionSerializer(roles_mapping={})
+    msg = messages.Message(
+        content="",
+        sender=_assistant_actor,
+        _meta={
+            "tool_calls": [
+                ToolInvocation(name="add", call_id="call_1", arguments='{"a":')
+            ]
+        },
+    )
+    [out] = list(serializer.dump_message(msg))
+    assert out["tool_calls"][0]["function"]["arguments"] == '{"a":'
+
+
+def test_dump_text_message_missing_call_id_defaults_to_empty_string():
+    """`id` is required on OpenAI tool_calls; if call_id is None, defensively
+    emit an empty string rather than `None`."""
+    serializer = openai_serializer.OpenAICompletionSerializer(roles_mapping={})
+    msg = messages.Message(
+        content="",
+        sender=_assistant_actor,
+        _meta={
+            "tool_calls": [
+                ToolInvocation(name="add", call_id=None, arguments={"a": 1})
+            ]
+        },
+    )
+    [out] = list(serializer.dump_message(msg))
+    assert out["tool_calls"][0]["id"] == ""
+
+
 def test_dump_chat():
     serializer = openai_serializer.OpenAICompletionSerializer(roles_mapping={})
     msgs = [

--- a/tests/serializers/test_openai_serializer.py
+++ b/tests/serializers/test_openai_serializer.py
@@ -278,9 +278,7 @@ def test_dump_text_message_missing_call_id_defaults_to_empty_string():
         content="",
         sender=_assistant_actor,
         _meta={
-            "tool_calls": [
-                ToolInvocation(name="add", call_id=None, arguments={"a": 1})
-            ]
+            "tool_calls": [ToolInvocation(name="add", call_id=None, arguments={"a": 1})]
         },
     )
     [out] = list(serializer.dump_message(msg))

--- a/tests/serializers/test_openai_serializer.py
+++ b/tests/serializers/test_openai_serializer.py
@@ -216,18 +216,11 @@ def test_dump_image_message_with_extra_api_params():
     ]
 
 
-# Mirrors how built-in OpenAI/ModelProxy LLMChat clients map sender roles.
-# Standalone tests (below) need an assistant-role sender so the
-# `dump_text_message` tool_calls branch fires (it checks for role ==
-# "assistant"). The default parametrized batch uses roles_mapping={}, which
-# would prevent the branch from running for an actor with a different role.
+# Assistant-role sender is required to exercise the dump_text_message tool_calls branch.
 _assistant_actor = actors.Actor(name="LLM", role="assistant", avatar="🤖")
 
 
 def test_dump_text_message_with_meta_tool_invocation():
-    """Plain Message with normalized ToolInvocation in _meta — the path
-    taken by built-in LLM responses after respond()'s normalization. The
-    serializer converts back to OpenAI Chat Completions wire format."""
     serializer = openai_serializer.OpenAICompletionSerializer(roles_mapping={})
     msg = messages.Message(
         content="here you go",
@@ -254,8 +247,7 @@ def test_dump_text_message_with_meta_tool_invocation():
 
 
 def test_dump_text_message_with_string_arguments_passthrough():
-    """When arguments is a string (JSONDecodeError fallback from streaming),
-    it's passed through verbatim — the wire format accepts a JSON string."""
+    """String args (from JSONDecodeError fallback) pass through verbatim."""
     serializer = openai_serializer.OpenAICompletionSerializer(roles_mapping={})
     msg = messages.Message(
         content="",
@@ -271,8 +263,7 @@ def test_dump_text_message_with_string_arguments_passthrough():
 
 
 def test_dump_text_message_missing_call_id_defaults_to_empty_string():
-    """`id` is required on OpenAI tool_calls; if call_id is None, defensively
-    emit an empty string rather than `None`."""
+    """None call_id → "" (OpenAI spec requires id)."""
     serializer = openai_serializer.OpenAICompletionSerializer(roles_mapping={})
     msg = messages.Message(
         content="",

--- a/tests/test_genai_client.py
+++ b/tests/test_genai_client.py
@@ -193,6 +193,84 @@ def test_streaming_thought_output_matches_non_streaming():
     assert streaming_text == non_streaming_text
 
 
+def test_get_stream_response_synthesizes_tool_call_chunks():
+    """_get_stream_response converts function_call Parts in the GenAI stream
+    into OpenAI-style delta chunks (SimpleNamespace) that the Message stream
+    loop can accumulate. Covers the streaming-tool path that the golden test
+    hits against real APIs."""
+    llm = MockedGoogleGenAI()
+
+    fn_part = types.Part.from_function_call(
+        name="calculator", args={"a": 5, "b": 10}
+    )
+    fn_part.function_call.id = "call_123"
+    fn_part.thought_signature = b"sig"
+    fn_part.thought = True
+
+    stream = iter(
+        [
+            types.GenerateContentResponse(
+                candidates=[
+                    types.Candidate(content=types.Content(parts=[fn_part]))
+                ]
+            )
+        ]
+    )
+
+    [llm_response] = list(llm._get_stream_response(stream))
+    assert llm_response.tool_calls is not None
+    [chunk] = llm_response.tool_calls
+    # Shape duck-types the OpenAI delta consumed by _update_from_tool_call_chunk.
+    assert chunk.index == 0
+    assert chunk.id == "call_123"
+    assert chunk.function.name == "calculator"
+    assert chunk.function.arguments == '{"a": 5, "b": 10}'
+    assert chunk.thought_signature == b"sig"
+    assert chunk.thought is True
+
+
+def test_get_stream_response_text_only_produces_no_tool_calls():
+    """Streams without function_call Parts must yield LLMResponse with
+    tool_calls=None (no false-positive synthesis)."""
+    llm = MockedGoogleGenAI()
+    stream = iter(
+        [
+            types.GenerateContentResponse(
+                candidates=[
+                    types.Candidate(
+                        content=types.Content(parts=[types.Part(text="hello")])
+                    )
+                ]
+            )
+        ]
+    )
+    [chunk] = list(llm._get_stream_response(stream))
+    assert chunk.tool_calls is None
+    assert chunk.content == "hello"
+
+
+def test_get_stream_response_synthesizes_fallback_id_when_missing():
+    """When function_call.id is missing, _get_stream_response generates a
+    `call_<hex>` fallback so the accumulator has a unique identifier."""
+    llm = MockedGoogleGenAI()
+
+    fn_part = types.Part.from_function_call(name="f", args={})
+    # Leave fn_part.function_call.id unset.
+
+    stream = iter(
+        [
+            types.GenerateContentResponse(
+                candidates=[
+                    types.Candidate(content=types.Content(parts=[fn_part]))
+                ]
+            )
+        ]
+    )
+    [llm_response] = list(llm._get_stream_response(stream))
+    [chunk] = llm_response.tool_calls
+    assert chunk.id and chunk.id.startswith("call_")
+
+
 def test_thinking_captured_in_response(mocker):
     """Tests that thought parts from GenAI response are captured as reasoning traces."""
     mock_client = mocker.MagicMock()

--- a/tests/test_genai_client.py
+++ b/tests/test_genai_client.py
@@ -197,9 +197,7 @@ def test_get_stream_response_synthesizes_tool_call_chunks():
     """GenAI function_call Parts → OpenAI-style delta chunks the accumulator can consume."""
     llm = MockedGoogleGenAI()
 
-    fn_part = types.Part.from_function_call(
-        name="calculator", args={"a": 5, "b": 10}
-    )
+    fn_part = types.Part.from_function_call(name="calculator", args={"a": 5, "b": 10})
     fn_part.function_call.id = "call_123"
     fn_part.thought_signature = b"sig"
     fn_part.thought = True
@@ -207,9 +205,7 @@ def test_get_stream_response_synthesizes_tool_call_chunks():
     stream = iter(
         [
             types.GenerateContentResponse(
-                candidates=[
-                    types.Candidate(content=types.Content(parts=[fn_part]))
-                ]
+                candidates=[types.Candidate(content=types.Content(parts=[fn_part]))]
             )
         ]
     )
@@ -251,9 +247,7 @@ def test_get_stream_response_synthesizes_fallback_id_when_missing():
     stream = iter(
         [
             types.GenerateContentResponse(
-                candidates=[
-                    types.Candidate(content=types.Content(parts=[fn_part]))
-                ]
+                candidates=[types.Candidate(content=types.Content(parts=[fn_part]))]
             )
         ]
     )

--- a/tests/test_genai_client.py
+++ b/tests/test_genai_client.py
@@ -194,10 +194,7 @@ def test_streaming_thought_output_matches_non_streaming():
 
 
 def test_get_stream_response_synthesizes_tool_call_chunks():
-    """_get_stream_response converts function_call Parts in the GenAI stream
-    into OpenAI-style delta chunks (SimpleNamespace) that the Message stream
-    loop can accumulate. Covers the streaming-tool path that the golden test
-    hits against real APIs."""
+    """GenAI function_call Parts → OpenAI-style delta chunks the accumulator can consume."""
     llm = MockedGoogleGenAI()
 
     fn_part = types.Part.from_function_call(
@@ -220,7 +217,6 @@ def test_get_stream_response_synthesizes_tool_call_chunks():
     [llm_response] = list(llm._get_stream_response(stream))
     assert llm_response.tool_calls is not None
     [chunk] = llm_response.tool_calls
-    # Shape duck-types the OpenAI delta consumed by _update_from_tool_call_chunk.
     assert chunk.index == 0
     assert chunk.id == "call_123"
     assert chunk.function.name == "calculator"
@@ -230,8 +226,6 @@ def test_get_stream_response_synthesizes_tool_call_chunks():
 
 
 def test_get_stream_response_text_only_produces_no_tool_calls():
-    """Streams without function_call Parts must yield LLMResponse with
-    tool_calls=None (no false-positive synthesis)."""
     llm = MockedGoogleGenAI()
     stream = iter(
         [
@@ -250,13 +244,10 @@ def test_get_stream_response_text_only_produces_no_tool_calls():
 
 
 def test_get_stream_response_synthesizes_fallback_id_when_missing():
-    """When function_call.id is missing, _get_stream_response generates a
-    `call_<hex>` fallback so the accumulator has a unique identifier."""
+    """Missing function_call.id → `call_<hex>` fallback."""
     llm = MockedGoogleGenAI()
 
     fn_part = types.Part.from_function_call(name="f", args={})
-    # Leave fn_part.function_call.id unset.
-
     stream = iter(
         [
             types.GenerateContentResponse(

--- a/tests/test_llm_chats.py
+++ b/tests/test_llm_chats.py
@@ -138,25 +138,17 @@ def test_respond_preserves_thought_signature_for_gemini():
     assert normalized.thought is True
 
 
-def test_respond_with_no_tool_calls_sets_meta_to_none():
-    """When LLMResponse.tool_calls is None, _meta['tool_calls'] is None."""
-    llm = _ToolCallingLLM(tool_calls=None)
+@pytest.mark.parametrize(
+    "tool_calls",
+    [pytest.param(None, id="none"), pytest.param([], id="empty_list")],
+)
+def test_respond_with_falsy_tool_calls_sets_meta_to_none(tool_calls):
+    """Both `None` and `[]` yield `_meta['tool_calls'] is None`. Pins the
+    boundary so a refactor that flips the falsy check to `is not None` (which
+    would store `[]`) gets caught — downstream consumers do `is None` checks."""
+    llm = _ToolCallingLLM(tool_calls=tool_calls)
 
-    with chats.new("No tool calls"):
-        actors.user.send("hi")
-        response = llm.respond()
-
-    assert response._meta["tool_calls"] is None
-
-
-def test_respond_with_empty_tool_calls_list_sets_meta_to_none():
-    """An empty `tool_calls` list and `None` are treated the same — both yield
-    `_meta['tool_calls'] is None`. Pins the boundary so a refactor that flips
-    the falsy check to `is not None` (which would store `[]`) gets caught,
-    since downstream consumers do `is None` checks rather than truthiness."""
-    llm = _ToolCallingLLM(tool_calls=[])
-
-    with chats.new("Empty tool calls list"):
+    with chats.new("Falsy tool calls"):
         actors.user.send("hi")
         response = llm.respond()
 

--- a/tests/test_llm_chats.py
+++ b/tests/test_llm_chats.py
@@ -21,6 +21,7 @@ from kaggle_benchmarks.actors.llms import LLMResponse
 from kaggle_benchmarks.content_types import images, videos
 from kaggle_benchmarks.llm_messages import LLMMessage
 from kaggle_benchmarks.prompting import handler
+from kaggle_benchmarks.tools.base import ToolInvocation
 from tests.mocks import MockedChat
 
 
@@ -68,6 +69,98 @@ def test_respond():
         r = llm.respond()
         assert len(t.messages) == 2
         assert {"messages": [["user", "A"]], "system": None} == json.loads(r.text)
+
+
+class _ToolCallingLLM(actors.LLMChat):
+    """Returns an LLMResponse with raw OpenAI-format tool_calls dicts —
+    exercises the normalization path in respond()."""
+
+    def __init__(self, tool_calls, **kwargs):
+        super().__init__(name="ToolCaller", **kwargs)
+        self._tool_calls = tool_calls
+
+    def invoke(self, messages, system=None, **kwargs):
+        return LLMResponse(content="", tool_calls=self._tool_calls)
+
+
+def test_respond_normalizes_tool_calls_to_typed_invocations():
+    """respond() converts raw provider dicts in LLMResponse.tool_calls into
+    typed ToolInvocation objects in _meta["tool_calls"]."""
+    raw_tool_calls = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "add", "arguments": '{"a": 1, "b": 2}'},
+        },
+        {
+            "id": "call_2",
+            "type": "function",
+            "function": {"name": "mul", "arguments": {"a": 3, "b": 4}},
+        },
+    ]
+    llm = _ToolCallingLLM(tool_calls=raw_tool_calls)
+
+    with chats.new("Tool normalization"):
+        actors.user.send("compute")
+        response = llm.respond()
+
+    normalized = response._meta["tool_calls"]
+    assert len(normalized) == 2
+    assert all(isinstance(tc, ToolInvocation) for tc in normalized)
+    assert normalized[0].name == "add"
+    assert normalized[0].arguments == {"a": 1, "b": 2}
+    assert normalized[0].call_id == "call_1"
+    assert normalized[1].name == "mul"
+    assert normalized[1].arguments == {"a": 3, "b": 4}
+    assert normalized[1].call_id == "call_2"
+
+
+def test_respond_preserves_thought_signature_for_gemini():
+    """respond() carries _thought_signature (bytes) / _thought (bool) through
+    normalization into typed ToolInvocation fields (Gemini 3.x round-trip)."""
+    raw_tool_calls = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "add", "arguments": {"a": 1}},
+            "_thought_signature": b"sig-bytes",
+            "_thought": True,
+        },
+    ]
+    llm = _ToolCallingLLM(tool_calls=raw_tool_calls)
+
+    with chats.new("Gemini thought round-trip"):
+        actors.user.send("compute")
+        response = llm.respond()
+
+    [normalized] = response._meta["tool_calls"]
+    assert normalized.thought_signature == b"sig-bytes"
+    assert normalized.thought is True
+
+
+def test_respond_with_no_tool_calls_sets_meta_to_none():
+    """When LLMResponse.tool_calls is None, _meta['tool_calls'] is None."""
+    llm = _ToolCallingLLM(tool_calls=None)
+
+    with chats.new("No tool calls"):
+        actors.user.send("hi")
+        response = llm.respond()
+
+    assert response._meta["tool_calls"] is None
+
+
+def test_respond_with_empty_tool_calls_list_sets_meta_to_none():
+    """An empty `tool_calls` list and `None` are treated the same — both yield
+    `_meta['tool_calls'] is None`. Pins the boundary so a refactor that flips
+    the falsy check to `is not None` (which would store `[]`) gets caught,
+    since downstream consumers do `is None` checks rather than truthiness."""
+    llm = _ToolCallingLLM(tool_calls=[])
+
+    with chats.new("Empty tool calls list"):
+        actors.user.send("hi")
+        response = llm.respond()
+
+    assert response._meta["tool_calls"] is None
 
 
 def test_chat_context():

--- a/tests/test_llm_chats.py
+++ b/tests/test_llm_chats.py
@@ -72,8 +72,7 @@ def test_respond():
 
 
 class _ToolCallingLLM(actors.LLMChat):
-    """Returns an LLMResponse with raw OpenAI-format tool_calls dicts —
-    exercises the normalization path in respond()."""
+    """Returns LLMResponse with raw OpenAI-format tool_calls dicts."""
 
     def __init__(self, tool_calls, **kwargs):
         super().__init__(name="ToolCaller", **kwargs)
@@ -84,8 +83,6 @@ class _ToolCallingLLM(actors.LLMChat):
 
 
 def test_respond_normalizes_tool_calls_to_typed_invocations():
-    """respond() converts raw provider dicts in LLMResponse.tool_calls into
-    typed ToolInvocation objects in _meta["tool_calls"]."""
     raw_tool_calls = [
         {
             "id": "call_1",
@@ -116,8 +113,7 @@ def test_respond_normalizes_tool_calls_to_typed_invocations():
 
 
 def test_respond_preserves_thought_signature_for_gemini():
-    """respond() carries _thought_signature (bytes) / _thought (bool) through
-    normalization into typed ToolInvocation fields (Gemini 3.x round-trip)."""
+    """Gemini 3.x carriers round-trip via _thought_signature/_thought keys."""
     raw_tool_calls = [
         {
             "id": "call_1",
@@ -143,9 +139,7 @@ def test_respond_preserves_thought_signature_for_gemini():
     [pytest.param(None, id="none"), pytest.param([], id="empty_list")],
 )
 def test_respond_with_falsy_tool_calls_sets_meta_to_none(tool_calls):
-    """Both `None` and `[]` yield `_meta['tool_calls'] is None`. Pins the
-    boundary so a refactor that flips the falsy check to `is not None` (which
-    would store `[]`) gets caught — downstream consumers do `is None` checks."""
+    """Both None and [] yield _meta['tool_calls'] is None."""
     llm = _ToolCallingLLM(tool_calls=tool_calls)
 
     with chats.new("Falsy tool calls"):

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -14,12 +14,14 @@
 
 import json
 from dataclasses import dataclass
+from types import SimpleNamespace
 
 import pydantic
 import pytest
 
 from kaggle_benchmarks import chats, messages, user
 from kaggle_benchmarks.actors.llms import LLMResponse
+from kaggle_benchmarks.tools.base import ToolInvocation
 from tests.mocks import MockedChat
 
 
@@ -100,7 +102,12 @@ def test_streaming_with_token_counts():
 
 
 def test_tool_calls_property():
-    """Tests that the tool_calls property correctly retrieves data from _meta."""
+    """Tests that the tool_calls property correctly retrieves data from _meta.
+
+    Intentionally uses raw dicts — verifies the property shim is agnostic to
+    value type. Post-`_meta` normalization, real LLM responses store
+    ToolInvocation objects here, but the property itself makes no assumptions.
+    """
     mock_tool_calls = [{"id": "call_abc", "type": "function"}]
 
     # Message with tool calls
@@ -112,3 +119,123 @@ def test_tool_calls_property():
 
     assert msg_with_tools.tool_calls == mock_tool_calls
     assert msg_without_tools.tool_calls is None
+
+
+def _make_tool_call_chunk(index, id_=None, name=None, arguments=None):
+    """Builds an OpenAI-style streaming tool-call chunk delta."""
+    return SimpleNamespace(
+        index=index,
+        id=id_,
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def test_streaming_tool_calls_finalized_to_typed_invocations():
+    """After stream() completes with tool-call chunks, _meta['tool_calls']
+    contains typed ToolInvocation objects (not raw dicts).
+
+    Tool-call arguments arrive as partial JSON string chunks that must be
+    concatenated and parsed once at the end of the stream — the finalize pass
+    in stream() does this conversion.
+    """
+
+    def chunk_generator():
+        # First chunk announces the call with the name + opening of arguments.
+        yield LLMResponse(
+            content="",
+            tool_calls=[
+                _make_tool_call_chunk(
+                    index=0, id_="call_1", name="add", arguments='{"a":'
+                )
+            ],
+        )
+        # Second chunk appends the rest of the arguments JSON.
+        yield LLMResponse(
+            content="",
+            tool_calls=[_make_tool_call_chunk(index=0, arguments=' 1, "b": 2}')],
+        )
+
+    msg = messages.Message(content="", sender=None)
+    msg.stream(chunk_generator())
+
+    [tc] = msg._meta["tool_calls"]
+    assert isinstance(tc, ToolInvocation)
+    assert tc.name == "add"
+    assert tc.arguments == {"a": 1, "b": 2}
+    assert tc.call_id == "call_1"
+
+
+def test_streaming_no_tool_calls_leaves_meta_unset():
+    """When the stream contains no tool-call chunks, _meta['tool_calls']
+    is not touched (stays absent)."""
+
+    def chunk_generator():
+        yield LLMResponse(content="Hello ", meta={"input_tokens": 5})
+        yield LLMResponse(content="world", meta={"input_tokens": 5, "output_tokens": 2})
+
+    msg = messages.Message(content="", sender=None)
+    msg.stream(chunk_generator())
+
+    assert msg.content == "Hello world"
+    assert "tool_calls" not in msg._meta
+
+
+def test_finalize_tool_calls_is_idempotent():
+    """Calling _finalize_tool_calls() twice must not re-wrap or lose the
+    already-typed ToolInvocation objects. The `isinstance(raw_calls[0], dict)`
+    guard inside _finalize is the safety net — this test pins it."""
+
+    def chunk_generator():
+        yield LLMResponse(
+            content="",
+            tool_calls=[
+                _make_tool_call_chunk(
+                    index=0, id_="call_1", name="add", arguments='{"a": 1}'
+                )
+            ],
+        )
+
+    msg = messages.Message(content="", sender=None)
+    msg.stream(chunk_generator())  # runs finalize once internally
+    [first] = msg._meta["tool_calls"]
+    assert isinstance(first, ToolInvocation)
+
+    # Second finalize must be a no-op.
+    msg._finalize_tool_calls()
+    [second] = msg._meta["tool_calls"]
+    assert second is first  # exact same object, not re-wrapped
+    assert second.arguments == {"a": 1}
+
+
+def test_streaming_content_and_tool_calls_in_same_chunk():
+    """Real OpenAI streams interleave delta.content and delta.tool_calls in
+    the same chunk. The stream() loop must accumulate both, and the finalize
+    pass must still produce a typed ToolInvocation at the end."""
+
+    def chunk_generator():
+        # First chunk has the call announcement AND some text.
+        yield LLMResponse(
+            content="Let me ",
+            tool_calls=[
+                _make_tool_call_chunk(
+                    index=0, id_="call_1", name="add", arguments='{"a":'
+                )
+            ],
+        )
+        # Second chunk continues both text and arguments.
+        yield LLMResponse(
+            content="compute. ",
+            tool_calls=[_make_tool_call_chunk(index=0, arguments=' 1, "b": 2}')],
+        )
+        # Final chunk is text-only — typical OpenAI pattern.
+        yield LLMResponse(content="Done.")
+
+    msg = messages.Message(content="", sender=None)
+    msg.stream(chunk_generator())
+
+    assert msg.content == "Let me compute. Done."
+    [tc] = msg._meta["tool_calls"]
+    assert isinstance(tc, ToolInvocation)
+    assert tc.name == "add"
+    assert tc.arguments == {"a": 1, "b": 2}
+    assert tc.call_id == "call_1"

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -121,48 +121,19 @@ def test_tool_calls_property():
     assert msg_without_tools.tool_calls is None
 
 
-def _make_tool_call_chunk(index, id_=None, name=None, arguments=None):
-    """Builds an OpenAI-style streaming tool-call chunk delta."""
+def _make_tool_call_chunk(
+    index, id_=None, name=None, arguments=None, thought_signature=None, thought=None
+):
+    """Builds an OpenAI-style streaming tool-call chunk delta. The thought
+    fields mirror what GenAI streaming chunks carry (synthesized via
+    SimpleNamespace in GoogleGenAI._get_stream_response)."""
     return SimpleNamespace(
         index=index,
         id=id_,
         function=SimpleNamespace(name=name, arguments=arguments),
+        thought_signature=thought_signature,
+        thought=thought,
     )
-
-
-def test_streaming_tool_calls_finalized_to_typed_invocations():
-    """After stream() completes with tool-call chunks, _meta['tool_calls']
-    contains typed ToolInvocation objects (not raw dicts).
-
-    Tool-call arguments arrive as partial JSON string chunks that must be
-    concatenated and parsed once at the end of the stream — the finalize pass
-    in stream() does this conversion.
-    """
-
-    def chunk_generator():
-        # First chunk announces the call with the name + opening of arguments.
-        yield LLMResponse(
-            content="",
-            tool_calls=[
-                _make_tool_call_chunk(
-                    index=0, id_="call_1", name="add", arguments='{"a":'
-                )
-            ],
-        )
-        # Second chunk appends the rest of the arguments JSON.
-        yield LLMResponse(
-            content="",
-            tool_calls=[_make_tool_call_chunk(index=0, arguments=' 1, "b": 2}')],
-        )
-
-    msg = messages.Message(content="", sender=None)
-    msg.stream(chunk_generator())
-
-    [tc] = msg._meta["tool_calls"]
-    assert isinstance(tc, ToolInvocation)
-    assert tc.name == "add"
-    assert tc.arguments == {"a": 1, "b": 2}
-    assert tc.call_id == "call_1"
 
 
 def test_streaming_no_tool_calls_leaves_meta_unset():
@@ -180,54 +151,32 @@ def test_streaming_no_tool_calls_leaves_meta_unset():
     assert "tool_calls" not in msg._meta
 
 
-def test_finalize_tool_calls_is_idempotent():
-    """Calling _finalize_tool_calls() twice must not re-wrap or lose the
-    already-typed ToolInvocation objects. The `isinstance(raw_calls[0], dict)`
-    guard inside _finalize is the safety net — this test pins it."""
+def test_streaming_content_and_tool_calls_finalized():
+    """Realistic shape: chunks interleave delta.content and delta.tool_calls
+    (OpenAI's actual streaming format) and may carry Gemini 3.x thought
+    fields. The finalize pass converts accumulated dicts to typed
+    ToolInvocation. Second _finalize call is a no-op (idempotency guard)."""
 
     def chunk_generator():
-        yield LLMResponse(
-            content="",
-            tool_calls=[
-                _make_tool_call_chunk(
-                    index=0, id_="call_1", name="add", arguments='{"a": 1}'
-                )
-            ],
-        )
-
-    msg = messages.Message(content="", sender=None)
-    msg.stream(chunk_generator())  # runs finalize once internally
-    [first] = msg._meta["tool_calls"]
-    assert isinstance(first, ToolInvocation)
-
-    # Second finalize must be a no-op.
-    msg._finalize_tool_calls()
-    [second] = msg._meta["tool_calls"]
-    assert second is first  # exact same object, not re-wrapped
-    assert second.arguments == {"a": 1}
-
-
-def test_streaming_content_and_tool_calls_in_same_chunk():
-    """Real OpenAI streams interleave delta.content and delta.tool_calls in
-    the same chunk. The stream() loop must accumulate both, and the finalize
-    pass must still produce a typed ToolInvocation at the end."""
-
-    def chunk_generator():
-        # First chunk has the call announcement AND some text.
+        # First chunk announces the call + opens args + carries thought fields
+        # (mirrors how GenAI _get_stream_response synthesizes its delta).
         yield LLMResponse(
             content="Let me ",
             tool_calls=[
                 _make_tool_call_chunk(
-                    index=0, id_="call_1", name="add", arguments='{"a":'
+                    index=0,
+                    id_="call_1",
+                    name="add",
+                    arguments='{"a":',
+                    thought_signature=b"sig-bytes",
+                    thought=True,
                 )
             ],
         )
-        # Second chunk continues both text and arguments.
         yield LLMResponse(
             content="compute. ",
             tool_calls=[_make_tool_call_chunk(index=0, arguments=' 1, "b": 2}')],
         )
-        # Final chunk is text-only — typical OpenAI pattern.
         yield LLMResponse(content="Done.")
 
     msg = messages.Message(content="", sender=None)
@@ -239,3 +188,11 @@ def test_streaming_content_and_tool_calls_in_same_chunk():
     assert tc.name == "add"
     assert tc.arguments == {"a": 1, "b": 2}
     assert tc.call_id == "call_1"
+    # Thought fields captured during accumulation, preserved through finalize.
+    assert tc.thought_signature == b"sig-bytes"
+    assert tc.thought is True
+
+    # Idempotency: re-running finalize must not re-wrap or replace the object.
+    msg._finalize_tool_calls()
+    [second] = msg._meta["tool_calls"]
+    assert second is tc

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -102,12 +102,7 @@ def test_streaming_with_token_counts():
 
 
 def test_tool_calls_property():
-    """Tests that the tool_calls property correctly retrieves data from _meta.
-
-    Intentionally uses raw dicts — verifies the property shim is agnostic to
-    value type. Post-`_meta` normalization, real LLM responses store
-    ToolInvocation objects here, but the property itself makes no assumptions.
-    """
+    """The property shim is value-type agnostic — raw dicts work too."""
     mock_tool_calls = [{"id": "call_abc", "type": "function"}]
 
     # Message with tool calls
@@ -124,9 +119,7 @@ def test_tool_calls_property():
 def _make_tool_call_chunk(
     index, id_=None, name=None, arguments=None, thought_signature=None, thought=None
 ):
-    """Builds an OpenAI-style streaming tool-call chunk delta. The thought
-    fields mirror what GenAI streaming chunks carry (synthesized via
-    SimpleNamespace in GoogleGenAI._get_stream_response)."""
+    """OpenAI-style streaming delta; thought fields mirror GenAI's synthesis."""
     return SimpleNamespace(
         index=index,
         id=id_,
@@ -137,9 +130,6 @@ def _make_tool_call_chunk(
 
 
 def test_streaming_no_tool_calls_leaves_meta_unset():
-    """When the stream contains no tool-call chunks, _meta['tool_calls']
-    is not touched (stays absent)."""
-
     def chunk_generator():
         yield LLMResponse(content="Hello ", meta={"input_tokens": 5})
         yield LLMResponse(content="world", meta={"input_tokens": 5, "output_tokens": 2})
@@ -152,14 +142,10 @@ def test_streaming_no_tool_calls_leaves_meta_unset():
 
 
 def test_streaming_content_and_tool_calls_finalized():
-    """Realistic shape: chunks interleave delta.content and delta.tool_calls
-    (OpenAI's actual streaming format) and may carry Gemini 3.x thought
-    fields. The finalize pass converts accumulated dicts to typed
-    ToolInvocation. Second _finalize call is a no-op (idempotency guard)."""
+    """Interleaved content + tool_calls chunks → typed ToolInvocation post-finalize.
+    Also asserts idempotency of _finalize_tool_calls."""
 
     def chunk_generator():
-        # First chunk announces the call + opens args + carries thought fields
-        # (mirrors how GenAI _get_stream_response synthesizes its delta).
         yield LLMResponse(
             content="Let me ",
             tool_calls=[
@@ -188,11 +174,10 @@ def test_streaming_content_and_tool_calls_finalized():
     assert tc.name == "add"
     assert tc.arguments == {"a": 1, "b": 2}
     assert tc.call_id == "call_1"
-    # Thought fields captured during accumulation, preserved through finalize.
     assert tc.thought_signature == b"sig-bytes"
     assert tc.thought is True
 
-    # Idempotency: re-running finalize must not re-wrap or replace the object.
+    # Second finalize is a no-op.
     msg._finalize_tool_calls()
     [second] = msg._meta["tool_calls"]
     assert second is tc

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -89,11 +89,22 @@ class MockedOpenAIWithToolCall(OpenAI):
         super().__init__(client=None, model="mock-tool-caller", **kwargs)
 
     def _call_api(self, messages, **kwargs):
-        tool_call = MockToolCall(
-            id="call_123",
-            function=MockFunction(name="calculator", arguments='{"a": 1, "b": 2}'),
+        # Real OpenAI._call_api wraps tool calls with `t.model_dump()` (see
+        # llms.py:551), producing OpenAI-style dicts. The mock mirrors that
+        # shape so respond()'s normalization sees the same input as production.
+        return LLMResponse(
+            content="",
+            tool_calls=[
+                {
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {
+                        "name": "calculator",
+                        "arguments": '{"a": 1, "b": 2}',
+                    },
+                }
+            ],
         )
-        return LLMResponse(content="", tool_calls=[tool_call])
 
 
 class MockedOpenAIWithStreamingToolCall(OpenAI):
@@ -480,10 +491,13 @@ def test_llm_extracts_tool_calls():
         actors.user.send("call a tool")
         response_msg = llm.respond()
 
+    # respond() normalizes raw OpenAI dicts → typed ToolInvocation.
     assert response_msg.tool_calls is not None
     assert len(response_msg.tool_calls) == 1
-    assert response_msg.tool_calls[0].function.name == "calculator"
-    assert response_msg.tool_calls[0].function.arguments == '{"a": 1, "b": 2}'
+    [tc] = response_msg.tool_calls
+    assert tc.name == "calculator"
+    assert tc.arguments == {"a": 1, "b": 2}
+    assert tc.call_id == "call_123"
 
 
 def test_streaming_accumulates_tool_calls():
@@ -496,16 +510,15 @@ def test_streaming_accumulates_tool_calls():
 
     assert response_msg.content == "Okay, calculating..."
 
+    # _update_from_tool_call_chunk accumulates dicts as chunks stream in;
+    # stream()'s finalize pass converts them to ToolInvocation at end.
     final_tool_calls = response_msg.tool_calls
     assert final_tool_calls is not None
     assert len(final_tool_calls) == 1
-
-    final_call_obj = MockToolCallDelta(index=0, **final_tool_calls[0])
-    final_call_obj.function = MockFunctionDelta(**final_call_obj.function)
-
-    assert final_call_obj.id == "call_123"
-    assert final_call_obj.function.name == "calculator"
-    assert final_call_obj.function.arguments == '{"a": 5, "b": 10}'
+    [tc] = final_tool_calls
+    assert tc.call_id == "call_123"
+    assert tc.name == "calculator"
+    assert tc.arguments == {"a": 5, "b": 10}
 
 
 def test_streaming_accumulates_multiple_tool_calls():
@@ -519,16 +532,14 @@ def test_streaming_accumulates_multiple_tool_calls():
     assert response_msg.content == "Okay, processing requests..."
 
     final_tool_calls = response_msg.tool_calls
-
     assert final_tool_calls is not None
     assert len(final_tool_calls) == 2
 
-    calculator_call = final_tool_calls[0]
-    assert calculator_call["id"] == "call_calc_123"
-    assert calculator_call["function"]["name"] == "calculator"
-    assert calculator_call["function"]["arguments"] == '{"a": 100, "b": 200}'
+    calculator_call, weather_call = final_tool_calls
+    assert calculator_call.call_id == "call_calc_123"
+    assert calculator_call.name == "calculator"
+    assert calculator_call.arguments == {"a": 100, "b": 200}
 
-    weather_call = final_tool_calls[1]
-    assert weather_call["id"] == "call_weather_456"
-    assert weather_call["function"]["name"] == "get_weather"
-    assert weather_call["function"]["arguments"] == '{"city": "NYC"}'
+    assert weather_call.call_id == "call_weather_456"
+    assert weather_call.name == "get_weather"
+    assert weather_call.arguments == {"city": "NYC"}

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -23,19 +23,6 @@ from kaggle_benchmarks.actors.llms import LLMResponse, OpenAI, _parse_think_tags
 from kaggle_benchmarks.prompting import handler
 
 
-@dataclass
-class MockFunction:
-    name: str
-    arguments: str
-
-
-@dataclass
-class MockToolCall:
-    id: str
-    function: MockFunction
-    type: str = "function"
-
-
 class MockedOpenAI(OpenAI):
     def __init__(self, model: str, **kwargs):
         super().__init__(client=None, model=model, **kwargs)
@@ -89,9 +76,7 @@ class MockedOpenAIWithToolCall(OpenAI):
         super().__init__(client=None, model="mock-tool-caller", **kwargs)
 
     def _call_api(self, messages, **kwargs):
-        # Real OpenAI._call_api wraps tool calls with `t.model_dump()` (see
-        # llms.py:551), producing OpenAI-style dicts. The mock mirrors that
-        # shape so respond()'s normalization sees the same input as production.
+        # Mirrors real _call_api shape: dicts (post-model_dump), not SDK objects.
         return LLMResponse(
             content="",
             tool_calls=[
@@ -491,7 +476,6 @@ def test_llm_extracts_tool_calls():
         actors.user.send("call a tool")
         response_msg = llm.respond()
 
-    # respond() normalizes raw OpenAI dicts → typed ToolInvocation.
     assert response_msg.tool_calls is not None
     assert len(response_msg.tool_calls) == 1
     [tc] = response_msg.tool_calls
@@ -510,8 +494,6 @@ def test_streaming_accumulates_tool_calls():
 
     assert response_msg.content == "Okay, calculating..."
 
-    # _update_from_tool_call_chunk accumulates dicts as chunks stream in;
-    # stream()'s finalize pass converts them to ToolInvocation at end.
     final_tool_calls = response_msg.tool_calls
     assert final_tool_calls is not None
     assert len(final_tool_calls) == 1

--- a/tests/test_tool_loop.py
+++ b/tests/test_tool_loop.py
@@ -84,6 +84,7 @@ def _make_tool_call_response(
 @pytest.mark.parametrize(
     "api_dict, expected_name, expected_args, expected_id",
     [
+        # Happy paths: dict and string-encoded dict arguments.
         pytest.param(
             {"id": "c1", "function": {"name": "add", "arguments": {"a": 1, "b": 2}}},
             "add",
@@ -98,6 +99,7 @@ def _make_tool_call_response(
             "c2",
             id="string_arguments",
         ),
+        # Missing / null inputs → empty-args default.
         pytest.param(
             {"id": "c3", "function": {"name": "noop", "arguments": None}},
             "noop",
@@ -119,6 +121,37 @@ def _make_tool_call_response(
             None,
             id="missing_id",
         ),
+        # JSON "null" treated as no-args (parity with the missing-key default).
+        pytest.param(
+            {"id": "c5", "function": {"name": "f", "arguments": "null"}},
+            "f",
+            {},
+            "c5",
+            id="json_null_treated_as_no_args",
+        ),
+        # Malformed / non-dict JSON: kept as the raw string so invoke_tool
+        # can surface a clear error instead of crashing.
+        pytest.param(
+            {"id": "c6", "function": {"name": "f", "arguments": '{"a":'}},
+            "f",
+            '{"a":',
+            "c6",
+            id="malformed_json_kept_as_string",
+        ),
+        pytest.param(
+            {"id": "c7", "function": {"name": "f", "arguments": "[1, 2, 3]"}},
+            "f",
+            "[1, 2, 3]",
+            "c7",
+            id="json_list_kept_as_string",
+        ),
+        pytest.param(
+            {"id": "c8", "function": {"name": "f", "arguments": "42"}},
+            "f",
+            "42",
+            "c8",
+            id="json_scalar_kept_as_string",
+        ),
     ],
 )
 def test_from_api_dict(api_dict, expected_name, expected_args, expected_id):
@@ -129,75 +162,33 @@ def test_from_api_dict(api_dict, expected_name, expected_args, expected_id):
     assert invocation.call_id == expected_id
 
 
-def test_from_api_dict_captures_thought_fields():
-    """from_api_dict reads _thought_signature (bytes) and _thought (bool)
-    when present — these mirror google.genai types.Part for Gemini 3.x
-    multi-turn round-tripping."""
-    api_dict = {
-        "id": "c1",
-        "function": {"name": "add", "arguments": {"a": 1}},
-        "_thought_signature": b"sig-bytes",
-        "_thought": True,
-    }
-    invocation = ToolInvocation.from_api_dict(api_dict)
-    assert invocation.thought_signature == b"sig-bytes"
-    assert invocation.thought is True
-
-
-def test_from_api_dict_thought_fields_default_to_none():
-    """When _thought_signature / _thought are absent, fields default to None."""
-    api_dict = {"id": "c1", "function": {"name": "add", "arguments": {}}}
-    invocation = ToolInvocation.from_api_dict(api_dict)
-    assert invocation.thought_signature is None
-    assert invocation.thought is None
-
-
-def test_from_api_dict_malformed_json_kept_as_string():
-    """When `arguments` is a malformed JSON string (e.g., truncated streaming
-    output), from_api_dict keeps it as a string rather than raising."""
-    api_dict = {
-        "id": "c1",
-        "function": {"name": "add", "arguments": '{"a": 1, "b":'},  # truncated
-    }
-    invocation = ToolInvocation.from_api_dict(api_dict)
-    assert invocation.arguments == '{"a": 1, "b":'
-    assert isinstance(invocation.arguments, str)
-
-
 @pytest.mark.parametrize(
-    "args_str, expected_args",
+    "api_dict, expected_signature, expected_thought",
     [
-        pytest.param("[1, 2, 3]", "[1, 2, 3]", id="json_list_kept_as_string"),
-        pytest.param("42", "42", id="json_int_kept_as_string"),
-        pytest.param("false", "false", id="json_bool_kept_as_string"),
-        pytest.param('"hello"', '"hello"', id="json_string_kept_as_string"),
+        pytest.param(
+            {
+                "id": "c1",
+                "function": {"name": "f", "arguments": {}},
+                "_thought_signature": b"sig-bytes",
+                "_thought": True,
+            },
+            b"sig-bytes",
+            True,
+            id="present",
+        ),
+        pytest.param(
+            {"id": "c2", "function": {"name": "f", "arguments": {}}},
+            None,
+            None,
+            id="absent_defaults_to_none",
+        ),
     ],
 )
-def test_from_api_dict_non_dict_parse_kept_as_string(args_str, expected_args):
-    """When `arguments` parses as valid JSON but not to a dict (list, scalar,
-    nested string), from_api_dict keeps the raw string so invoke_tool can
-    surface a clear error instead of crashing downstream with AttributeError
-    when something tries to splat the arguments."""
-    api_dict = {"id": "c1", "function": {"name": "f", "arguments": args_str}}
+def test_from_api_dict_thought_fields(api_dict, expected_signature, expected_thought):
+    """Gemini 3.x carriers round-trip through _thought_signature / _thought keys."""
     invocation = ToolInvocation.from_api_dict(api_dict)
-    assert invocation.arguments == expected_args
-    assert isinstance(invocation.arguments, str)
-
-
-def test_from_api_dict_json_null_treated_as_no_args():
-    """`arguments: "null"` is JSON-valid but encodes a no-args call. Treat it
-    the same as a missing arguments key (default `{}`) rather than letting
-    None propagate into ToolInvocation."""
-    api_dict = {"id": "c1", "function": {"name": "f", "arguments": "null"}}
-    invocation = ToolInvocation.from_api_dict(api_dict)
-    assert invocation.arguments == {}
-
-
-def test_tool_invocation_accepts_string_arguments():
-    """ToolInvocation.arguments is widened to dict | str to accommodate the
-    JSONDecodeError fallback in from_api_dict."""
-    invocation = ToolInvocation(name="add", arguments='{"a": 1}', call_id="c1")
-    assert invocation.arguments == '{"a": 1}'
+    assert invocation.thought_signature == expected_signature
+    assert invocation.thought is expected_thought
 
 
 # ---------------------------------------------------------------------------
@@ -456,7 +447,8 @@ class _StreamingTruncatedToolLLM(actors.LLMChat):
                         index=0,
                         id="call_1",
                         function=SimpleNamespace(
-                            name="_add", arguments='{"a": 1, "b":'  # truncated
+                            name="_add",
+                            arguments='{"a": 1, "b":',  # truncated
                         ),
                     )
                 ],
@@ -488,13 +480,9 @@ def test_truncated_streaming_json_surfaces_clean_error_end_to_end():
 
         # The forked tool-loop chat hangs off the parent chat. Walk into it
         # to find the tool-result message with the parse error.
-        tool_loop = next(
-            item for item in chat.history if isinstance(item, chats.Chat)
-        )
+        tool_loop = next(item for item in chat.history if isinstance(item, chats.Chat))
         tool_results = [
-            m
-            for m in tool_loop.history
-            if isinstance(m.content, ToolInvocationResult)
+            m for m in tool_loop.history if isinstance(m.content, ToolInvocationResult)
         ]
         assert len(tool_results) == 1
         result = tool_results[0].content

--- a/tests/test_tool_loop.py
+++ b/tests/test_tool_loop.py
@@ -14,10 +14,13 @@
 
 """Tests for the tool invocation loop in LLMChat.prompt()."""
 
+from types import SimpleNamespace
+
 import pydantic
 import pytest
 
-from kaggle_benchmarks import assertions, chats
+from kaggle_benchmarks import actors, assertions, chats
+from kaggle_benchmarks.actors.llms import LLMResponse
 from kaggle_benchmarks.llm_messages import LLMMessage
 from kaggle_benchmarks.tools.base import (
     ToolInvocation,
@@ -59,18 +62,18 @@ def _make_tool_call_response(
 ) -> LLMMessage[str]:
     """Creates an LLMMessage that simulates a tool call from the LLM.
 
-    Populates _meta["tool_calls"] with the OpenAI-style dict format that
-    native_tool_agent expects.
+    Populates the typed `tool_calls` field with a ToolInvocation. We can't
+    use _meta["tool_calls"] here: MockedChat hits respond()'s LLMMessage
+    branch which does not normalize _meta, and LLMMessage's typed
+    tool_calls field shadows the Message.tool_calls property shim.
     """
-    msg = LLMMessage(sender=None, content="")
-    msg._meta["tool_calls"] = [
-        {
-            "id": call_id,
-            "type": "function",
-            "function": {"name": name, "arguments": arguments},
-        }
-    ]
-    return msg
+    return LLMMessage(
+        sender=None,
+        content="",
+        tool_calls=[
+            ToolInvocation(name=name, arguments=arguments or {}, call_id=call_id)
+        ],
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -124,6 +127,77 @@ def test_from_api_dict(api_dict, expected_name, expected_args, expected_id):
     assert invocation.name == expected_name
     assert invocation.arguments == expected_args
     assert invocation.call_id == expected_id
+
+
+def test_from_api_dict_captures_thought_fields():
+    """from_api_dict reads _thought_signature (bytes) and _thought (bool)
+    when present — these mirror google.genai types.Part for Gemini 3.x
+    multi-turn round-tripping."""
+    api_dict = {
+        "id": "c1",
+        "function": {"name": "add", "arguments": {"a": 1}},
+        "_thought_signature": b"sig-bytes",
+        "_thought": True,
+    }
+    invocation = ToolInvocation.from_api_dict(api_dict)
+    assert invocation.thought_signature == b"sig-bytes"
+    assert invocation.thought is True
+
+
+def test_from_api_dict_thought_fields_default_to_none():
+    """When _thought_signature / _thought are absent, fields default to None."""
+    api_dict = {"id": "c1", "function": {"name": "add", "arguments": {}}}
+    invocation = ToolInvocation.from_api_dict(api_dict)
+    assert invocation.thought_signature is None
+    assert invocation.thought is None
+
+
+def test_from_api_dict_malformed_json_kept_as_string():
+    """When `arguments` is a malformed JSON string (e.g., truncated streaming
+    output), from_api_dict keeps it as a string rather than raising."""
+    api_dict = {
+        "id": "c1",
+        "function": {"name": "add", "arguments": '{"a": 1, "b":'},  # truncated
+    }
+    invocation = ToolInvocation.from_api_dict(api_dict)
+    assert invocation.arguments == '{"a": 1, "b":'
+    assert isinstance(invocation.arguments, str)
+
+
+@pytest.mark.parametrize(
+    "args_str, expected_args",
+    [
+        pytest.param("[1, 2, 3]", "[1, 2, 3]", id="json_list_kept_as_string"),
+        pytest.param("42", "42", id="json_int_kept_as_string"),
+        pytest.param("false", "false", id="json_bool_kept_as_string"),
+        pytest.param('"hello"', '"hello"', id="json_string_kept_as_string"),
+    ],
+)
+def test_from_api_dict_non_dict_parse_kept_as_string(args_str, expected_args):
+    """When `arguments` parses as valid JSON but not to a dict (list, scalar,
+    nested string), from_api_dict keeps the raw string so invoke_tool can
+    surface a clear error instead of crashing downstream with AttributeError
+    when something tries to splat the arguments."""
+    api_dict = {"id": "c1", "function": {"name": "f", "arguments": args_str}}
+    invocation = ToolInvocation.from_api_dict(api_dict)
+    assert invocation.arguments == expected_args
+    assert isinstance(invocation.arguments, str)
+
+
+def test_from_api_dict_json_null_treated_as_no_args():
+    """`arguments: "null"` is JSON-valid but encodes a no-args call. Treat it
+    the same as a missing arguments key (default `{}`) rather than letting
+    None propagate into ToolInvocation."""
+    api_dict = {"id": "c1", "function": {"name": "f", "arguments": "null"}}
+    invocation = ToolInvocation.from_api_dict(api_dict)
+    assert invocation.arguments == {}
+
+
+def test_tool_invocation_accepts_string_arguments():
+    """ToolInvocation.arguments is widened to dict | str to accommodate the
+    JSONDecodeError fallback in from_api_dict."""
+    invocation = ToolInvocation(name="add", arguments='{"a": 1}', call_id="c1")
+    assert invocation.arguments == '{"a": 1}'
 
 
 # ---------------------------------------------------------------------------
@@ -192,6 +266,17 @@ def test_invoke_tool_success_sets_output():
 
     assert result.output == 7.0
     assert result.error is None
+
+
+def test_invoke_tool_string_arguments_set_error():
+    """When arguments is a string (from from_api_dict's JSONDecodeError
+    fallback), invoke_tool surfaces an error rather than crashing."""
+    invocation = ToolInvocation(name="_add", arguments='{"a": 1, "b":')
+    result = invoke_tool(invocation, [_add])
+
+    assert result.error is not None
+    assert "arguments" in result.error.lower()
+    assert result.output is None
 
 
 # ---------------------------------------------------------------------------
@@ -322,22 +407,16 @@ def test_none_arguments_handled():
 
 def test_multiple_tool_calls_in_single_response():
     """When the LLM requests multiple tools at once, all are invoked."""
-    msg = LLMMessage(sender=None, content="")
-    msg._meta["tool_calls"] = [
-        {
-            "id": "call_1",
-            "type": "function",
-            "function": {"name": "_add", "arguments": {"a": 1, "b": 2}},
-        },
-        {
-            "id": "call_2",
-            "type": "function",
-            "function": {
-                "name": "_multiply",
-                "arguments": {"a": 3, "b": 4},
-            },
-        },
-    ]
+    msg = LLMMessage(
+        sender=None,
+        content="",
+        tool_calls=[
+            ToolInvocation(name="_add", arguments={"a": 1, "b": 2}, call_id="call_1"),
+            ToolInvocation(
+                name="_multiply", arguments={"a": 3, "b": 4}, call_id="call_2"
+            ),
+        ],
+    )
     final_response = LLMMessage(sender=None, content="1+2=3, 3*4=12")
 
     llm = MockedChat(responses=[msg, final_response])
@@ -357,6 +436,73 @@ def test_tool_not_found_through_loop():
     result = llm.prompt("Call the tool.", tools=[_add])
 
     assert result == "That tool doesn't exist."
+
+
+class _StreamingTruncatedToolLLM(actors.LLMChat):
+    """Streams a single tool-call chunk whose arguments JSON is truncated —
+    exercises the full defensive chain: stream() → _finalize_tool_calls →
+    from_api_dict's JSONDecodeError fallback → invoke_tool's str-arg branch."""
+
+    def __init__(self):
+        super().__init__(name="StreamingTruncated")
+        self.stream_responses = True
+
+    def invoke(self, messages, system=None, **kwargs):
+        def chunks():
+            yield LLMResponse(
+                content="",
+                tool_calls=[
+                    SimpleNamespace(
+                        index=0,
+                        id="call_1",
+                        function=SimpleNamespace(
+                            name="_add", arguments='{"a": 1, "b":'  # truncated
+                        ),
+                    )
+                ],
+            )
+
+        return chunks()
+
+
+def test_truncated_streaming_json_surfaces_clean_error_end_to_end():
+    """End-to-end: a model that streams malformed tool-call JSON does not
+    crash the tool loop. The truncated string is preserved through
+    _finalize_tool_calls, invoke_tool produces a ToolInvocationResult with
+    `error` set, and that error message lands in the chat history.
+
+    Guards against regressions across three layers — from_api_dict,
+    invoke_tool, and the streaming finalize — by exercising the full chain
+    in one assertion."""
+    llm = _StreamingTruncatedToolLLM()
+
+    with chats.new("Truncated JSON loop") as chat:
+        # max_tool_rounds=1 keeps the test tight; the model keeps returning
+        # the same broken call so the loop exhausts after one round.
+        with pytest.raises(ToolInvocationLimitExhausted):
+            llm.prompt(
+                "Compute 1+2",
+                tools=[_add],
+                extra_api_params={"max_tool_rounds": 1},
+            )
+
+        # The forked tool-loop chat hangs off the parent chat. Walk into it
+        # to find the tool-result message with the parse error.
+        tool_loop = next(
+            item for item in chat.history if isinstance(item, chats.Chat)
+        )
+        tool_results = [
+            m
+            for m in tool_loop.history
+            if isinstance(m.content, ToolInvocationResult)
+        ]
+        assert len(tool_results) == 1
+        result = tool_results[0].content
+        assert result.error is not None
+        assert "could not be parsed as JSON" in result.error
+        # The raw truncated string must round-trip through the error, so an
+        # operator can see exactly what the model emitted.
+        assert '{"a": 1, "b":' in result.error
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_loop.py
+++ b/tests/test_tool_loop.py
@@ -60,13 +60,8 @@ def _make_tool_call_response(
     arguments: dict | None = None,
     call_id: str = "call_1",
 ) -> LLMMessage[str]:
-    """Creates an LLMMessage that simulates a tool call from the LLM.
-
-    Populates the typed `tool_calls` field with a ToolInvocation. We can't
-    use _meta["tool_calls"] here: MockedChat hits respond()'s LLMMessage
-    branch which does not normalize _meta, and LLMMessage's typed
-    tool_calls field shadows the Message.tool_calls property shim.
-    """
+    """Simulates an LLM tool call via LLMMessage's typed tool_calls field
+    (the LLMMessage branch of respond() doesn't normalize _meta)."""
     return LLMMessage(
         sender=None,
         content="",
@@ -84,7 +79,6 @@ def _make_tool_call_response(
 @pytest.mark.parametrize(
     "api_dict, expected_name, expected_args, expected_id",
     [
-        # Happy paths: dict and string-encoded dict arguments.
         pytest.param(
             {"id": "c1", "function": {"name": "add", "arguments": {"a": 1, "b": 2}}},
             "add",
@@ -99,7 +93,6 @@ def _make_tool_call_response(
             "c2",
             id="string_arguments",
         ),
-        # Missing / null inputs → empty-args default.
         pytest.param(
             {"id": "c3", "function": {"name": "noop", "arguments": None}},
             "noop",
@@ -121,7 +114,6 @@ def _make_tool_call_response(
             None,
             id="missing_id",
         ),
-        # JSON "null" treated as no-args (parity with the missing-key default).
         pytest.param(
             {"id": "c5", "function": {"name": "f", "arguments": "null"}},
             "f",
@@ -129,8 +121,7 @@ def _make_tool_call_response(
             "c5",
             id="json_null_treated_as_no_args",
         ),
-        # Malformed / non-dict JSON: kept as the raw string so invoke_tool
-        # can surface a clear error instead of crashing.
+        # Non-dict JSON kept as raw string; invoke_tool surfaces the error.
         pytest.param(
             {"id": "c6", "function": {"name": "f", "arguments": '{"a":'}},
             "f",
@@ -155,7 +146,6 @@ def _make_tool_call_response(
     ],
 )
 def test_from_api_dict(api_dict, expected_name, expected_args, expected_id):
-    """ToolInvocation.from_api_dict handles various argument formats."""
     invocation = ToolInvocation.from_api_dict(api_dict)
     assert invocation.name == expected_name
     assert invocation.arguments == expected_args
@@ -185,7 +175,6 @@ def test_from_api_dict(api_dict, expected_name, expected_args, expected_id):
     ],
 )
 def test_from_api_dict_thought_fields(api_dict, expected_signature, expected_thought):
-    """Gemini 3.x carriers round-trip through _thought_signature / _thought keys."""
     invocation = ToolInvocation.from_api_dict(api_dict)
     assert invocation.thought_signature == expected_signature
     assert invocation.thought is expected_thought
@@ -260,8 +249,6 @@ def test_invoke_tool_success_sets_output():
 
 
 def test_invoke_tool_string_arguments_set_error():
-    """When arguments is a string (from from_api_dict's JSONDecodeError
-    fallback), invoke_tool surfaces an error rather than crashing."""
     invocation = ToolInvocation(name="_add", arguments='{"a": 1, "b":')
     result = invoke_tool(invocation, [_add])
 
@@ -430,9 +417,7 @@ def test_tool_not_found_through_loop():
 
 
 class _StreamingTruncatedToolLLM(actors.LLMChat):
-    """Streams a single tool-call chunk whose arguments JSON is truncated —
-    exercises the full defensive chain: stream() → _finalize_tool_calls →
-    from_api_dict's JSONDecodeError fallback → invoke_tool's str-arg branch."""
+    """Streams a tool-call chunk with truncated arguments JSON."""
 
     def __init__(self):
         super().__init__(name="StreamingTruncated")
@@ -447,8 +432,7 @@ class _StreamingTruncatedToolLLM(actors.LLMChat):
                         index=0,
                         id="call_1",
                         function=SimpleNamespace(
-                            name="_add",
-                            arguments='{"a": 1, "b":',  # truncated
+                            name="_add", arguments='{"a": 1, "b":'
                         ),
                     )
                 ],
@@ -458,19 +442,10 @@ class _StreamingTruncatedToolLLM(actors.LLMChat):
 
 
 def test_truncated_streaming_json_surfaces_clean_error_end_to_end():
-    """End-to-end: a model that streams malformed tool-call JSON does not
-    crash the tool loop. The truncated string is preserved through
-    _finalize_tool_calls, invoke_tool produces a ToolInvocationResult with
-    `error` set, and that error message lands in the chat history.
-
-    Guards against regressions across three layers — from_api_dict,
-    invoke_tool, and the streaming finalize — by exercising the full chain
-    in one assertion."""
+    """End-to-end chain: stream → finalize → invoke_tool surfaces error."""
     llm = _StreamingTruncatedToolLLM()
 
     with chats.new("Truncated JSON loop") as chat:
-        # max_tool_rounds=1 keeps the test tight; the model keeps returning
-        # the same broken call so the loop exhausts after one round.
         with pytest.raises(ToolInvocationLimitExhausted):
             llm.prompt(
                 "Compute 1+2",
@@ -478,8 +453,6 @@ def test_truncated_streaming_json_surfaces_clean_error_end_to_end():
                 extra_api_params={"max_tool_rounds": 1},
             )
 
-        # The forked tool-loop chat hangs off the parent chat. Walk into it
-        # to find the tool-result message with the parse error.
         tool_loop = next(item for item in chat.history if isinstance(item, chats.Chat))
         tool_results = [
             m for m in tool_loop.history if isinstance(m.content, ToolInvocationResult)
@@ -488,8 +461,6 @@ def test_truncated_streaming_json_surfaces_clean_error_end_to_end():
         result = tool_results[0].content
         assert result.error is not None
         assert "could not be parsed as JSON" in result.error
-        # The raw truncated string must round-trip through the error, so an
-        # operator can see exactly what the model emitted.
         assert '{"a": 1, "b":' in result.error
 
 


### PR DESCRIPTION
## What

Normalizes `_meta["tool_calls"]` from raw OpenAI-format dicts to typed `ToolInvocation` objects. Fixes GenAI streaming silently dropping tool calls.

## Why

- **Bug fix:** GenAI streaming ignored `function_call` Parts — streaming tool use was broken.
- **Cleaner API:** Consumers use `.name`, `.arguments`, `.call_id` instead of `["function"]["name"]`, `["function"]["arguments"]`, `["id"]`.
- **Resilience:** Malformed streaming JSON no longer crashes; returns a clear error to the LLM.
- **Unblocks future work:** Typed `ToolInvocation` maps directly to a future `ToolCall` proto for run.json serialization.

## How

Two conversion points, same outcome:
- **Non-streaming:** `respond()` converts dicts → `ToolInvocation` via `from_api_dict()` right after `_call_api()` returns.
- **Streaming:** `stream()` accumulates JSON fragments as dicts, then `_finalize_tool_calls()` converts them after the loop ends.

## Scope

Only affects tool calling. No changes to text content, usage/cost/latency, reasoning traces, or serialization to run.json. Breaking change for code accessing `tool_calls` with dict syntax (`tool_call["function"]["name"]` → `tool_call.name`).

## Relation to full LLMMessage migration

There's a broader plan to replace `Message` + `_meta` with `LLMMessage` (typed fields for tools, usage, reasoning). This PR extracts just the tool-call normalization because:

- **Lower risk of changes:** Only changes what `_meta["tool_calls"]` contains — no message type change, no serializer rerouting, no `usage` field/property shadowing to untangle.
- **Independently valuable:** The streaming bug fix and typed tool-call API are useful regardless of whether the full migration happens.
- **Non-blocking:** Doesn't preclude or conflict with the full migration — it pre-completes the tool-call portion.

[The full migration](http://docs/document/d/1n0zS3X1aTZYDfTiXcxAG5c-D3ZQHlTBgFoI0ntm3dPk?resourcekey=0-hDbqECwru-Q3-ERKyJzxyA&tab=t.0#heading=h.tsz4kbz6j85y) (switching to `LLMMessage` in chat history) is now **optional rather than urgent**. This PR addressed the biggest pain point (`tool_calls` as raw dicts). What remains — `reasoning_traces` and `usage` — already have working properties on `Message`. The full migration would add `isinstance(msg, LLMMessage)` type discrimination and eliminate `_meta` entirely, but those are code-hygiene wins, not functional gaps.
