### PR TITLE
[Internal Local Env] add run guardrail local environment to pass in only list[str] other than raw str

### DIFF
--- a/src/kaggle_benchmarks/envs/local.py
+++ b/src/kaggle_benchmarks/envs/local.py
@@ -53,12 +53,20 @@ class InternalUnsafeLocalEnvironment(mixins.TemporalDirectoryMixin):
             )
 
     def run(
-        self, command: list[str], input: str | None = None
+        self, command: str | list[str], input: str | None = None
     ) -> environment.RunResult:
         """Runs a command in the temporary directory.
 
-        ``command`` must be a list of argument strings (``argv`` form). String
-        commands are rejected to avoid a shell-injection foot-gun when callers
+        The goal of the ``list[str]`` runtime requirement is to enhance
+        security by eliminating the shell-injection attack surface that
+        ``shell=True`` string commands expose.
+
+        The signature accepts ``str | list[str]`` to match the
+        :class:`~kaggle_benchmarks.envs.environment.Environment` protocol, but
+        this implementation requires ``command`` to be a ``list[str]`` (argv
+        form) at runtime. Anything else — including strings and other
+        iterables like tuples or generators — raises ``TypeError``. The list
+        requirement prevents a shell-injection foot-gun when callers
         interpolate untrusted input. To intentionally invoke a shell, pass
         ``["bash", "-c", "<script>"]`` explicitly.
 
@@ -66,9 +74,9 @@ class InternalUnsafeLocalEnvironment(mixins.TemporalDirectoryMixin):
             No sandboxing is applied. The command has full access to the host
             filesystem and network.
         """
-        if isinstance(command, str):
+        if not isinstance(command, list):
             raise TypeError(
-                "command must be a list[str], not str. "
+                f"command must be a list[str], got {type(command).__name__}. "
                 "Pass arguments as a list (e.g. ['echo', 'hi']). "
                 "To run a shell pipeline, use ['bash', '-c', '<script>']."
             )

--- a/src/kaggle_benchmarks/envs/local.py
+++ b/src/kaggle_benchmarks/envs/local.py
@@ -29,8 +29,6 @@ class InternalUnsafeLocalEnvironment(mixins.TemporalDirectoryMixin):
 
         - Path traversal (e.g. ``../``) can escape the temporary directory and
           read/write anywhere the current user has access.
-        - String commands run with ``shell=True``, allowing shell metacharacter
-          injection.
 
         **Do not use this with untrusted or adversarial model outputs.** For
         isolated execution, use :class:`DockerEnvironment` instead.
@@ -55,17 +53,29 @@ class InternalUnsafeLocalEnvironment(mixins.TemporalDirectoryMixin):
             )
 
     def run(
-        self, command: str | list[str], input: str | None = None
+        self, command: list[str], input: str | None = None
     ) -> environment.RunResult:
