### PR TITLE
refactor: introduce Actor/Event/Session base classes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@ This is a **library-first codebase** organized by functional concerns:
 - **LLM clients** → `src/kaggle_benchmarks/clients.py` (client abstraction and resolution)
 
 ### Subsystems
-- **Actor system** → `src/kaggle_benchmarks/actors/` (LLMChat, Actor base classes)
+- **Core objects** → `src/kaggle_benchmarks/core.py` (base classes `Actor`, `Event`, `BaseMessage`, `Session` + the `Status` enum; concrete types are `Message` in `messages.py`, `Chat`/`GoldfishChat` in `chats.py`, and the actors in `actors/base.py`. These are plain classes, not dataclasses.)
+- **Actor system** → `src/kaggle_benchmarks/actors/` (`LLMChat` in `llms.py`; concrete `Tool`/`system`/`user` actors in `base.py`; `Actor` base class in `core.py`)
 - **Tools** → `src/kaggle_benchmarks/tools/` (Python interpreter, web search)
 - **Execution environments** → `src/kaggle_benchmarks/envs/` (local, docker)
 - **Kaggle integration** → `src/kaggle_benchmarks/kaggle/` (model loading, serialization)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,8 +14,9 @@ The source lives in `src/kaggle_benchmarks/`. Here are the main subsystems — b
 
 | Subsystem | Key Modules | Responsibility |
 |-----------|------------|----------------|
-| **Core primitives** | `tasks.py`, `messages.py`, `runs.py`, `results.py` | Task/benchmark decorators, message types, execution records |
-| **LLM interaction** | `actors/` (incl. `llms.py`), `chats.py`, `prompting.py` | LLM abstraction (`LLMChat`, `OpenAI`, `GoogleGenAI`), conversation management, schema processing |
+| **Core objects** | `core.py`, `messages.py`, `chats.py`, `actors/base.py` | Base classes `Actor`/`Event`/`BaseMessage`/`Session` and the `Status` enum (`core.py`); their concrete types — `Message`, `Chat`/`GoldfishChat`, and the `Tool`/`system`/`user` actors |
+| **Core primitives** | `tasks.py`, `runs.py`, `results.py` | Task/benchmark decorators, execution records |
+| **LLM interaction** | `actors/llms.py`, `chats.py`, `prompting.py` | LLM abstraction (`LLMChat`, `OpenAI`, `GoogleGenAI`), conversation management, schema processing |
 | **Serialization** | `serializers/` | Translating messages to/from provider-specific API payloads |
 | **Content types** | `content_types/` | Provider-agnostic data models for images, audio, video |
 | **Configuration** | `_config.py` | Centralized `Config` dataclass, `ExecutionMode` enum |
@@ -44,6 +45,31 @@ Each layer has a single responsibility. Understanding which layer owns a piece o
 ---
 
 ## 2. Architecture & Design Principles
+
+### Core Objects: `Actor`, `Event`, `BaseMessage`, `Session`
+
+The library's core objects are defined together in `core.py`:
+
+- **`Actor`** — participates in a conversation and produces events (`send()`, `stream()`).
+- **`Event`** — a single item in a session's history; carries a `sender`, a `status`, and a unique `id`.
+- **`BaseMessage(Event)`** — a minimal event that carries `content`. Kept deliberately small (no usage/reasoning/tool-call state) so it — or `Event` — can serve as a lightweight type.
+- **`Session(Event)`** — an ordered list of `Event`s. Because `Session` subclasses `Event`, a session's `history` can hold both messages and nested sessions.
+
+The `Status` lifecycle enum also lives in `core` (`utils` re-exports it for backward compatibility).
+
+The full concrete types live in their own modules and subclass these bases:
+
+| Base | Concrete type(s) | Module |
+|------|------------------|--------|
+| `BaseMessage` (→ `Event`) | `Message` → `LLMMessage` | `messages.py`, `llm_messages.py` |
+| `Session` (→ `Event`) | `Chat` → `GoldfishChat` | `chats.py` |
+| `Actor` | `Tool`, `system`, `assertion`, `user` | `actors/base.py` |
+
+Keeping the bases together in `core.py` lets them reference each other directly, which removes the circular imports that otherwise arise between the concrete `Message`/`Actor`/`Chat` types. `core.py` imports only leaf modules at load time (`events`); `Message` is imported lazily where an `Actor` produces one, and referenced under `TYPE_CHECKING` for annotations.
+
+These core types are **plain classes, not dataclasses**: each concrete type defines an explicit `__init__` that calls `super().__init__`, so every event/session gets a stable `id` (a chat's `id` no longer changes when it's renamed) and consistent `sender`/`status` handling. `BaseMessage`/`Message` keep their positional `content`/`sender` constructor (e.g. `Message(content, sender=...)`).
+
+For backward compatibility the concrete types remain importable from their original locations — `messages.Message`, `actors.Actor`/`Tool`/`system`/`user`/`assertion`, `chats.Chat`/`GoldfishChat` — and `messages.BaseMessage`/`messages.Event` and `chats.Session` are also exposed.
 
 ### Content Types Are Provider-Agnostic
 
