### PR TITLE
Nit fix: unlock permanently disabled tqdm bars

### DIFF
--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -94,13 +94,13 @@ import re
 import typing
 import uuid
 from types import SimpleNamespace
-from typing import Any, Callable, Iterator, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, TypeVar
 
 import openai
 from google import genai
 from google.genai import types
 
-from kaggle_benchmarks import actors, chats, llm_messages, messages, prompting, utils
+from kaggle_benchmarks import actors, chats, messages, prompting, utils
 from kaggle_benchmarks._config import config
 from kaggle_benchmarks.content_types import audios, images, videos
 from kaggle_benchmarks.serializers import genai as genai_serializer
@@ -109,6 +109,9 @@ from kaggle_benchmarks.tools import base as tool_utils
 from kaggle_benchmarks.tools import functions, native
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from kaggle_benchmarks import llm_messages
 
 T = TypeVar("T")
 ReasoningLevel = Literal["none", "low", "medium", "high"]
@@ -174,7 +177,7 @@ class LLMChat(actors.Actor):
         reasoning: ReasoningLevel | None = None,
         tools: list[Callable] | None = None,
         **kwargs,
-    ) -> LLMResponse | Iterator[LLMResponse] | llm_messages.LLMMessage[str]:
+    ) -> LLMResponse | Iterator[LLMResponse] | "llm_messages.LLMMessage[str]":
         """Invokes the LLM with the given messages and system instructions."""
         raise NotImplementedError
 

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -94,13 +94,13 @@ import re
 import typing
 import uuid
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, TypeVar
+from typing import Any, Callable, Iterator, Literal, TypeVar
 
 import openai
 from google import genai
 from google.genai import types
 
-from kaggle_benchmarks import actors, chats, messages, prompting, utils
+from kaggle_benchmarks import actors, chats, llm_messages, messages, prompting, utils
 from kaggle_benchmarks._config import config
 from kaggle_benchmarks.content_types import audios, images, videos
 from kaggle_benchmarks.serializers import genai as genai_serializer
@@ -109,9 +109,6 @@ from kaggle_benchmarks.tools import base as tool_utils
 from kaggle_benchmarks.tools import functions, native
 
 logger = logging.getLogger(__name__)
-
-if TYPE_CHECKING:
-    from kaggle_benchmarks import llm_messages
 
 T = TypeVar("T")
 ReasoningLevel = Literal["none", "low", "medium", "high"]
@@ -177,7 +174,7 @@ class LLMChat(actors.Actor):
         reasoning: ReasoningLevel | None = None,
         tools: list[Callable] | None = None,
         **kwargs,
-    ) -> LLMResponse | Iterator[LLMResponse] | "llm_messages.LLMMessage[str]":
+    ) -> LLMResponse | Iterator[LLMResponse] | llm_messages.LLMMessage[str]:
         """Invokes the LLM with the given messages and system instructions."""
         raise NotImplementedError
 

--- a/src/kaggle_benchmarks/orchestration/scheduling.py
+++ b/src/kaggle_benchmarks/orchestration/scheduling.py
@@ -66,7 +66,7 @@ def evaluate_function(
         parameters,
         desc="Parameters",
         colour="#777777",
-        disable=config.disable_tqdm or len(parameters) == 1,
+        disable=config.disable_tqdm() or len(parameters) == 1,
         leave=False,
     ):
         if evaluation_data is None:
@@ -100,6 +100,6 @@ def evaluate_function(
                     total=len(evaluation_data),
                     desc="Running subtasks",
                     colour="#888888",
-                    disable=config.disable_tqdm or len(evaluation_data) == 1,
+                    disable=config.disable_tqdm() or len(evaluation_data) == 1,
                     leave=False,
                 )

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -18,6 +18,7 @@ import time
 import pandas as pd
 
 from kaggle_benchmarks import orchestration
+from kaggle_benchmarks._config import ExecutionMode, config
 from kaggle_benchmarks.tasks import task
 
 
@@ -115,3 +116,30 @@ def test_parallel_subruns_are_nested_correctly():
     # Verify the results of the sub-runs
     subrun_results = [run.result for run in parent_run.subruns]
     assert sorted(subrun_results) == [10, 20, 30, 40]
+
+
+def test_tqdm_enabled_in_notebook_mode():
+    # config.disable_tqdm is a method; reading it without calling it yields a
+    # truthy bound method that silently disables every progress bar.
+    disable_flags = []
+
+    def recording_tqdm(iterable, **kwargs):
+        disable_flags.append(kwargs.get("disable"))
+        return iterable
+
+    original_mode = config.execution_mode
+    try:
+        config.execution_mode = ExecutionMode.NOTEBOOK
+        list(
+            orchestration.evaluate_function(
+                func=lambda a, x: (a, x),
+                grid={"a": [1, 2]},
+                evaluation_data=pd.DataFrame({"x": [1, 2]}),
+                tqdm=recording_tqdm,
+            )
+        )
+    finally:
+        config.execution_mode = original_mode
+
+    assert disable_flags
+    assert all(flag is False for flag in disable_flags)


### PR DESCRIPTION
[`config.disable_tqdm` is a method](https://github.com/Kaggle/kaggle-benchmarks/blob/ci/src/kaggle_benchmarks/_config.py#L288), but two `tqdm()` call sites in
`evaluate_function` read it as an attribute. The resulting bound method
is always truthy, so progress bars were unconditionally hidden even in
notebooks. A third call site in the same function already called it
correctly.

Adds a regression test for the tqdm bug, verified to fail without the
fix.

Co-authored-by: kaggle-agent <kaggle-agent@users.noreply.github.com>