### PR TITLE
Rebase base Docker image on full python:3.11

### DIFF
--- a/cicd/Dockerfile.base
+++ b/cicd/Dockerfile.base
@@ -1,6 +1,6 @@
 # Create an image that will run personal benchmarks on Kaggle
 # BASE LAYER: Contains OS, system deps, and third-party libraries.
-FROM python:3.11-slim
+FROM python:3.11
 
 COPY --from=ghcr.io/astral-sh/uv:0.6.14 /uv /uvx /bin/
 


### PR DESCRIPTION
Now that base image is cached, we don't have to worry about image size.

To make things easier for developers to have the basic tools (git, curl, etc), switch out the base image from `python:3.11-slim` to the full `python:3.11` image. 

Tested on unit tests, integration tests, and golden tests.

Follow up: update Dockerfile to point to v3 instead of v2.