### PR TITLE
Fix typos in documentation example files

### DIFF
--- a/documentation/examples/demo_candidates_bm2.py
+++ b/documentation/examples/demo_candidates_bm2.py
@@ -315,7 +315,7 @@ def score_game(x_player, o_player, round):
             x_move = llm.prompt(
                 f"""I am playing tic-tac-toe.
                 It's my turn as player {game.current_player}.
-                What is the best next move (0-indexed)? Only give your answer in terms of of `col` and `row` and nothing else:\n```\n{game}\n```
+                What is the best next move (0-indexed)? Only give your answer in terms of `col` and `row` and nothing else:\n```\n{game}\n```
                 """,
                 schema=TicTacToeMove,
             )

--- a/documentation/examples/describe_image.py
+++ b/documentation/examples/describe_image.py
@@ -17,8 +17,8 @@
 # ## How to Send Images to LLM
 #
 # You can send images using a direct URL or a Base64 string. We also provide helper function to load a local image to base64.
-# - When using URL, the image image format is automatically guessed.
-# - When using Base64, you need specify the image format if it's different from default jpeg.
+# - When using URL, the image format is automatically guessed.
+# - When using Base64, you need to specify the image format if it's different from default jpeg.
 # - Use `from_path`` to load from local images.
 # %%
 import httpx

--- a/documentation/examples/prompt_with_tools.py
+++ b/documentation/examples/prompt_with_tools.py
@@ -17,7 +17,7 @@
 # title: Example of using `prompt` with `tools` parameter.
 # ---
 # - **Automatic tool calling is currently only supported via the `Gemini`` API**
-# - **For manual tool calling with with `OpenAI` API, please refer to the example in `use_calculator_tool.py`.**
+# - **For manual tool calling with `OpenAI` API, please refer to the example in `use_calculator_tool.py`.**
 
 # %%
 import kaggle_benchmarks as kbench


### PR DESCRIPTION
Correct four minor typos in the documentation examples (doubled
words and a missing "to") to improve readability.

---

Task: [addisonhoward-20260716182751-f508d432](https://agents.dev.kaggle.net/tasks/addisonhoward-20260716182751-f508d432)

### Prompt

Fix 4 typos in the kaggle-benchmarks repository (Kaggle/kaggle-benchmarks).

1. `documentation/examples/prompt_with_tools.py` line 20: "with with \`OpenAI\` API" → "with \`OpenAI\` API" (doubled "with")
2. `documentation/examples/describe_image.py` line 20: "image image format" → "image format" (doubled "image")
3. `documentation/examples/describe_image.py` line 21: "you need specify" → "you need to specify" (missing "to")
4. `documentation/examples/demo_candidates_bm2.py` line 318: "of of \`col\`" → "of \`col\`" (doubled "of")

