### PR TITLE
Fix TemporalDirectoryMixin, preventing it from escaping to other directories

### DIFF
--- a/src/kaggle_benchmarks/envs/mixins.py
+++ b/src/kaggle_benchmarks/envs/mixins.py
@@ -22,9 +22,23 @@ class TemporalDirectoryMixin:
         self.temp_dir = tempfile.TemporaryDirectory()
         self.directory = Path(self.temp_dir.name)
 
-    def _check_path(self, path: str | Path):
+    def _resolve_checked_path(self, path: str | Path) -> Path:
+        """Resolve ``path`` relative to :attr:`directory` and verify it stays inside.
+
+        Rejects absolute paths and any relative path that escapes the
+        temporary directory via ``..`` traversal (see
+        Kaggle/kaggle-benchmarks#159).
+        """
         if os.path.isabs(path):
             raise ValueError(f"Absolute paths are not supported: {path}")
+
+        base = self.directory.resolve()
+        candidate = (base / path).resolve()
+
+        if candidate != base and base not in candidate.parents:
+            raise ValueError(f"Path escapes temporary directory: {path}")
+
+        return candidate
 
     def __getitem__(self, path: str | Path) -> str:
         """Read the content of a file in the temporary directory."""
@@ -32,17 +46,13 @@ class TemporalDirectoryMixin:
             return file.read()
 
     def __setitem__(self, path: str | Path, content: str):
-        """Read the content of a file in the temporary directory."""
-        self._check_path(path)
-
-        full_path = self.directory / path
+        """Write ``content`` to a file in the temporary directory."""
+        full_path = self._resolve_checked_path(path)
         full_path.parent.mkdir(exist_ok=True)
 
-        with self.open(path, "w") as file:
+        with open(full_path, "w") as file:
             file.write(content)
 
     def open(self, path: str | Path, mode: str = "r"):
-        self._check_path(path)
-
-        full_path = self.directory / path
+        full_path = self._resolve_checked_path(path)
         return open(full_path, mode=mode)

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -74,3 +74,51 @@ def test_absolute_path(cls, params):
 
         with pytest.raises(ValueError):
             env["/cage"] = "test"
+
+
+@pytest.mark.parametrize(("cls", "params"), envs)
+@pytest.mark.parametrize(
+    "path",
+    [
+        "../escape",
+        "../../escape",
+        "subfolder/../../escape",
+        "./../escape",
+    ],
+    ids=["parent", "grandparent", "nested-traversal", "dot-parent"],
+)
+def test_parent_traversal_rejected(cls, params, path, tmp_path, monkeypatch):
+    """Regression test for Kaggle/kaggle-benchmarks#159.
+
+    Relative ``..`` traversal must not be able to escape the environment's
+    temporary directory, even when the resolved path would land in a
+    directory the current user has write access to.
+    """
+    # Point traversal at a scratch directory we own so a buggy implementation
+    # would actually succeed in writing/reading there, making the test a true
+    # positive rather than incidentally passing on a permission error.
+    monkeypatch.chdir(tmp_path)
+
+    with cls(**params) as env:
+        with pytest.raises(ValueError):
+            env[path] = "escaped"
+
+        with pytest.raises(ValueError):
+            env[path]
+
+        with pytest.raises(ValueError):
+            env.open(path, "w")
+
+
+@pytest.mark.parametrize(("cls", "params"), envs)
+def test_setitem_does_not_write_outside_directory(cls, params, tmp_path, monkeypatch):
+    """Even if the ValueError check were skipped, no file should land outside
+    the environment's temp directory."""
+    monkeypatch.chdir(tmp_path)
+    marker_name = "kbench_path_escape_marker"
+
+    with cls(**params) as env:
+        with pytest.raises(ValueError):
+            env[f"../{marker_name}"] = "escaped"
+
+    assert not (tmp_path / marker_name).exists()


### PR DESCRIPTION
Final PR for https://github.com/Kaggle/kaggle-benchmarks/issues/159 

Add full-path resolution to check if the "cd" operation is within the current temp direcotry.

## Testing
Testing both local and docker environment - please note that the TemporalDirectoryMixin only operates in the host machine and not in the docker folders (i.e. the file operation in the temp folder always happens in the host machine). So we will need tests to cover docker environment as well.