-        """Runs a shell command in the temporary directory.
+        """Runs a command in the temporary directory.
+
+        ``command`` must be a list of argument strings (``argv`` form). String
+        commands are rejected to avoid a shell-injection foot-gun when callers
+        interpolate untrusted input. To intentionally invoke a shell, pass
+        ``["bash", "-c", "<script>"]`` explicitly.
 
         .. warning::
             No sandboxing is applied. The command has full access to the host
             filesystem and network.
         """
+        if isinstance(command, str):
+            raise TypeError(
+                "command must be a list[str], not str. "
+                "Pass arguments as a list (e.g. ['echo', 'hi']). "
+                "To run a shell pipeline, use ['bash', '-c', '<script>']."
+            )
+
         result = subprocess.run(
             command,
-            shell=isinstance(command, str),
+            shell=False,
             input=input,
             cwd=self.temp_dir.name,
             capture_output=True,

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -34,19 +34,13 @@ envs = [
 @pytest.mark.parametrize(("cls", "params"), envs)
 def test_run(cls, params):
     with cls(**params) as env:
-        result = env.run("echo Hi")
+        result = env.run(["echo", "Hi"])
 
         assert result.exit_code == 0
         assert result.stdout.strip() == "Hi"
         assert result.stderr.strip() == ""
 
-        result = env.run("echo Hi".split())
-
-        assert result.exit_code == 0
-        assert result.stdout.strip() == "Hi"
-        assert result.stderr.strip() == ""
-
-        result = env.run("cat schrödinger")
+        result = env.run(["cat", "schrödinger"])
 
         assert result.exit_code != 0
         assert result.stdout.strip() == ""

--- a/tests/test_unsafe_local_environment.py
+++ b/tests/test_unsafe_local_environment.py
@@ -59,6 +59,25 @@ class TestInternalUnsafeLocalEnvironmentWarning:
                 with pytest.raises(TypeError, match="list"):
                     env.run("echo hello; touch /tmp/should_not_exist")
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            ("echo", "hi"),
+            (x for x in ["echo", "hi"]),
+        ],
+        ids=["tuple", "generator"],
+    )
+    def test_run_rejects_non_list_command(self, command):
+        """Non-list command containers (tuple, generator, etc.) must be rejected
+        even though subprocess.run would accept them. The list[str] requirement
+        is the contract — narrowing it to "any iterable" would let callers
+        forget the security rationale and start passing whatever they have."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with InternalUnsafeLocalEnvironment(_internal=True) as env:
+                with pytest.raises(TypeError, match="list"):
+                    env.run(command)
+
     def test_run_list_args_neutralize_shell_metacharacters(self, tmp_path):
         """Shell metacharacters interpolated into a list argument must be
         treated as literal text, not interpreted by a shell.

--- a/tests/test_unsafe_local_environment.py
+++ b/tests/test_unsafe_local_environment.py
@@ -47,6 +47,14 @@ class TestInternalUnsafeLocalEnvironmentWarning:
             warnings.simplefilter("ignore")
             for internal in (True, False):
                 with InternalUnsafeLocalEnvironment(_internal=internal) as env:
-                    result = env.run("echo hello")
+                    result = env.run(["echo", "hello"])
                     assert result.exit_code == 0
                     assert result.stdout.strip() == "hello"
+
+    def test_run_rejects_string_command(self):
+        """String commands must be rejected to prevent shell-injection foot-guns."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with InternalUnsafeLocalEnvironment(_internal=True) as env:
+                with pytest.raises(TypeError, match="list"):
+                    env.run("echo hello; touch /tmp/should_not_exist")

--- a/tests/test_unsafe_local_environment.py
+++ b/tests/test_unsafe_local_environment.py
@@ -58,3 +58,35 @@ class TestInternalUnsafeLocalEnvironmentWarning:
             with InternalUnsafeLocalEnvironment(_internal=True) as env:
                 with pytest.raises(TypeError, match="list"):
                     env.run("echo hello; touch /tmp/should_not_exist")
+
+    def test_run_list_args_neutralize_shell_metacharacters(self, tmp_path):
+        """Shell metacharacters interpolated into a list argument must be
+        treated as literal text, not interpreted by a shell.
+
+        Regression test for Kaggle/kaggle-benchmarks#159: this is the actual
+        security guarantee the list[str] requirement provides — even if a
+        caller does ``env.run(["echo", untrusted_input])``, the metacharacters
+        in ``untrusted_input`` cannot spawn additional commands on the host.
+        """
+        marker = tmp_path / "injection_marker"
+        malicious = f"hello; touch {marker}"
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with InternalUnsafeLocalEnvironment(_internal=True) as env:
+                result = env.run(["echo", malicious])
+
+        assert result.exit_code == 0
+        assert malicious in result.stdout
+        assert not marker.exists(), "shell metacharacters were interpreted"
+
+    def test_run_explicit_shell_escape_hatch_still_works(self):
+        """Callers that explicitly opt into a shell (the documented migration
+        path for old string usage) must still be able to use shell features."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with InternalUnsafeLocalEnvironment(_internal=True) as env:
+                result = env.run(["bash", "-c", "echo one two three | wc -w"])
+
+        assert result.exit_code == 0
+        assert result.stdout.strip() == "3"


### PR DESCRIPTION
This is a follow-up of https://github.com/Kaggle/kaggle-benchmarks/issues/159 to avoid calling LocalEnvironment.run() with only raw strings to enhance security.

Note that LocalEnvironment is intended to only used by internal packages, not to be called by user code.

## Testing
Ran all tests (existing + new) and they are passing.