### PR TITLE
build(docker): add reusable dev/test image for running tests & mypy

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -244,6 +244,36 @@ uv run --group test pytest tests/test_assertions.py
 uv run --group test pytest tests -v
 ```
 
+### Running tests & type checks in Docker
+
+When a full local dev environment isn't available (e.g. an automated/agent
+session), `cicd/Dockerfile.dev` provides a self-contained image with all
+third-party deps and the type-checking tools baked in from the lockfile. The
+project source is **not** baked in — mount it at run time and import it via
+`PYTHONPATH=src` (no editable install needed), so the same image is reusable
+across sessions and checkouts.
+
+```bash
+# Build once. --network=host lets the build reach PyPI (a plain build may
+# have no DNS). Rebuild only when uv.lock / pyproject.toml change.
+docker build --network=host -t kbench-dev -f cicd/Dockerfile.dev .
+
+# Start a container with the repo mounted.
+docker run -d --name kb-dev --network=host \
+  -v "$PWD":/work -w /work kbench-dev sleep infinity
+
+# Unit tests and type checks against the mounted source.
+docker exec -e PYTHONPATH=src kb-dev python -m pytest tests -q
+docker exec -e PYTHONPATH=src kb-dev mypy src/kaggle_benchmarks
+
+# Tear down when done.
+docker rm -f kb-dev
+```
+
+Expected: the browser-backed tests in `tests/tools/test_web.py` fail here
+(Playwright browsers are intentionally not installed); a few serialization/
+line-number tests also depend on the checkout path. Everything else passes.
+
 ---
 
 ## 5. Code Style & Tooling

--- a/cicd/Dockerfile.dev
+++ b/cicd/Dockerfile.dev
@@ -1,0 +1,48 @@
+# Copyright 2026 Kaggle Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Self-contained image for running the unit tests and type checks outside a
+# full dev environment (e.g. from an automated/agent session). All third-party
+# dependencies (the `test` group) plus the type-checking tools are baked in
+# from the lockfile, so a container only needs the repo mounted at /work.
+#
+# Build:  docker build --network=host -t kbench-dev -f cicd/Dockerfile.dev .
+#         (--network=host lets the build reach PyPI; a plain build has no DNS
+#          in some environments.)
+# Use:    see DEVELOPMENT.md, "Running tests & type checks in Docker".
+#
+# Note: Playwright browsers are intentionally NOT installed — the few
+# browser-backed tests (tests/tools/test_web.py) are expected to fail here and
+# are not part of this image's scope.
+FROM python:3.11
+
+COPY --from=ghcr.io/astral-sh/uv:0.6.14 /uv /uvx /bin/
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PROJECT_ENVIRONMENT=/opt/venv \
+    PATH="/opt/venv/bin:$PATH"
+
+WORKDIR /work
+
+# Bake the third-party deps (test group) + type stubs from the lockfile.
+# --no-install-project: the project source is mounted at run time, not baked in
+# (import it via PYTHONPATH=src — see DEVELOPMENT.md).
+RUN --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --frozen --no-install-project --group test && \
+    uv pip install \
+    mypy pandas-stubs types-protobuf types-tqdm docker-stubs mypy-protobuf
+
+CMD ["bash"]


### PR DESCRIPTION
Add cicd/Dockerfile.dev — a self-contained image that bakes all third-party deps (test group) plus the type-checking tools from the lockfile. The project source is not baked in; it's mounted at run time and imported via PYTHONPATH=src, so the image is reusable across sessions and checkouts (handy for automated/agent runs without a full local dev environment).

DEVELOPMENT.md documents the build/run/test/mypy workflow (including that the build needs --network=host to reach PyPI, and that the Playwright-backed tests don't run in this image).