### PR TITLE
Fix Runs.as_dataframe() raising KeyError on empty Runs

### DIFF
--- a/src/kaggle_benchmarks/runs.py
+++ b/src/kaggle_benchmarks/runs.py
@@ -216,6 +216,8 @@ class Runs(Generic[T], abc.MutableSequence):
         return Runs([r for r in self.runs if r.status == utils.Status.FAILED])
 
     def as_dataframe(self) -> pd.DataFrame:
+        if not self.runs:
+            return pd.DataFrame().rename_axis("run_id")
         return pd.DataFrame(
             [
                 t.params

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -308,6 +308,29 @@ def test_runs_completed_and_errored_partition(monkeypatch):
     assert errored.status == utils.Status.FAILED
 
 
+def test_as_dataframe_returns_empty_when_no_runs(monkeypatch):
+    """Runs.as_dataframe() returns an empty DataFrame when there are no runs,
+    rather than raising KeyError trying to set the non-existent 'run_id' index.
+    """
+    monkeypatch.setattr(config, "continue_with_exceptions", True)
+
+    @tasks.task()
+    def always_fails(x: str) -> bool:
+        raise ValueError(f"intentional failure for {x}")
+
+    df = pd.DataFrame({"x": ["a", "b"]})
+    results = always_fails.evaluate(
+        evaluation_data=df,
+        on_failure="continue",
+        max_attempts=1,
+    )
+
+    assert len(results.completed_runs) == 0
+    empty_df = results.completed_runs.as_dataframe()
+    assert empty_df.empty
+    assert len(empty_df) == 0
+
+
 def test_run_passed_false_when_status_failed(monkeypatch):
     """Run.passed reports False when the run hit a general exception, regardless
     of result type's default `passed(value)` behavior.


### PR DESCRIPTION
## Summary
Fixes #179.

When zero runs completed (e.g. all subruns failed under `on_failure=\"continue\"`), `Runs.as_dataframe()` called `.set_index(\"run_id\")` on a column-less DataFrame and raised `KeyError: \"None of ['run_id'] are in the columns\"`. Now returns an empty DataFrame with a `run_id` index name, so callers can uniformly use `df.empty` / `len(df) == 0`.

## Test plan
- [x] Added `test_as_dataframe_returns_empty_when_no_runs` reproducing the reported scenario (all runs fail with `on_failure=\"continue\"`, then call `.completed_runs.as_dataframe()`). Verified it fails before the fix and passes after.
- [x] Full `tests/test_benchmarks.py` suite (40 tests) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)