### PR TITLE
test: skip web tests when the Playwright browser isn't installed

### DIFF
--- a/tests/tools/test_web.py
+++ b/tests/tools/test_web.py
@@ -12,11 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import tempfile
 
 import pytest
 
 from kaggle_benchmarks import tools
+
+
+@contextlib.contextmanager
+def _skip_if_browser_unavailable():
+    """Skips (instead of failing) when the Playwright browser isn't installed.
+
+    The ``playwright`` package is a dependency, but its Chromium browser is a
+    separate download (``playwright install chromium``). Without it, launching
+    raises; re-raise anything else so real failures still surface.
+    """
+    try:
+        yield
+    except Exception as e:  # noqa: BLE001 - narrowed by the message check below
+        message = str(e).lower()
+        if "executable doesn't exist" in message or "playwright install" in message:
+            pytest.skip("Playwright browser is not installed")
+        raise
 
 
 @pytest.mark.asyncio
@@ -26,13 +44,16 @@ async def test_snapshot():
         with open(f"{tmp_dir}/index.html", "w") as f:
             f.write(html_string)
 
-        snapshot = await tools.web.async_take_snapshot(f"file://{tmp_dir}/index.html")
+        with _skip_if_browser_unavailable():
+            snapshot = await tools.web.async_take_snapshot(
+                f"file://{tmp_dir}/index.html"
+            )
         assert html_string == snapshot.html
         assert ["hello"] == snapshot.logs
 
 
 def test_browser_screenshot():
-    with tools.web.Browser() as browser:
+    with _skip_if_browser_unavailable(), tools.web.Browser() as browser:
         response = browser.take_screenshot(
             "<html><head><title>Test</title></head><body><h1>Hello</h1></body></html>"
         )
@@ -40,7 +61,7 @@ def test_browser_screenshot():
 
 
 def test_browser_snapshot():
-    with tools.web.Browser() as browser:
+    with _skip_if_browser_unavailable(), tools.web.Browser() as browser:
         response = browser.take_snapshot(
             "<html><head><title>Test</title></head><body><h1>Hello</h1></body></html>"
         )


### PR DESCRIPTION
The playwright package is a dependency, but its Chromium browser is a separate download (`playwright install chromium`). Without it, the web tests raised. Wrap the browser-launching calls so they pytest.skip() on the "executable doesn't exist" / "playwright install" error while still surfacing any other exception as a real failure.