### PR TITLE
fix: prevent premature REPL output collection for long-running executions

### DIFF
--- a/src/kaggle_benchmarks/tools/python.py
+++ b/src/kaggle_benchmarks/tools/python.py
@@ -14,6 +14,7 @@
 
 import queue
 import re
+import time
 from dataclasses import dataclass
 from typing import Literal
 
@@ -154,11 +155,13 @@ class IPythonREPL(actors.Actor):
         self, code: str, timeout: int = -1, input: str | None = None
     ) -> CellOutput:
         code = extract_code(code)
-        self.client.execute(code)
+        msg_id = self.client.execute(code)
 
         if input:
             self.client.input(input)
-        msgs = list(self._collect_iopub_messages())
+
+        iopub_timeout = None if timeout <= 0 else float(timeout)
+        msgs = list(self._collect_iopub_messages(msg_id, timeout=iopub_timeout))
 
         result = None
         for msg in msgs:
@@ -172,8 +175,15 @@ class IPythonREPL(actors.Actor):
             if m["msg_type"] == "error"
         ).strip()
 
-        # shell_msg = self.client.get_shell_msg(timeout=timeout)["content"]
-        # status = shell_msg["status"] is unrealiable
+        # Clean up the shell channel for this execution to prevent message leakage
+        while True:
+            try:
+                shell_msg = self.client.get_shell_msg(timeout=0.1)
+                if shell_msg.get("parent_header", {}).get("msg_id") == msg_id:
+                    break
+            except queue.Empty:
+                break
+
         status = "error" if traceback else "ok"
 
         return CellOutput(
@@ -185,11 +195,35 @@ class IPythonREPL(actors.Actor):
             traceback=traceback or None,
         )
 
-    def _collect_iopub_messages(self):
+    def _collect_iopub_messages(self, msg_id: str, timeout: float | None = None):
+        start_time = time.time()
         while True:
+            poll_timeout = 1.0
+            if timeout is not None:
+                elapsed = time.time() - start_time
+                remaining = timeout - elapsed
+                if remaining <= 0:
+                    break
+                poll_timeout = min(poll_timeout, remaining)
+
             try:
-                yield self.client.get_iopub_msg(timeout=1)
+                msg = self.client.get_iopub_msg(timeout=poll_timeout)
             except queue.Empty:
+                if timeout is not None and (time.time() - start_time) >= timeout:
+                    break
+                if not self.km.is_alive():
+                    raise RuntimeError("Kernel died during execution")
+                continue
+
+            if msg.get("parent_header", {}).get("msg_id") != msg_id:
+                continue
+
+            yield msg
+
+            if (
+                msg.get("msg_type") == "status"
+                and msg.get("content", {}).get("execution_state") == "idle"
+            ):
                 break
 
     def respond(self, **kwargs) -> CellOutput:

--- a/tests/tools/test_python.py
+++ b/tests/tools/test_python.py
@@ -157,3 +157,38 @@ print(y)
 
     assert out.status == "ok"
     assert out.stdout.strip() == "20"
+    repl.stop()
+
+
+def test_repl_long_running_sleep():
+    """Test that long-running executions with inactivity sleep do not terminate prematurely."""
+    repl = python.IPythonREPL()
+    try:
+        # Sleep for 1.5 seconds, which exceeds the old 1s timeout
+        out = repl.run_code("import time; time.sleep(1.5); print('done')")
+        assert out.status == "ok"
+        assert out.stdout.strip() == "done"
+    finally:
+        repl.stop()
+
+
+def test_repl_no_stale_message_pollution():
+    """Test that stale messages from a previous slow command do not contaminate a subsequent command."""
+    import time
+
+    repl = python.IPythonREPL()
+    try:
+        # This will time out on old code, returning immediately but leaving messages in the queue
+        # On fixed code, it blocks for 1.5s and returns 'first'
+        out1 = repl.run_code("import time; time.sleep(1.5); print('first')", timeout=1)
+        assert out1.stdout == ""
+
+        # Give it a moment to make sure the first execution actually prints 'first' if it was running in bg
+        time.sleep(1.0)
+
+        # Second run should only return 'second', and not include 'first'
+        out2 = repl.run_code("print('second')")
+        assert "first" not in out2.stdout
+        assert out2.stdout.strip() == "second"
+    finally:
+        repl.stop()


### PR DESCRIPTION
## Summary

This PR fixes a race condition in `IPythonREPL` where output from long-running code could be returned incorrectly.

Previously, if a code block didn't produce any IOPub messages for more than one second (for example, during `time.sleep()`, a network request, or a long computation), the REPL would stop collecting messages too early. As a result, the current execution could return incomplete output, and the remaining messages would appear during the next execution.

## Root Cause

`_collect_iopub_messages()` treated one second of inactivity as the end of execution.

However, a Jupyter kernel can continue running without sending any IOPub messages during that time. Since message collection stopped early, the remaining output and the final `status: idle` message stayed in the queue and were picked up by the next call to `run_code()`.

## Solution

This change updates the REPL to track the execution request using its `msg_id` and continue collecting messages until the matching `status: idle` message is received.

The implementation also:

- filters IOPub messages using the current execution's `parent_header.msg_id`
- periodically checks that the kernel is still alive while waiting
- cleans up the matching shell reply after execution

This ensures that outputs from different executions remain isolated and that long-running cells are handled correctly.

## Before

```python
out1 = repl.run_code("import time; time.sleep(2); print('hello')")
print(out1.stdout)
# ''

out2 = repl.run_code("print('world')")
print(out2.stdout)
# 'hello\n\nworld\n'