### PR TITLE
Add xai/grok-4.6 to seed-unsupported model prefixes

### DIFF
--- a/src/kaggle_benchmarks/actors/llms.py
+++ b/src/kaggle_benchmarks/actors/llms.py
@@ -425,6 +425,7 @@ class OpenAI(LLMChat):
             "openai/gpt-5.4-pro",
             "openai/gpt-5.6",
             "xai/grok-4.5",
+            "xai/grok-4.6",
         )
         return any(self.model.startswith(prefix) for prefix in unsupported_prefixes)
 


### PR DESCRIPTION
Grok 4.6 rejects the `seed` parameter the same way Grok 4.5 does, so
requests to it need the seed stripped before dispatch. Adding the prefix
to `_should_remove_seed` keeps the model usable without callers having to
special-case it.

---

Task: [taehykim-20260820182917-741df950](https://agents.dev.kaggle.net/tasks/taehykim-20260820182917-741df950)
Context: https://chat.kaggle.net/kaggle/pl/dhykxrg5ubrj8xhtjy8iyxx59y

