### PR TITLE
fix: Guard llm tool calls against errors

### DIFF
--- a/cicd/build/cloudbuild_branch.yaml
+++ b/cicd/build/cloudbuild_branch.yaml
@@ -54,7 +54,7 @@ steps:
     name: "${_IMAGE_REPO_NAME}/${_IMAGE_NAME}:${COMMIT_SHA}"
     dir: /benchmarks
     entrypoint: uvx
-    args: ["ruff", "check"]
+    args: ["ruff@0.11.4", "check"]
     waitFor: ["push-image"]
 
 images:

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -89,6 +89,7 @@ import dataclasses
 import enum
 import inspect
 import json
+import logging
 import re
 import typing
 import uuid
@@ -106,6 +107,8 @@ from kaggle_benchmarks.serializers import genai as genai_serializer
 from kaggle_benchmarks.serializers import openai as openai_serializer
 from kaggle_benchmarks.tools import base as tool_utils
 from kaggle_benchmarks.tools import functions, native
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from kaggle_benchmarks import llm_messages
@@ -417,7 +420,12 @@ class OpenAI(LLMChat):
         }
 
     def _should_remove_seed(self) -> bool:
-        unsupported_prefixes = ("google/", "openai/gpt-5.4-pro", "openai/gpt-5.6", "xai/grok-4.5")
+        unsupported_prefixes = (
+            "google/",
+            "openai/gpt-5.4-pro",
+            "openai/gpt-5.6",
+            "xai/grok-4.5",
+        )
         return any(self.model.startswith(prefix) for prefix in unsupported_prefixes)
 
     def invoke(
@@ -527,6 +535,18 @@ class OpenAI(LLMChat):
             # Anthropic models proxied through the OpenAI endpoint can
             # return choices=None on multi-turn tool conversations).
             if not response.choices:
+                return LLMResponse(
+                    content="",
+                    meta=self._get_usage_meta(response.usage),
+                )
+            # Handle choices[0].message being None (observed intermittently
+            # from Model Proxy — see issue #191).
+            if response.choices[0].message is None:
+                logger.warning(
+                    "Model Proxy returned choices[0].message=None for "
+                    "model %s; treating as empty response.",
+                    self.model,
+                )
                 return LLMResponse(
                     content="",
                     meta=self._get_usage_meta(response.usage),

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -382,6 +382,62 @@ def test_extra_api_params_rejects_sdk_params():
         llm.prompt("Hi", seed=42, extra_api_params={"seed": 99})
 
 
+def test_call_api_handles_none_message(mocker, caplog):
+    """Empty response when choices[0].message is None (see issue #191).
+
+    Model Proxy has been observed to intermittently return a response where
+    choices[0].message is None. The library must not raise AttributeError
+    on message.tool_calls; it should degrade to an empty LLMResponse so the
+    native tool loop can terminate cleanly.
+    """
+    mock_client = mocker.MagicMock()
+
+    mock_usage = mocker.MagicMock()
+    mock_usage.prompt_tokens = 10
+    mock_usage.completion_tokens = 0
+
+    mock_choice = mocker.MagicMock()
+    mock_choice.message = None
+
+    mock_response = mocker.MagicMock(spec=[])
+    mock_response.choices = [mock_choice]
+    mock_response.usage = mock_usage
+
+    mock_client.chat.completions.create.return_value = mock_response
+
+    llm = OpenAI(client=mock_client, model="anthropic/claude-opus-5@default")
+    llm.stream_responses = False
+
+    with chats.new("Test None message"), caplog.at_level("WARNING"):
+        response = llm.prompt("Hi")
+
+    assert response == ""
+    assert any("choices[0].message=None" in record.message for record in caplog.records)
+
+
+def test_call_api_handles_empty_choices(mocker):
+    """Empty response when choices is empty (existing guard, now covered by a test)."""
+    mock_client = mocker.MagicMock()
+
+    mock_usage = mocker.MagicMock()
+    mock_usage.prompt_tokens = 10
+    mock_usage.completion_tokens = 0
+
+    mock_response = mocker.MagicMock(spec=[])
+    mock_response.choices = []
+    mock_response.usage = mock_usage
+
+    mock_client.chat.completions.create.return_value = mock_response
+
+    llm = OpenAI(client=mock_client, model="anthropic/claude-opus-5@default")
+    llm.stream_responses = False
+
+    with chats.new("Test empty choices"):
+        response = llm.prompt("Hi")
+
+    assert response == ""
+
+
 def test_prompt_reasoning_none_sets_effort_without_thinking_config():
     """Tests that reasoning='none' sets reasoning_effort but skips thinking_config."""
     llm = MockedOpenAI(model="test-model")


### PR DESCRIPTION
Model Proxy has been observed to intermittently return responses where choices[0].message is None (see #191). Accessing message.tool_calls in that state raised AttributeError and aborted the whole task with a non-descriptive traceback.

Extend the existing empty-choices guard to also cover message=None, returning an empty LLMResponse so the native tool loop terminates gracefully. Log a warning so operators can see when the proxy misbehaves.

Fixes #191