### PR TITLE
fix: raise error when participant.reply() is called in an empty chatroom

### DIFF
--- a/skills/kaggle-benchmarks/SKILL.md
+++ b/skills/kaggle-benchmarks/SKILL.md
@@ -815,6 +815,10 @@ Key behaviors to remember:
   - `participant.reply(schema=..., **kwargs)` — that participant's LLM generates
     a response. Must be called inside `with room:`. Supports `schema=` for
     structured output, same as `llm.prompt()`.
+  - **Always seed the room with `room.post(...)` before the first `reply()`.**
+    A participant cannot speak into a void: some providers (e.g. Gemini)
+    reject requests with no user message, and the framework raises
+    `RuntimeError` if you call `reply()` on an empty room.
 - **Perspective projection is automatic.** Each `reply()` rebuilds the system
   prompt and re-projects history so the calling participant sees its own
   messages as `assistant` and peers' messages as `user` with `[Name]:` prefixes.

--- a/src/kaggle_benchmarks/rooms.py
+++ b/src/kaggle_benchmarks/rooms.py
@@ -303,8 +303,19 @@ class ChatRoom(Chat):
                 f"intend to bring them back (which creates a new identity)."
             )
 
-        system = self._build_system_prompt(participant)
         perspective = self._build_perspective(participant)
+
+        if not perspective:
+            raise RuntimeError(
+                f"Cannot generate a reply for {participant.name!r}: the room "
+                f"has no messages visible to this participant yet. Post an "
+                f'opening message with room.post("...") before calling '
+                f"participant.reply(), or have another participant speak "
+                f"first. (Some providers, e.g. Gemini, reject requests that "
+                f"contain no user message.)"
+            )
+
+        system = self._build_system_prompt(participant)
 
         response = participant.llm.respond(
             system=system,

--- a/tests/test_chatroom.py
+++ b/tests/test_chatroom.py
@@ -135,6 +135,7 @@ def test_remove_participant_excludes_from_roster():
     room.remove_participant(bob)
 
     with room:
+        room.post("kickoff")
         alice.reply()
     _, kwargs = alice_mock.invocations[0]
     system = kwargs["system"]
@@ -152,6 +153,7 @@ def test_remove_participant_preserves_historical_messages():
     bob = room.add_participant(bob_mock)
 
     with room:
+        room.post("kickoff")
         bob.reply()
     room.remove_participant(bob)
 
@@ -226,13 +228,14 @@ def test_remove_then_readd_same_name_creates_distinct_identity():
 
     p1 = room.add_participant(alice_mock, name="Alice", avatar="👩")
     with room:
+        room.post("kickoff")
         p1.reply()  # "before"
     room.remove_participant(p1)
 
     # Same name allowed again
     p2 = room.add_participant(alice_mock, name="Alice", avatar="🧙")
     with room:
-        p2.reply()  # "after"
+        p2.reply()  # "after" — room already has history from above
 
     # Distinct objects with different avatars
     assert p1 is not p2
@@ -240,9 +243,9 @@ def test_remove_then_readd_same_name_creates_distinct_identity():
     assert p2.avatar == "🧙"
 
     # Both messages stay in the transcript, attributed to their respective
-    # Participant identities
-    assert room.messages[0].sender is p1
-    assert room.messages[1].sender is p2
+    # Participant identities. messages[0] is the kickoff post.
+    assert room.messages[1].sender is p1
+    assert room.messages[2].sender is p2
 
     # p1 can no longer reply (was removed); p2 can
     with room:
@@ -268,6 +271,23 @@ def test_llmchat_reply_appends_to_room():
     assert len(room.messages) == 2
     assert room.messages[1].sender.name == "Alice"
     assert room.messages[1].content == "I agree!"
+
+
+def test_participant_reply_in_empty_room_raises():
+    """Calling reply() before anything has been posted is a usage bug.
+
+    Some providers (e.g. Gemini via Vertex AI) reject requests whose
+    message list contains only a system prompt with
+    "at least one contents field is required". We fail fast at the room
+    layer with an actionable error pointing the user at room.post(...).
+    """
+    alice_mock = MockedChat.from_contents(["should-not-be-called"], name="Alice")
+    room = ChatRoom()
+    alice = room.add_participant(alice_mock)
+
+    with room:
+        with pytest.raises(RuntimeError, match=r"room\.post"):
+            alice.reply()
 
 
 def test_participant_reply_outside_room_raises():
@@ -369,6 +389,7 @@ def test_system_prompt_composition():
     room.add_participant(bob_mock, system_prompt="SECRET: You are a villager")
 
     with room:
+        room.post("kickoff")
         alice.reply()
 
     _, kwargs = alice_mock.invocations[0]
@@ -580,8 +601,10 @@ def test_meta_chat_points_to_room():
     room = ChatRoom()
     alice = room.add_participant(alice_mock)
     with room:
+        room.post("kickoff")
         alice.reply()
-    assert room.messages[0]._meta.get("chat") is room
+    # messages[0] is the kickoff post; messages[1] is alice's reply.
+    assert room.messages[1]._meta.get("chat") is room
 
 
 class MockedLLMResponseChat(actors.LLMChat):
@@ -626,9 +649,11 @@ def test_meta_llm_response_path():
     alice = room.add_participant(alice_mock)
 
     with room:
+        room.post("kickoff")
         alice.reply()
 
-    room_msg = room.messages[0]
+    # messages[0] is the kickoff post; messages[1] is alice's reply.
+    room_msg = room.messages[1]
     assert "input_tokens" in room_msg._meta
     assert room_msg._meta["input_tokens"] == 10
     assert room_msg._meta.get("chat") is room

--- a/user_guide.md
+++ b/user_guide.md
@@ -521,6 +521,14 @@ Inside `with room:` you only ever do two things:
   response is automatically added to the room transcript and attributed
   to the participant.
 
+> **The room must contain at least one visible message before any
+> `participant.reply()`.** Always open the room with `room.post(...)` so
+> the first speaking LLM has something to react to. A participant cannot
+> speak into a void: some providers (e.g. Gemini via Vertex AI) reject
+> requests that contain only a system prompt and no user message. If
+> you call `reply()` on an empty room, the framework raises
+> `RuntimeError` with a pointer to this rule.
+
 ``` python
 import kaggle_benchmarks as kbench
 


### PR DESCRIPTION
Context: [discord report](https://discord.com/channels/1101210829807956100/1475930354396303430/1518655319612588102)