@@ -326,6 +352,8 @@ def respond(self, ...):
     from kaggle_benchmarks import contexts, llm_messages  # Lazy import
     ...
 ```
+
+The shared base classes (`Actor`, `Event`, `Session`) live together in `core.py` for the same reason — co-locating them lets the mutually-referential core types avoid importing one another at module load. See §2, "Core Objects".
 
 ### `TYPE_CHECKING` for Type-Only Imports
 

--- a/quick_start.md
+++ b/quick_start.md
@@ -68,11 +68,13 @@ Here are some core concepts for using the library effectively:
 - **`LLM`**: An object representing a large language model you can
   interact with. You can access available Kaggle models via
   `kbench.llms["vendor/model-name"]`.
-- **`Chat` and `Actor`**: The library represents interactions as a
-  conversation. When you call `llm.prompt()` or `kbench.user.send()`, a
-  `Message` is added to the current `Chat`. The `Actor` (e.g.,
-  `kbench.user` or an `LLM` instance) defines who is sending the
-  message.
+- **`Chat`, `Message`, and `Actor`**: The library represents interactions
+  as a conversation. When you call `llm.prompt()` or `kbench.user.send()`, a
+  `Message` is added to the current `Chat` — an ordered list of events that
+  can also contain nested chats. The `Actor` (e.g., `kbench.user` or an
+  `LLM` instance) defines who is sending the message. (Under the hood a
+  `Chat` is a `Session` and a `Message` is an `Event`; a session is a list
+  of events, and both live in `kaggle_benchmarks.core`.)
 - **`Assertion`**: A check to verify the model’s output. If an assertion
   fails, it’s recorded in the run results. You can make assertions using
   `kbench.assertions.assert_that(..., expectation)`, where `expectation`

--- a/src/kaggle_benchmarks/actors/base.py
+++ b/src/kaggle_benchmarks/actors/base.py
@@ -12,62 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable, Literal, TypeVar
+"""Concrete actors.
 
-from kaggle_benchmarks import utils
-from kaggle_benchmarks.messages import Message
+The abstract ``Actor`` base class lives in :mod:`kaggle_benchmarks.core`
+(alongside the other core objects) and is re-exported here. This module
+defines the concrete actor types and singletons.
+"""
 
-T = TypeVar("T")
+from kaggle_benchmarks.core import Actor
 
-
-class Actor:
-    def __init__(
-        self,
-        name: str | None = None,
-        role: Literal["system", "user", "assistant", "developer", "tool"] = "assistant",
-        avatar: str = "",
-        id: str | None = None,
-    ):
-        self.name = type(self).__name__ if name is None else name
-        self.id = id or name
-        self.role = role
-        self.avatar = avatar
-
-    def send(
-        self, message: T | Message[T], is_visible_to_llm: bool = True
-    ) -> Message[T]:
-        return self._send(message, is_visible_to_llm)
-
-    def _send(self, message: T | Message[T], is_visible_to_llm: bool) -> Message[T]:
-        from kaggle_benchmarks import chats
-
-        if isinstance(message, Message):
-            message.is_visible_to_llm = is_visible_to_llm
-        else:
-            message = Message(
-                sender=self, content=message, is_visible_to_llm=is_visible_to_llm
-            )
-
-        chats.send(message)
-        return message
-
-    def stream(self, content: Iterable[str]) -> Message[str]:
-        msg = Message(content="", sender=self, _status=utils.Status.RUNNING)
-        self.send(msg)
-        msg.stream(content)
-        msg.status = utils.Status.SUCCESS
-        return msg
-
-    def as_dict(self) -> dict[str, str]:
-        """Returns a dictionary representation of the agent."""
-        return dict(id=self.id, name=self.name, role=self.role, avatar=self.avatar)
-
-    def __repr__(self) -> str:
-        cls = type(self)
-        return f"{cls.__name__}(name={self.name!r}, avatar={self.avatar!r})"
-
-    def __str__(self) -> str:
-        return f"{self.avatar} {self.name}"
+__all__ = ["Actor", "Tool", "assertion", "system", "user"]
 
 
 class Tool(Actor):

--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -100,7 +100,7 @@ import openai
 from google import genai
 from google.genai import types
 
-from kaggle_benchmarks import actors, chats, messages, prompting, utils
+from kaggle_benchmarks import actors, chats, core, messages, prompting, utils
 from kaggle_benchmarks._config import config
 from kaggle_benchmarks.content_types import audios, images, videos
 from kaggle_benchmarks.serializers import genai as genai_serializer
@@ -319,7 +319,7 @@ class LLMChat(actors.Actor):
         response = messages.Message(
             sender=sender or self,
             content="",
-            _status=utils.Status.RUNNING,
+            _status=core.Status.RUNNING,
         )
 
         raw_messages = [
@@ -346,18 +346,18 @@ class LLMChat(actors.Actor):
                 response._meta["tool_calls"] = None
             response._meta.update(invoke_response.meta)
             response._meta["reasoning_traces"] = invoke_response.reasoning_traces
-            response.status = utils.Status.SUCCESS
+            response.status = core.Status.SUCCESS
             chat.append(response)
         elif isinstance(invoke_response, Iterator):
-            # Append before streaming so UIs see new_message (with empty
+            # Append before streaming so UIs see new_event (with empty
             # content + RUNNING status) before chunks arrive — lets them
             # render the message header before tokens stream in.
             chat.append(response)
             response.stream(invoke_response)
-            response.status = utils.Status.SUCCESS
+            response.status = core.Status.SUCCESS
         elif isinstance(invoke_response, llm_messages.LLMMessage):
             response = invoke_response
-            # Set sender before append: chat.append fires the new_message
+            # Set sender before append: chat.append fires the new_event
             # event, so the sender must already be the Participant (not the
             # backing LLMChat) by then.
             response.sender = sender or self
@@ -380,7 +380,7 @@ class LLMChat(actors.Actor):
                     sender=actors.system,
                 )
             )
-            response.status = utils.Status.FAILED
+            response.status = core.Status.FAILED
             raise e
 
         except StopIteration as e:

--- a/src/kaggle_benchmarks/assertions.py
+++ b/src/kaggle_benchmarks/assertions.py
@@ -538,7 +538,8 @@ def assert_tool_was_invoked(
                 if _find_in_chat(item):
                     return True
             elif (
-                isinstance(item.content, tool_utils.ToolInvocationResult)
+                isinstance(item, chats.Message)
+                and isinstance(item.content, tool_utils.ToolInvocationResult)
                 and item.content.name == tool_name
             ):
                 return True

--- a/src/kaggle_benchmarks/chats.py
+++ b/src/kaggle_benchmarks/chats.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import uuid
 from collections.abc import Iterable
 from typing import Iterator
 
@@ -70,10 +71,24 @@ class Chat(Session):
             status=status,
             id=id,
         )
+        # Preserve the historical name-derived id format ("<name>-<hex8>") for
+        # backward compatibility (e.g. serialized conversation ids). Event's
+        # __init__ assigns a bare uuid; override it when no explicit id is given.
+        if id is None:
+            self.id = f"{self.name}-{uuid.uuid4().hex[:8]}"
 
     @property
     def messages(self) -> list[Message]:
         return [m for m in self.history if isinstance(m, Message)]
+
+    def to_dict(self) -> dict:
+        """Returns a dictionary representation of the chat.
+
+        Emits the legacy ``messages`` key alongside the ``history`` key so that
+        consumers written before the Event refactor keep working.
+        """
+        serialized = [obj.to_dict() for obj in self.history]
+        return dict(messages=serialized, history=serialized, name=self.name)
 
     @property
     def usage(self) -> Usage:
@@ -98,7 +113,7 @@ class Chat(Session):
 class GoldfishChat(Chat):
     """A chat that keeps only the last message (useful for interactive mode)."""
 
-    @events.manager.event_dispatcher("new_event")
+    @events.manager.event_dispatcher("new_event", "new_message")
     def append(self, item: Event) -> Event:
         self.history = [item]
         return item

--- a/src/kaggle_benchmarks/chats.py
+++ b/src/kaggle_benchmarks/chats.py
@@ -12,35 +12,64 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Core classes and functions for representing and managing chats."""
+"""The ``Chat`` type and helpers for creating and managing chats.
+
+``Chat`` is a concrete :class:`kaggle_benchmarks.core.Session` — an ordered
+list of events (messages and nested chats). ``Session`` is re-exported here
+for convenience, and ``Message`` is re-exported so that ``chats.Message``
+keeps resolving.
+"""
+
+from __future__ import annotations
 
 import contextlib
-import dataclasses
 import functools
-import uuid
-from typing import Any, Iterator, Self
+from collections.abc import Iterable
+from typing import Iterator
 
-from kaggle_benchmarks import actors, events, utils
+from kaggle_benchmarks import actors, events
+from kaggle_benchmarks.core import Actor, Event, Session, Status
 from kaggle_benchmarks.messages import Message
 from kaggle_benchmarks.usage import Usage
 
+__all__ = [
+    "Chat",
+    "GoldfishChat",
+    "Message",
+    "Session",
+    "emits_message",
+    "fork",
+    "get_current_chat",
+    "last_reasoning_traces",
+    "new",
+    "send",
+]
 
-@dataclasses.dataclass
-class Chat:
+
+class Chat(Session):
     """Represents a thread of messages in a chat."""
 
-    history: list[Message | Self] = dataclasses.field(default_factory=list)
-    name: str = "chat"
-    _id_suffix: str = dataclasses.field(
-        default_factory=lambda: uuid.uuid4().hex[:8], init=False
-    )
-    sender: actors.Actor = actors.system  # added to mach Message's structural type
+    # Name dispatched by Event.status setter when this chat's status changes.
+    _status_event = "chat_update"
 
-    _status: utils.Status = utils.Status.PENDING
-
-    @property
-    def id(self) -> str:
-        return f"{self.name}-{self._id_suffix}"
+    def __init__(
+        self,
+        *,
+        history: Iterable[Event] = (),
+        name: str = "chat",
+        sender: Actor | None = None,
+        status: Status = Status.PENDING,
+        id: str | None = None,
+    ):
+        super().__init__(
+            history=history,
+            name=name,
+            # A chat carries a sender so it matches Message's structural type
+            # when it sits (nested) in another chat's history.
+            sender=actors.system if sender is None else sender,
+            status=status,
+            id=id,
+        )
 
     @property
     def messages(self) -> list[Message]:
@@ -55,15 +84,6 @@ class Chat:
                 total = total + m.usage
         return total
 
-    @property
-    def status(self):
-        return self._status
-
-    @status.setter
-    def status(self, value):
-        events.manager.dispatch("chat_update", self, value)
-        self._status = value
-
     def __panel__(self):
         from kaggle_benchmarks.ui import panel
 
@@ -74,26 +94,12 @@ class Chat:
 
         return panel.render_chat(self)._repr_mimebundle_(include, exclude)
 
-    @events.manager.event_dispatcher("new_message")
-    def append(self, item: Message | Self) -> Message | Self:
-        """Adds a message to the chat."""
-        self.history.append(item)
-        return item
-
-    def to_dict(self) -> dict[str, Any]:
-        """Returns a dictionary representation of the thread."""
-        return dict(messages=[obj.to_dict() for obj in self.history], name=self.name)
-
-    def __str__(self, indent: str = "") -> str:
-        messages = "\n".join(m.__str__(indent + "  ") for m in self.history)
-        return f"{indent}🧵{self.name or ''}:\n{messages}"
-
 
 class GoldfishChat(Chat):
     """A chat that keeps only the last message (useful for interactive mode)."""
 
-    @events.manager.event_dispatcher("new_message")
-    def append(self, item: Message | Self) -> Message | Self:
+    @events.manager.event_dispatcher("new_event")
+    def append(self, item: Event) -> Event:
         self.history = [item]
         return item
 

--- a/src/kaggle_benchmarks/contexts.py
+++ b/src/kaggle_benchmarks/contexts.py
@@ -38,7 +38,7 @@ import dataclasses
 from contextvars import ContextVar
 from typing import Iterator, Self
 
-from kaggle_benchmarks import chats, events, runs, utils
+from kaggle_benchmarks import chats, core, events, runs
 from kaggle_benchmarks.tasks import NonRecoverableError
 
 
@@ -67,15 +67,15 @@ def enter(**kwargs) -> Iterator[Context]:
     try:
         for key, value in kwargs.items():
             events.manager.dispatch(f"new_{key}", value)
-            value.status = utils.Status.RUNNING
+            value.status = core.Status.RUNNING
 
-        status = utils.Status.SUCCESS
+        status = core.Status.SUCCESS
         yield new
 
     except (NonRecoverableError, KeyboardInterrupt):
         raise
     except Exception:
-        status = utils.Status.FAILED
+        status = core.Status.FAILED
         # Re-raise it if we are within a run so the exception can be propagated.
         if parent and parent.run:
             raise

--- a/src/kaggle_benchmarks/core.py
+++ b/src/kaggle_benchmarks/core.py
@@ -212,7 +212,9 @@ class Session(Event):
         self.history = list(history)
         self.name = type(self).__name__ if name is None else name
 
-    @manager.event_dispatcher("new_event")
+    # "new_message" is dispatched alongside "new_event" for backward
+    # compatibility with listeners written before the Event refactor.
+    @manager.event_dispatcher("new_event", "new_message")
     def append(self, item: Event) -> Event:
         """Adds an event to the session."""
         self.history.append(item)

--- a/src/kaggle_benchmarks/core.py
+++ b/src/kaggle_benchmarks/core.py
@@ -1,0 +1,232 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Core base classes: ``Actor``, ``Event``, ``BaseMessage``, and ``Session``.
+
+These are the "core objects" the rest of the library is built on:
+
+* ``Actor``       — something that participates in a conversation and produces
+                    events. Concrete actors (``Tool``, ``system``, ``user`` …)
+                    live in :mod:`kaggle_benchmarks.actors.base`.
+* ``Event``       — a single item in a ``Session``'s history. Carries a
+                    ``sender``, a ``status`` and an ``id``.
+* ``BaseMessage`` — a minimal ``Event`` that carries ``content``. It is kept
+                    deliberately small (no usage/reasoning/tool-call fields) so
+                    it can be used as a lightweight type. The full concrete
+                    ``Message`` (in :mod:`kaggle_benchmarks.messages`) subclasses
+                    it and is what the library builds at runtime.
+* ``Session``     — an ordered list of ``Event`` objects. Because a ``Session``
+                    is itself an ``Event``, a session's history can hold both
+                    messages and nested sessions. ``Chat`` (in
+                    :mod:`kaggle_benchmarks.chats`) is the concrete session type.
+
+Keeping the bases here lets them reference each other directly without the
+circular imports that arise when the concrete ``Message``/``Chat``/``Actor``
+types import one another. This module imports only leaf modules at load time
+(``events`` for the dispatcher); the concrete ``Message`` is imported lazily
+inside the methods that build one (and under ``TYPE_CHECKING`` for annotations).
+
+``Status`` (the lifecycle enum) also lives here; ``utils`` re-exports it for
+backward compatibility.
+"""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Generic, Literal, TypeVar
+
+from kaggle_benchmarks.events import manager
+
+if TYPE_CHECKING:
+    from kaggle_benchmarks.messages import Message
+
+T = TypeVar("T")
+Role = Literal["system", "user", "assistant", "developer", "tool"]
+
+
+class Status(enum.StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCESS = "success"
+    FAILED = "failed"
+
+
+class Event:
+    """A single item in a ``Session``'s history — a message or a nested session.
+
+    Carries a ``sender``, a ``status`` and a unique ``id``. Subclasses set
+    ``_status_event`` to the name dispatched on the shared event manager when
+    their status changes (``Message`` uses ``"message_update"``; ``Chat`` uses
+    ``"chat_update"``).
+    """
+
+    # Event name dispatched when ``status`` is assigned. Overridden by subclasses.
+    _status_event: str = "event_update"
+
+    def __init__(
+        self,
+        *,
+        sender: Actor,
+        status: Status = Status.SUCCESS,
+        id: str | None = None,
+    ):
+        self.sender = sender
+        self._status = status
+        self.id = uuid.uuid4().hex if id is None else id
+
+    @property
+    def status(self):
+        return self._status
+
+    @status.setter
+    def status(self, value: Status):
+        manager.dispatch(self._status_event, self, value)
+        self._status = value
+
+    def to_dict(self) -> dict:
+        """Returns a dictionary representation of the event.
+
+        Concrete subclasses (``Message``, ``Session``) override this.
+        """
+        raise NotImplementedError
+
+    def __str__(self, indent: str = "") -> str:
+        raise NotImplementedError
+
+
+class BaseMessage(Event, Generic[T]):
+    """A minimal ``Event`` carrying ``content``.
+
+    Deliberately small — it does not know about token usage, reasoning traces
+    or tool calls. The concrete :class:`kaggle_benchmarks.messages.Message`
+    subclasses this and adds those. Use ``BaseMessage`` (or ``Event``) for
+    typing when you only need ``content``/``sender``/``status``.
+    """
+
+    _status_event: str = "message_update"
+
+    def __init__(
+        self,
+        content: T,
+        *,
+        sender: Actor,
+        status: Status = Status.SUCCESS,
+        id: str | None = None,
+    ):
+        super().__init__(sender=sender, status=status, id=id)
+        self.content = content
+
+    @property
+    def text(self) -> str:
+        return str(self.content)
+
+    def __str__(self, indent: str = "") -> str:
+        return f"{indent}{self.sender.avatar} [{self.sender.name}]: {self.text}"
+
+
+class Actor:
+    def __init__(
+        self,
+        name: str | None = None,
+        role: Role = "assistant",
+        avatar: str = "",
+        id: str | None = None,
+    ):
+        self.name = type(self).__name__ if name is None else name
+        self.id = id or name
+        self.role = role
+        self.avatar = avatar
+
+    def send(
+        self, message: T | Message[T], is_visible_to_llm: bool = True
+    ) -> Message[T]:
+        return self._send(message, is_visible_to_llm)
+
+    def _send(self, message: T | Message[T], is_visible_to_llm: bool) -> Message[T]:
+        from kaggle_benchmarks import chats
+        from kaggle_benchmarks.messages import Message
+
+        if isinstance(message, Message):
+            message.is_visible_to_llm = is_visible_to_llm
+        else:
+            message = Message(
+                sender=self, content=message, is_visible_to_llm=is_visible_to_llm
+            )
+
+        chats.send(message)
+        return message
+
+    def stream(self, content: Iterable[str]) -> Message[str]:
+        from kaggle_benchmarks.messages import Message
+
+        msg = Message(content="", sender=self, _status=Status.RUNNING)
+        self.send(msg)
+        msg.stream(content)
+        msg.status = Status.SUCCESS
+        return msg
+
+    def as_dict(self) -> dict[str, str]:
+        """Returns a dictionary representation of the agent."""
+        return dict(id=self.id, name=self.name, role=self.role, avatar=self.avatar)
+
+    def __repr__(self) -> str:
+        cls = type(self)
+        return f"{cls.__name__}(name={self.name!r}, avatar={self.avatar!r})"
+
+    def __str__(self) -> str:
+        return f"{self.avatar} {self.name}"
+
+
+class Session(Event):
+    """An ordered list of ``Event`` objects; the base class for ``Chat``.
+
+    A ``Session`` is itself an ``Event``, so a session's ``history`` can
+    contain both messages and nested sessions.
+    """
+
+    _status_event: str = "session_update"
+
+    def __init__(
+        self,
+        *,
+        history: Iterable[Event] = (),
+        name: str | None = None,
+        sender: Actor,
+        status: Status = Status.SUCCESS,
+        id: str | None = None,
+    ):
+        super().__init__(sender=sender, status=status, id=id)
+        self.history = list(history)
+        self.name = type(self).__name__ if name is None else name
+
+    @manager.event_dispatcher("new_event")
+    def append(self, item: Event) -> Event:
+        """Adds an event to the session."""
+        self.history.append(item)
+        return item
+
+    @property
+    def events(self) -> list[Event]:
+        """All events in this session's history."""
+        return [e for e in self.history if isinstance(e, Event)]
+
+    def to_dict(self) -> dict:
+        """Returns a dictionary representation of the session."""
+        return dict(history=[obj.to_dict() for obj in self.history], name=self.name)
+
+    def __str__(self, indent: str = "") -> str:
+        events = "\n".join(m.__str__(indent + "  ") for m in self.history)
+        return f"{indent}🧵{self.name or ''}:\n{events}"

--- a/src/kaggle_benchmarks/events.py
+++ b/src/kaggle_benchmarks/events.py
@@ -35,12 +35,20 @@ class EventManager:
             if hasattr(listener, event):
                 getattr(listener, event)(*args, **kwargs)
 
-    def event_dispatcher(self, event):
+    def event_dispatcher(self, *events):
+        """Wraps a method so that, after it runs, each named event is dispatched.
+
+        Multiple event names may be given; they are dispatched in order with the
+        same arguments. This is used to emit a legacy alias alongside the
+        canonical event name (e.g. ``"new_event"`` and ``"new_message"``).
+        """
+
         def decorator(func):
             @functools.wraps(func)
             def wrapper(*args, **kwargs):
                 result = func(*args, **kwargs)
-                self.dispatch(event, *args, **kwargs)
+                for event in events:
+                    self.dispatch(event, *args, **kwargs)
                 return result
 
             return wrapper

--- a/src/kaggle_benchmarks/kaggle/serialization.py
+++ b/src/kaggle_benchmarks/kaggle/serialization.py
@@ -28,6 +28,7 @@ from kaggle_benchmarks import (
     assertions,
     chats,
     content_types,
+    core,
     results,
     runs,
     tasks,
@@ -206,13 +207,15 @@ def _extract_model_version_data(run: runs.Run) -> dict[str, Any | None]:
     }
 
 
-def _get_run_state_proto(run_status: utils.Status | str) -> types.BenchmarkTaskRunState:
+def _get_run_state_proto(
+    run_status: core.Status | str,
+) -> types.BenchmarkTaskRunState:
     """Maps a run status string to its corresponding protobuf enum."""
     RUN_STATUS_MAP = {
-        utils.Status.PENDING: types.BenchmarkTaskRunState.BENCHMARK_TASK_RUN_STATE_QUEUED,
-        utils.Status.RUNNING: types.BenchmarkTaskRunState.BENCHMARK_TASK_RUN_STATE_RUNNING,
-        utils.Status.SUCCESS: types.BenchmarkTaskRunState.BENCHMARK_TASK_RUN_STATE_COMPLETED,
-        utils.Status.FAILED: types.BenchmarkTaskRunState.BENCHMARK_TASK_RUN_STATE_ERRORED,
+        core.Status.PENDING: types.BenchmarkTaskRunState.BENCHMARK_TASK_RUN_STATE_QUEUED,
+        core.Status.RUNNING: types.BenchmarkTaskRunState.BENCHMARK_TASK_RUN_STATE_RUNNING,
+        core.Status.SUCCESS: types.BenchmarkTaskRunState.BENCHMARK_TASK_RUN_STATE_COMPLETED,
+        core.Status.FAILED: types.BenchmarkTaskRunState.BENCHMARK_TASK_RUN_STATE_ERRORED,
     }
     return RUN_STATUS_MAP.get(
         run_status, types.BenchmarkTaskRunState.BENCHMARK_TASK_RUN_STATE_UNSPECIFIED

--- a/src/kaggle_benchmarks/llm_messages.py
+++ b/src/kaggle_benchmarks/llm_messages.py
@@ -11,22 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import dataclasses
-from typing import Iterable, Self, TypeVar
 
-from kaggle_benchmarks import chats, messages, utils
+from __future__ import annotations
+
+from typing import Any, Iterable, Self, TypeVar
+
+from kaggle_benchmarks import chats, messages
 from kaggle_benchmarks import tools as tool_utils
+from kaggle_benchmarks.core import Actor, Status
 from kaggle_benchmarks.usage import Usage
 
 T = TypeVar("T")
 
 
-@dataclasses.dataclass
 class LLMMessage(messages.Message[T]):
     """Represents a message from an LLM, including content, status, and metadata."""
 
-    content: T
-    _status: utils.Status = utils.Status.RUNNING
+    # Real attributes that shadow Message's ``_meta``-backed properties, so an
+    # LLM message can carry them as first-class typed fields.
     reasoning_traces: str | None = None
     tool_calls: (
         list[tool_utils.ToolInvocation | tool_utils.ToolInvocationResult] | None
@@ -35,6 +37,35 @@ class LLMMessage(messages.Message[T]):
     # Used to keep the history that was sent to the LLM and may include response
     # format and tool invocation instructions.
     chat: chats.Chat | None = None
+
+    def __init__(
+        self,
+        content: T,
+        sender: Actor,
+        _status: Status = Status.RUNNING,
+        reasoning_traces: str | None = None,
+        tool_calls: (
+            list[tool_utils.ToolInvocation | tool_utils.ToolInvocationResult] | None
+        ) = None,
+        usage: Usage | None = None,
+        chat: chats.Chat | None = None,
+        is_visible_to_llm: bool = True,
+        _meta: dict[str, Any] | None = None,
+        *,
+        id: str | None = None,
+    ):
+        super().__init__(
+            content,
+            sender=sender,
+            _status=_status,
+            is_visible_to_llm=is_visible_to_llm,
+            _meta=_meta,
+            id=id,
+        )
+        self.reasoning_traces = reasoning_traces
+        self.tool_calls = tool_calls
+        self.usage = usage
+        self.chat = chat
 
     def add_chunk(self, chunk: str):
         from kaggle_benchmarks import events
@@ -55,7 +86,7 @@ class LLMMessage(messages.Message[T]):
 
         tool_calls = []
         obj = cls(content="", tool_calls=tool_calls, **kwargs)
-        events.manager.dispatch("new_message", chats.get_current_chat(), obj)
+        events.manager.dispatch("new_event", chats.get_current_chat(), obj)
         events.manager.dispatch("start_streaming", obj)
         for chunk in chunks:
             if isinstance(chunk, str):
@@ -79,7 +110,7 @@ class LLMMessage(messages.Message[T]):
                 if obj.usage is None:
                     obj.usage = Usage()
                 obj.usage += chunk
-        obj.status = utils.Status.SUCCESS
+        obj.status = Status.SUCCESS
         events.manager.dispatch("end_content", obj)
         return obj
 

--- a/src/kaggle_benchmarks/llm_messages.py
+++ b/src/kaggle_benchmarks/llm_messages.py
@@ -86,7 +86,10 @@ class LLMMessage(messages.Message[T]):
 
         tool_calls = []
         obj = cls(content="", tool_calls=tool_calls, **kwargs)
-        events.manager.dispatch("new_event", chats.get_current_chat(), obj)
+        current_chat = chats.get_current_chat()
+        events.manager.dispatch("new_event", current_chat, obj)
+        # Legacy alias for listeners predating the Event refactor.
+        events.manager.dispatch("new_message", current_chat, obj)
         events.manager.dispatch("start_streaming", obj)
         for chunk in chunks:
             if isinstance(chunk, str):

--- a/src/kaggle_benchmarks/messages.py
+++ b/src/kaggle_benchmarks/messages.py
@@ -12,45 +12,50 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""The ``Message`` type: the full concrete conversation message.
+
+``Message`` is a :class:`kaggle_benchmarks.core.BaseMessage` (itself an
+``Event``) that adds LLM-oriented state — visibility, streaming, token usage,
+reasoning traces and tool calls. ``BaseMessage`` and ``Event`` are re-exported
+here for convenience; use them for typing when you only need ``content``.
+"""
+
+from __future__ import annotations
+
 import dataclasses
 import json
 import warnings
-from typing import TYPE_CHECKING, Any, Generic, Iterable, TypeVar
+from typing import Any, Iterable, TypeVar
 
 import pydantic
 
-from kaggle_benchmarks import events, utils
+from kaggle_benchmarks import events
+from kaggle_benchmarks.core import Actor, BaseMessage, Event, Status
 
-if TYPE_CHECKING:
-    from kaggle_benchmarks import actors
-
+__all__ = ["BaseMessage", "Chunk", "Event", "Message", "T"]
 
 T = TypeVar("T")
 Chunk = TypeVar("Chunk")
 
 
-@dataclasses.dataclass
-class Message(Generic[T]):
-    content: T
-    sender: "actors.Actor"
-    _status: utils.Status = utils.Status.SUCCESS
-    # Controls 1) visibility to the LLM and 2) inclusion in the
-    # conversation's protobuf JSON output. Defaults to True.
-    is_visible_to_llm: bool = True
-    _meta: dict[str, Any] = dataclasses.field(default_factory=dict)
+class Message(BaseMessage[T]):
+    """A message sent by an ``Actor`` into a chat."""
 
-    @property
-    def status(self):
-        return self._status
-
-    @status.setter
-    def status(self, value: utils.Status):
-        events.manager.dispatch("message_update", self, value)
-        self._status = value
-
-    @property
-    def text(self):
-        return str(self.content)
+    def __init__(
+        self,
+        content: T,
+        sender: Actor,
+        _status: Status = Status.SUCCESS,
+        is_visible_to_llm: bool = True,
+        _meta: dict[str, Any] | None = None,
+        *,
+        id: str | None = None,
+    ):
+        super().__init__(content, sender=sender, status=_status, id=id)
+        # Controls 1) visibility to the LLM and 2) inclusion in the
+        # conversation's protobuf JSON output. Defaults to True.
+        self.is_visible_to_llm = is_visible_to_llm
+        self._meta: dict[str, Any] = {} if _meta is None else _meta
 
     @property
     def reasoning_traces(self):
@@ -112,10 +117,9 @@ class Message(Generic[T]):
         """Returns a dictionary representation of the message."""
         return dict(sender={"id": self.sender.id}, content=self.payload)
 
-    def __str__(self, indent: str = "") -> str:
-        return f"{indent}{self.sender.avatar} [{self.sender.name}]: {self.text}"
-
     def __eq__(self, other):
+        # Defining __eq__ makes Message unhashable (Python sets __hash__ = None),
+        # matching the old dataclass behavior.
         return (
             isinstance(other, Message)
             and self.sender == other.sender
@@ -161,8 +165,6 @@ class Message(Generic[T]):
             content: An iterable of chunks. Chunks can be strings or objects
                 with `content` and `meta` attributes.
         """
-        from kaggle_benchmarks import events
-
         events.manager.dispatch("start_streaming", self)
         for chunk in content:
             chunk_content = (

--- a/src/kaggle_benchmarks/runs.py
+++ b/src/kaggle_benchmarks/runs.py
@@ -21,7 +21,7 @@ from typing import Any, Generic, Literal, Self, TypeVar
 
 import pandas as pd
 
-from kaggle_benchmarks import actors, assertions, chats, results, tasks, utils
+from kaggle_benchmarks import actors, assertions, chats, core, results, tasks
 from kaggle_benchmarks.actors.llms import LLMChat
 
 T = TypeVar("T")
@@ -35,7 +35,7 @@ class Run(Generic[T]):
     task: tasks.Task[T]
     result: T | results.Unknown = results.PENDING
     chat: chats.Chat | None = None
-    status: utils.Status = utils.Status.PENDING
+    status: core.Status = core.Status.PENDING
     params: dict[str, Any] = dataclasses.field(default_factory=dict)
     id: str = ""
     param_id: Any = None
@@ -69,7 +69,7 @@ class Run(Generic[T]):
 
     def fail_with_message(self, msg: str | None = None):
         """Sets the run status to FAILED and records the error message."""
-        self.status = utils.Status.FAILED
+        self.status = core.Status.FAILED
         self.error_message = msg
         self.result = results.FAILED
 
@@ -128,7 +128,7 @@ class Run(Generic[T]):
         # Reject known-bad first: a run whose task body raised an exception.
         # Without this guard, result_type.passed() would return True for most
         # result types regardless of the value, masking the failure.
-        if self.status == utils.Status.FAILED:
+        if self.status == core.Status.FAILED:
             return False
         # TODO: cached runs always report passed=True here because
         # _handle_cached_run restores self.result but not assertion_results
@@ -203,7 +203,7 @@ class Runs(Generic[T], abc.MutableSequence):
         may still have failed assertions or scored 0. Use `run.passed`
         to check that.
         """
-        return Runs([r for r in self.runs if r.status == utils.Status.SUCCESS])
+        return Runs([r for r in self.runs if r.status == core.Status.SUCCESS])
 
     @property
     def errored_runs(self) -> "Runs[T]":
@@ -213,7 +213,7 @@ class Runs(Generic[T], abc.MutableSequence):
         They're the candidates that `max_attempts > 1` will retry on the
         next attempt (with `enable_cache()` enabled).
         """
-        return Runs([r for r in self.runs if r.status == utils.Status.FAILED])
+        return Runs([r for r in self.runs if r.status == core.Status.FAILED])
 
     def as_dataframe(self) -> pd.DataFrame:
         if not self.runs:

--- a/src/kaggle_benchmarks/tasks.py
+++ b/src/kaggle_benchmarks/tasks.py
@@ -31,7 +31,7 @@ from typing import (
 
 import pandas as pd
 
-from kaggle_benchmarks import chats, events, results, utils
+from kaggle_benchmarks import chats, core, events, results
 
 if TYPE_CHECKING:
     from kaggle_benchmarks import runs
@@ -93,7 +93,7 @@ class Task(Generic[T]):
                     f"Skipping run {run.id} for task {self.name} as its output file already exists."
                 )
                 run.cached = True
-                run.status = utils.Status.SUCCESS
+                run.status = core.Status.SUCCESS
                 run.result = client.load_run_result(run)
                 if ctx.parent and ctx.parent.run:
                     ctx.parent.run.subruns.append(run)
@@ -330,7 +330,7 @@ class Task(Generic[T]):
             # because contexts.enter swallowed them (Kaggle batch). In dev
             # mode, the worker already raised and we never reach here.
             if on_failure == "raise":
-                failures = [r for r in all_runs if r.status == utils.Status.FAILED]
+                failures = [r for r in all_runs if r.status == core.Status.FAILED]
                 if failures:
                     first = failures[0]
                     summary = (
@@ -390,7 +390,7 @@ class Task(Generic[T]):
                 all_runs = runs.Runs(list(runs_by_position.values()))
 
                 # Nothing failed — no point trying again.
-                if not any(r.status == utils.Status.FAILED for r in all_runs):
+                if not any(r.status == core.Status.FAILED for r in all_runs):
                     break
 
                 if stop_condition and stop_condition(all_runs):

--- a/src/kaggle_benchmarks/ui/console.py
+++ b/src/kaggle_benchmarks/ui/console.py
@@ -19,7 +19,7 @@ import sys
 import textwrap
 import threading
 
-from kaggle_benchmarks import assertions, chats, utils
+from kaggle_benchmarks import assertions, chats, core
 
 _DEFAULT_MIN_WIDTH = 40
 _DEFAULT_MAX_WIDTH = 120
@@ -86,7 +86,7 @@ class ConsoleUI:
         self._in_run = False
         self._run_depth = 0
         # Tracks message ids whose body was already rendered via new_chunk
-        # events; new_message skips the eager body print for these so the
+        # events; new_event skips the eager body print for these so the
         # text isn't duplicated. Stores id(message) to avoid pinning Message
         # objects in memory.
         self._streamed_messages: set[int] = set()
@@ -204,7 +204,7 @@ class ConsoleUI:
     def _quiet_end_chat(self, chat):
         self.depth -= 1
 
-    def _quiet_new_message(self, chat, message):
+    def _quiet_new_event(self, chat, message):
         if isinstance(message, chats.Chat):
             return
         # If this message was streamed, chunks already rendered the body.
@@ -212,7 +212,7 @@ class ConsoleUI:
             return
         print(
             message.__str__(indent=" " * (self.depth * self.tab_size)),
-            end="" if message.status == utils.Status.RUNNING else "\n",
+            end="" if message.status == core.Status.RUNNING else "\n",
             file=self._output,
         )
 
@@ -260,7 +260,7 @@ class ConsoleUI:
                 self._print(f"\n{self._colorize('METRICS:', c.BOLD)}  {usage_str}")
 
         # Result or error
-        if run.status == utils.Status.FAILED:
+        if run.status == core.Status.FAILED:
             error_msg = run.error_message or "Unknown Error"
             self._print(self._colorize(f"ERROR:    {error_msg}", c.RED))
         else:
@@ -313,14 +313,14 @@ class ConsoleUI:
                 wrapped_lines.append(line)
         return "\n".join(wrapped_lines)
 
-    def new_message(self, chat, message):
+    def new_event(self, chat, message):
         if self.quiet:
-            self._quiet_new_message(chat, message)
+            self._quiet_new_event(chat, message)
             return
         if isinstance(message, chats.Chat):
             return
         if not self._in_run:
-            self._quiet_new_message(chat, message)
+            self._quiet_new_event(chat, message)
             return
 
         # Skip assertion result messages -- they're shown in the assertion

--- a/src/kaggle_benchmarks/ui/panel.py
+++ b/src/kaggle_benchmarks/ui/panel.py
@@ -24,6 +24,7 @@ from IPython import core, display
 
 from kaggle_benchmarks import chats, messages, runs, tasks, utils
 from kaggle_benchmarks._config import config
+from kaggle_benchmarks.core import Status
 
 
 def json_pane(data, title: str = "Object", **kwargs):
@@ -79,7 +80,7 @@ def render_message(message: messages.Message, **kwargs) -> pn.chat.ChatMessage:
         user=message.sender.name,
         avatar=message.sender.avatar,
         show_reaction_icons=False,
-        show_activity_dot=message.status == utils.Status.RUNNING,
+        show_activity_dot=message.status == Status.RUNNING,
         # show_activity_dot=False,
         show_copy_icon=False,
         show_edit_icon=False,
@@ -160,7 +161,7 @@ def render_chat_as_step(chat: chats.Chat, **kwargs) -> pn.chat.ChatStep | None:
         status=chat._status,
         min_width=400,
         objects=chat.history,
-        collapsed=chat.status != utils.Status.RUNNING,
+        collapsed=chat.status != Status.RUNNING,
         collapsed_on_success=True,
         **kwargs,
     )
@@ -212,9 +213,9 @@ def render_run(run: runs.Run, with_title: bool = True) -> pn.viewable.Viewable:
         objects.append(render_chat(run.chat, with_header=False))
 
     match run.status:
-        case utils.Status.SUCCESS:
+        case Status.SUCCESS:
             objects.append(render_result(run))
-        case utils.Status.FAILED:
+        case Status.FAILED:
             objects.append(render_error(run))
 
     return pn.Feed(objects=objects)
@@ -392,7 +393,7 @@ class PanelUI:
             self.add_card(pn.Card(pane, title=f"🧵: {chat.name}"))
 
         elif parent is None:
-            # handled in new_message
+            # handled in new_event
             return
 
         elif context.run:
@@ -416,7 +417,7 @@ class PanelUI:
             self[chat].awaiting = True
             self[chat].append(self.placeholder)
 
-    def new_message(self, chat: chats.Chat, message: messages.Message | chats.Chat):
+    def new_event(self, chat: chats.Chat, message: messages.Message | chats.Chat):
         if isinstance(message, chats.Chat):
             if chat in self:
                 self[message] = msg = render_chat_as_step(message)
@@ -437,15 +438,15 @@ class PanelUI:
         if self.depth == 0:
             self.add_card(pn.Card(pane, title=f"✉️: {message.sender.name}"))
 
-    def message_update(self, message: messages.Message, status: utils.Status):
-        if status == utils.Status.SUCCESS and message in self:
+    def message_update(self, message: messages.Message, status: Status):
+        if status == Status.SUCCESS and message in self:
             self[message].object = render_message_content(message.content)
             self[message].show_activity_dot = False
 
     def chat_update(self, chat, status):
         if chat in self:
             self[chat].status = status
-            self[chat].collapsed = status != utils.Status.RUNNING
+            self[chat].collapsed = status != Status.RUNNING
 
     def new_chunk(self, message, chunk):
         if message in self:

--- a/src/kaggle_benchmarks/utils.py
+++ b/src/kaggle_benchmarks/utils.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import difflib
-import enum
 import inspect
 import json
 import re
@@ -24,12 +23,8 @@ import hishel.httpx
 import httpx
 import pydantic
 
-
-class Status(enum.StrEnum):
-    PENDING = "pending"
-    RUNNING = "running"
-    SUCCESS = "success"
-    FAILED = "failed"
+# Re-exported for backward compatibility; ``Status`` now lives in ``core``.
+from kaggle_benchmarks.core import Status  # noqa: F401
 
 
 class JSONEncoder(json.encoder.JSONEncoder):

--- a/tests/test_chatroom.py
+++ b/tests/test_chatroom.py
@@ -664,7 +664,7 @@ def test_meta_llm_response_path():
 
 def test_sender_is_participant_at_event_time_llm_message():
     """Message sender must be the Participant (not the backing LLMChat)
-    at the moment new_message fires — not patched after the fact."""
+    at the moment new_event fires — not patched after the fact."""
     from kaggle_benchmarks import events
 
     alice_mock = MockedChat.from_contents(["hi"], name="Alice", cycle=True)
@@ -674,7 +674,7 @@ def test_sender_is_participant_at_event_time_llm_message():
     captured_senders = []
 
     class SenderCapture:
-        def new_message(self, chat, message):
+        def new_event(self, chat, message):
             captured_senders.append(message.sender)
 
     capture = SenderCapture()
@@ -705,7 +705,7 @@ def test_sender_is_participant_at_event_time_llm_response():
     captured_senders = []
 
     class SenderCapture:
-        def new_message(self, chat, message):
+        def new_event(self, chat, message):
             captured_senders.append(message.sender)
 
     capture = SenderCapture()

--- a/tests/test_console_ui.py
+++ b/tests/test_console_ui.py
@@ -303,7 +303,7 @@ class TestLLMResponseRendering:
         """LLMResponse path in quiet mode must terminate each message with \\n.
 
         Regression: an earlier version swapped chat.append/status order so
-        new_message fired with status=RUNNING, causing _quiet_new_message to
+        new_event fired with status=RUNNING, causing _quiet_new_event to
         omit the trailing newline and glue messages together.
         """
         handler, output = _make_handler(quiet=True)
@@ -317,7 +317,7 @@ class TestLLMResponseRendering:
         assert "alpha  " not in captured  # not followed by next message inline
 
     def test_streaming_header_before_chunks_in_rich_mode(self):
-        """Streaming path must dispatch new_message BEFORE chunks stream in,
+        """Streaming path must dispatch new_event BEFORE chunks stream in,
         so the rich UI's [RESPONSE: name] header appears above the tokens."""
         handler, output = _make_handler()
 
@@ -338,7 +338,7 @@ class TestLLMResponseRendering:
 
     def test_streaming_no_duplicate_body(self):
         """Streamed text should appear exactly once, not also re-printed by
-        a later new_message dispatch."""
+        a later new_event dispatch."""
         handler, output = _make_handler()
 
         @tasks.task(name="StreamDup", store_task=False, store_run=False)
@@ -388,7 +388,7 @@ class TestLLMResponseRendering:
 
     def test_streaming_does_not_double_print(self):
         """If a message is streamed and *then* appended (the inverse of the
-        canonical order), new_message should still print the role header but
+        canonical order), new_event should still print the role header but
         skip the body since chunks already rendered it."""
         from kaggle_benchmarks import actors, messages, utils
 
@@ -477,18 +477,18 @@ class TestLLMResponseRendering:
         assert console_handler not in events.manager.listeners
         assert isinstance(cfg.ui_handler, panel_ui.PanelUI)
 
-    def test_llm_message_branch_dispatches_new_message_once(self):
+    def test_llm_message_branch_dispatches_new_event_once(self):
         """LLMMessage returned from invoke() should produce exactly one
-        new_message event for the response (the chat.append in respond()).
+        new_event event for the response (the chat.append in respond()).
 
         Guards against future regressions if invoke() starts using
-        LLMMessage.from_chunks (which dispatches new_message itself) — that
+        LLMMessage.from_chunks (which dispatches new_event itself) — that
         would need chat.history.append, not chat.append, to avoid a duplicate.
         """
         events_seen = []
 
         class Spy:
-            def new_message(self, chat, message):
+            def new_event(self, chat, message):
                 events_seen.append(message)
 
         events.manager.listeners = []

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -36,20 +36,20 @@ def logger():
 def test_start_end_chat(logger):
     with chats.new("test"):
         assert len(logger.events["new_chat"]) == 1
-        assert len(logger.events["new_message"]) == 1
+        assert len(logger.events["new_event"]) == 1
         user.send("hi")
-        assert len(logger.events["new_message"]) == 2
+        assert len(logger.events["new_event"]) == 2
 
     assert len(logger.events["end_chat"]) == 1
 
 
-def test_new_message(logger):
+def test_new_event(logger):
     user.send("hi")
-    assert len(logger.events["new_message"]) == 1
+    assert len(logger.events["new_event"]) == 1
 
     with chats.new("test"):
         user.send("hi")
-        assert len(logger.events["new_message"]) == 3
+        assert len(logger.events["new_event"]) == 3
 
 
 def test_console_ui(capsys):

--- a/tests/test_llm_chats.py
+++ b/tests/test_llm_chats.py
@@ -241,10 +241,12 @@ def test_nested_chat_id():
         with contexts.enter(chat=sub):
             llm.prompt("Hi")
 
+        sub_id = sub.id
         sub.name += " - analysis"
 
     assert root.history[0] is sub
-    assert sub.id.startswith("sub - analysis-")
+    # A chat's id is a stable identifier, unaffected by later name changes.
+    assert sub.id == sub_id
     assert len(sub.history) == 2
 
 
@@ -345,9 +347,9 @@ def test_invoke_llmmessage():
     assert mocked_chat.invocations[0][1] == {"temperature": 0.5}
 
 
-def test_panel_ui_tolerates_message_update_before_new_message():
+def test_panel_ui_tolerates_message_update_before_new_event():
     """PanelUI.message_update must not crash on messages it hasn't
-    registered via new_message yet.
+    registered via new_event yet.
 
     We call message_update directly rather than going through
     llm.prompt() because contexts.enter() swallows exceptions when
@@ -358,12 +360,12 @@ def test_panel_ui_tolerates_message_update_before_new_message():
     handler = panel_ui.PanelUI()
     msg = Message(content="test", sender=actors.user, _status=utils.Status.RUNNING)
 
-    # Must not raise KeyError for messages not yet seen via new_message.
+    # Must not raise KeyError for messages not yet seen via new_event.
     handler.message_update(msg, utils.Status.SUCCESS)
 
 
 def test_panel_ui_tolerates_unregistered_keys():
-    """Companion to test_panel_ui_tolerates_message_update_before_new_message
+    """Companion to test_panel_ui_tolerates_message_update_before_new_event
     for the other handlers. Under n_jobs > 1, joblib's threading backend
     dispatches lifecycle events from worker threads through the global
     events.manager, and PanelUI.new_chat can hit its `elif parent is None`
@@ -451,7 +453,7 @@ def test_panel_ui_concurrent_prompts():
 
 def test_panel_ui_streaming_with_bound_handler():
     """The streaming path must append the message (registering it in
-    PanelUI.shadows via new_message) before calling response.stream()
+    PanelUI.shadows via new_event) before calling response.stream()
     (which dispatches new_chunk). This test locks in that ordering."""
     from kaggle_benchmarks.ui import panel as panel_ui
 


### PR DESCRIPTION
Redefine the library's core objects around three abstract base classes in kaggle_benchmarks.core, without changing behavior or breaking imports:

  * Actor   — participates in a conversation and produces events.
  * Event   — a single item in a session's history, carrying a sender and a
              status.
  * Session — an ordered list of events. Session subclasses Event, so a
              session's history can hold both messages and nested sessions.

Concrete types stay in their own modules and subclass the bases: Message(Event) in messages, Chat(Session)/GoldfishChat in chats, and the Tool/system/assertion/user actors in actors.base (Actor re-exported from core). The bases reference each other directly and import only leaf modules, so the circular imports between the concrete types are gone; Event and Session are behavior-only, so the concrete dataclasses keep their existing fields and positional constructors.

Backward compatible: messages.Message, actors.Actor/Tool/system/user/ assertion, and chats.Chat/GoldfishChat/Message resolve to the same objects; messages.Event and chats.Session are also exposed. Chat.history is now typed list[Event] (was list[Message | Self]); assertions._find_in_chat narrows to Message accordingly.

Docs: document the Actor/Event/Session model in DEVELOPMENT.md (architecture section + subsystem table), quick_start.md (core-objects glossary), and AGENTS.md (repo map).